### PR TITLE
[codex] Fix Math Marauder audio playback and narration

### DIFF
--- a/math-marauder/js/audio.js
+++ b/math-marauder/js/audio.js
@@ -77,19 +77,19 @@
         }
 
         playCorrect() {
-            this._playArp([523, 659, 784], 0.08, 'triangle', 0.16);
+            this._playArp([523, 659, 784], 0.11, 'triangle', 0.28);
         }
 
         playWrong() {
-            this._playArp([220, 196], 0.11, 'sawtooth', 0.10);
+            this._playArp([196, 147], 0.14, 'sawtooth', 0.24);
         }
 
         playHit() {
-            this._playTone(140, 0.12, 'square', 0.12);
+            this._playTone(110, 0.18, 'square', 0.28);
         }
 
         playVictory() {
-            this._playArp([392, 523, 659, 784, 1046], 0.09, 'triangle', 0.18);
+            this._playArp([392, 523, 659, 784, 1046], 0.12, 'triangle', 0.26);
         }
 
         _getCtx() {
@@ -120,6 +120,7 @@
             const ctx = this._getCtx();
             if (!ctx || !this._effectsGain) return;
             ctx.resume().then(() => {
+                this._duckMusic(ctx, duration + 0.08);
                 const osc = ctx.createOscillator();
                 const gain = ctx.createGain();
                 osc.type = type;
@@ -138,6 +139,7 @@
             const ctx = this._getCtx();
             if (!ctx || !this._effectsGain) return;
             ctx.resume().then(() => {
+                this._duckMusic(ctx, freqs.length * noteLength + 0.08);
                 freqs.forEach((freq, i) => {
                     const osc = ctx.createOscillator();
                     const gain = ctx.createGain();
@@ -153,6 +155,15 @@
                     osc.stop(start + noteLength);
                 });
             });
+        }
+
+        _duckMusic(ctx, duration) {
+            if (!this._musicGain || !this.isMusicPlaying()) return;
+            const gain = this._musicGain.gain;
+            if (gain.cancelScheduledValues) gain.cancelScheduledValues(ctx.currentTime);
+            gain.setValueAtTime(Math.min(gain.value || 0.06, 0.06), ctx.currentTime);
+            gain.linearRampToValueAtTime(0.015, ctx.currentTime + 0.01);
+            gain.linearRampToValueAtTime(0.06, ctx.currentTime + duration);
         }
     }
 

--- a/math-marauder/js/audio.js
+++ b/math-marauder/js/audio.js
@@ -8,22 +8,72 @@
         constructor() {
             this._ctx = null;
             this._masterGain = null;
+            this._effectsGain = null;
+            this._musicGain = null;
+            this._musicNodes = [];
             this._volume = 0.7;
             this._muted = false;
+            this._musicEnabled = false;
         }
 
         preWarm() {
             this._resume();
+            if (this._musicEnabled) this.startMusic();
         }
 
         setMuted(muted) {
             this._muted = !!muted;
-            if (this._masterGain) this._masterGain.gain.value = this._muted ? 0 : this._volume;
+            if (this._effectsGain) this._effectsGain.gain.value = this._muted ? 0 : 1;
         }
 
         setVolume(volume) {
             this._volume = Math.max(0, Math.min(1, volume));
-            if (this._masterGain) this._masterGain.gain.value = this._muted ? 0 : this._volume;
+            if (this._masterGain) this._masterGain.gain.value = this._volume;
+        }
+
+        setMusicEnabled(enabled, startNow) {
+            this._musicEnabled = !!enabled;
+            if (this._musicEnabled && startNow !== false) this.startMusic();
+            else this.stopMusic();
+        }
+
+        isMusicPlaying() {
+            return this._musicNodes.length > 0;
+        }
+
+        startMusic() {
+            this._musicEnabled = true;
+            if (this.isMusicPlaying()) return;
+            const ctx = this._getCtx();
+            if (!ctx || !this._musicGain) return;
+            ctx.resume().then(() => {
+                if (!this._musicEnabled || this.isMusicPlaying()) return;
+                const root = ctx.createOscillator();
+                const fifth = ctx.createOscillator();
+                root.type = 'sine';
+                fifth.type = 'triangle';
+                root.frequency.value = 130.81;
+                fifth.frequency.value = 196;
+                root.connect(this._musicGain);
+                fifth.connect(this._musicGain);
+                this._musicGain.gain.setValueAtTime(0.06, ctx.currentTime);
+                root.start(ctx.currentTime);
+                fifth.start(ctx.currentTime);
+                this._musicNodes = [root, fifth];
+            });
+        }
+
+        stopMusic() {
+            const nodes = this._musicNodes.slice();
+            this._musicNodes = [];
+            nodes.forEach((node) => {
+                try {
+                    node.stop();
+                    if (node.disconnect) node.disconnect();
+                } catch (err) {
+                    // Oscillators may already be stopped by the browser.
+                }
+            });
         }
 
         playCorrect() {
@@ -49,7 +99,13 @@
             if (!Ctor) return null;
             this._ctx = new Ctor();
             this._masterGain = this._ctx.createGain();
-            this._masterGain.gain.value = this._muted ? 0 : this._volume;
+            this._effectsGain = this._ctx.createGain();
+            this._musicGain = this._ctx.createGain();
+            this._masterGain.gain.value = this._volume;
+            this._effectsGain.gain.value = this._muted ? 0 : 1;
+            this._musicGain.gain.value = 0.06;
+            this._effectsGain.connect(this._masterGain);
+            this._musicGain.connect(this._masterGain);
             this._masterGain.connect(this._ctx.destination);
             return this._ctx;
         }
@@ -62,7 +118,7 @@
 
         _playTone(freq, duration, type, gainValue) {
             const ctx = this._getCtx();
-            if (!ctx || !this._masterGain) return;
+            if (!ctx || !this._effectsGain) return;
             ctx.resume().then(() => {
                 const osc = ctx.createOscillator();
                 const gain = ctx.createGain();
@@ -72,7 +128,7 @@
                 gain.gain.linearRampToValueAtTime(gainValue, ctx.currentTime + 0.01);
                 gain.gain.linearRampToValueAtTime(0, ctx.currentTime + duration);
                 osc.connect(gain);
-                gain.connect(this._masterGain);
+                gain.connect(this._effectsGain);
                 osc.start(ctx.currentTime);
                 osc.stop(ctx.currentTime + duration);
             });
@@ -80,7 +136,7 @@
 
         _playArp(freqs, noteLength, type, gainValue) {
             const ctx = this._getCtx();
-            if (!ctx || !this._masterGain) return;
+            if (!ctx || !this._effectsGain) return;
             ctx.resume().then(() => {
                 freqs.forEach((freq, i) => {
                     const osc = ctx.createOscillator();
@@ -92,7 +148,7 @@
                     gain.gain.linearRampToValueAtTime(gainValue, start + 0.01);
                     gain.gain.linearRampToValueAtTime(0, start + noteLength);
                     osc.connect(gain);
-                    gain.connect(this._masterGain);
+                    gain.connect(this._effectsGain);
                     osc.start(start);
                     osc.stop(start + noteLength);
                 });

--- a/math-marauder/js/audio.js
+++ b/math-marauder/js/audio.js
@@ -117,6 +117,7 @@
         }
 
         _playTone(freq, duration, type, gainValue) {
+            if (this._muted) return;
             const ctx = this._getCtx();
             if (!ctx || !this._effectsGain) return;
             ctx.resume().then(() => {
@@ -136,6 +137,7 @@
         }
 
         _playArp(freqs, noteLength, type, gainValue) {
+            if (this._muted) return;
             const ctx = this._getCtx();
             if (!ctx || !this._effectsGain) return;
             ctx.resume().then(() => {

--- a/math-marauder/js/game.js
+++ b/math-marauder/js/game.js
@@ -131,7 +131,10 @@
             this._syncScene(correct);
             if (correct) {
                 this._audio.playCorrect();
-                if (resolved.spellTriggered) this._ui.showSpell(this._spellLabel(resolved.spellTriggered));
+                if (resolved.spellTriggered) {
+                    this._ui.showSpell(this._spellLabel(resolved.spellTriggered));
+                    this._narrateSpell(resolved.spellTriggered);
+                }
                 this._ui.announce(resolved.feedbackText || 'Correct. Spell hit.');
                 if (resolved.spellTriggered === 'starbolt') this._audio.playHit();
                 if (resolved.roomComplete || resolved.phaseComplete) {
@@ -143,17 +146,20 @@
             }
             this._audio.playWrong();
             this._firstTry = false;
-            if (resolved.spellTriggered) this._ui.showSpell(this._spellLabel(resolved.spellTriggered));
+            const spellNarration = this._spellNarrationText(resolved.spellTriggered);
+            if (resolved.spellTriggered) {
+                this._ui.showSpell(this._spellLabel(resolved.spellTriggered));
+            }
             if (resolved.recoveryMode === 'retreat') {
                 this._ui.announce(resolved.feedbackText);
-                this._speech.speak(resolved.feedbackText);
+                this._speech.speak(this._joinSpeech(spellNarration, resolved.feedbackText));
                 this._saveProgressOnly();
                 setTimeout(() => this.startRoom(), 900);
                 return;
             }
             const hint = resolved.hintText || 'Try again. The right rune is still here.';
             this._ui.announce(hint);
-            this._speech.speak(hint);
+            this._speech.speak(this._joinSpeech(spellNarration, hint));
             setTimeout(() => {
                 this._ui.setAnswers(this._currentProblem.choices, (retryChoice, retryIndex) => this.handleAnswer(retryChoice, retryIndex));
             }, 650);
@@ -215,6 +221,7 @@
                 this._encounter = MathMarauder.GameRules.advanceEncounterPhase(this._encounter);
                 this._phase = this._encounter.phaseIndex;
                 this._ui.showSpell(this._spellLabel(this._encounter.spellTriggered));
+                this._narrateSpell(this._encounter.spellTriggered);
                 this._ui.announce(`Boss phase ${this._phase}`);
                 this.presentProblem();
                 this._syncScene();
@@ -230,6 +237,24 @@
                 'dragon-guard': 'Dragon Guard shield',
                 'time-gem': 'Time Gem phase shift'
             }[spellId] || '';
+        }
+
+        _narrateSpell(spellId) {
+            const line = this._spellNarrationText(spellId);
+            if (line && this._speech) this._speech.speak(line);
+        }
+
+        _spellNarrationText(spellId) {
+            return {
+                'starbolt': 'Starbolt surge.',
+                'mirror-spark': 'Mirror Spark hint.',
+                'dragon-guard': 'Dragon Guard shield.',
+                'time-gem': 'Time Gem phase shift.'
+            }[spellId] || '';
+        }
+
+        _joinSpeech(first, second) {
+            return [first, second].filter(Boolean).join(' ');
         }
 
         _syncScene(spellFlash) {
@@ -258,6 +283,7 @@
             this._save.settings.speech = document.getElementById('setting-speech').checked;
             this._save.settings.reducedMotion = document.getElementById('setting-reduced-motion').checked;
             this._audio.setMuted(!this._save.settings.sfx);
+            this._audio.setMusicEnabled(this._save.settings.music, true);
             this._speech.setEnabled(this._save.settings.speech);
             this._ui.applySettings(this._save.settings);
             this._saveManager.save(this._save);
@@ -265,6 +291,7 @@
 
         _applySettings() {
             this._audio.setMuted(!this._save.settings.sfx);
+            this._audio.setMusicEnabled(this._save.settings.music, false);
             this._speech.setEnabled(this._save.settings.speech);
             this._ui.applySettings(this._save.settings);
             document.getElementById('setting-sfx').checked = !!this._save.settings.sfx;

--- a/math-marauder/scripts/run-tests.js
+++ b/math-marauder/scripts/run-tests.js
@@ -6,6 +6,8 @@ const tests = [
     '../tests/problem-engine.test.js',
     '../tests/progression.test.js',
     '../tests/game-rules.test.js',
+    '../tests/audio.test.js',
+    '../tests/game-audio-speech.test.js',
     '../tests/save.test.js',
     '../tests/content.test.js',
     '../tests/accessibility-static.test.js',

--- a/math-marauder/tests/audio.test.js
+++ b/math-marauder/tests/audio.test.js
@@ -112,3 +112,17 @@ class FakeAudioContext {
     assert.ok(audio._ctx.oscillators.length >= musicCount + 5, 'wrong SFX should schedule two more effect tones');
     global.window = originalWindow;
 }
+
+{
+    const originalWindow = global.window;
+    global.window = { AudioContext: FakeAudioContext };
+    const audio = new AudioManager();
+    audio.setMusicEnabled(true);
+    const musicCount = audio._ctx.oscillators.length;
+    const musicEventCount = audio._musicGain.gain.events.length;
+    audio.setMuted(true);
+    audio.playCorrect();
+    assert.strictEqual(audio._ctx.oscillators.length, musicCount, 'muted SFX should not schedule effect tones');
+    assert.strictEqual(audio._musicGain.gain.events.length, musicEventCount, 'muted SFX should not duck music');
+    global.window = originalWindow;
+}

--- a/math-marauder/tests/audio.test.js
+++ b/math-marauder/tests/audio.test.js
@@ -90,3 +90,25 @@ class FakeAudioContext {
     assert.ok(audio._ctx.oscillators.every((osc) => osc.stopped), 'music oscillators should stop cleanly');
     global.window = originalWindow;
 }
+
+{
+    const originalWindow = global.window;
+    global.window = { AudioContext: FakeAudioContext };
+    const audio = new AudioManager();
+    audio.setMusicEnabled(true);
+    const musicCount = audio._ctx.oscillators.length;
+    const musicGain = audio._musicGain;
+    audio.playCorrect();
+    assert.strictEqual(audio._effectsGain.gain.value, 1);
+    assert.ok(audio._ctx.oscillators.length >= musicCount + 3, 'correct SFX should schedule three effect tones');
+    assert.ok(audio._ctx.oscillators.slice(musicCount).every((osc) => osc.connections.length), 'SFX oscillators should connect to gains');
+    assert.ok(musicGain.gain.events.some((event) => event[1] <= 0.02), 'SFX should duck music so effects are audible');
+    assert.ok(audio._ctx.gains.some((gain) => gain.gain.events.some((event) => event[1] >= 0.24)), 'SFX gain should be strong enough for tablet speakers');
+    audio.setMuted(true);
+    assert.strictEqual(audio._effectsGain.gain.value, 0);
+    audio.setMuted(false);
+    audio.playWrong();
+    assert.strictEqual(audio._effectsGain.gain.value, 1);
+    assert.ok(audio._ctx.oscillators.length >= musicCount + 5, 'wrong SFX should schedule two more effect tones');
+    global.window = originalWindow;
+}

--- a/math-marauder/tests/audio.test.js
+++ b/math-marauder/tests/audio.test.js
@@ -1,0 +1,92 @@
+const assert = require('assert');
+
+const AudioManager = require('../js/audio.js');
+
+class FakeAudioParam {
+    constructor(value) {
+        this.value = value || 0;
+        this.events = [];
+    }
+
+    setValueAtTime(value, time) {
+        this.value = value;
+        this.events.push(['set', value, time]);
+    }
+
+    linearRampToValueAtTime(value, time) {
+        this.value = value;
+        this.events.push(['linear', value, time]);
+    }
+}
+
+class FakeNode {
+    constructor(type) {
+        this.type = type;
+        this.connections = [];
+        this.started = false;
+        this.stopped = false;
+        this.frequency = new FakeAudioParam(0);
+        this.gain = new FakeAudioParam(1);
+    }
+
+    connect(node) {
+        this.connections.push(node);
+    }
+
+    start() {
+        this.started = true;
+    }
+
+    stop() {
+        this.stopped = true;
+    }
+
+    disconnect() {
+        this.disconnected = true;
+    }
+}
+
+class FakeAudioContext {
+    constructor() {
+        this.currentTime = 10;
+        this.destination = new FakeNode('destination');
+        this.oscillators = [];
+        this.gains = [];
+    }
+
+    createGain() {
+        const gain = new FakeNode('gain');
+        this.gains.push(gain);
+        return gain;
+    }
+
+    createOscillator() {
+        const osc = new FakeNode('oscillator');
+        this.oscillators.push(osc);
+        return osc;
+    }
+
+    resume() {
+        this.resumed = true;
+        return {
+            then: (cb) => {
+                cb();
+                return { catch() {} };
+            }
+        };
+    }
+}
+
+{
+    const originalWindow = global.window;
+    global.window = { AudioContext: FakeAudioContext };
+    const audio = new AudioManager();
+    assert.strictEqual(audio.isMusicPlaying(), false);
+    audio.setMusicEnabled(true);
+    assert.strictEqual(audio.isMusicPlaying(), true);
+    assert.ok(audio._ctx.oscillators.length >= 2, 'music should create layered oscillators');
+    audio.setMusicEnabled(false);
+    assert.strictEqual(audio.isMusicPlaying(), false);
+    assert.ok(audio._ctx.oscillators.every((osc) => osc.stopped), 'music oscillators should stop cleanly');
+    global.window = originalWindow;
+}

--- a/math-marauder/tests/game-audio-speech.test.js
+++ b/math-marauder/tests/game-audio-speech.test.js
@@ -1,0 +1,72 @@
+const assert = require('assert');
+
+function makeElement(checked) {
+    return {
+        checked: !!checked,
+        addEventListener() {}
+    };
+}
+
+const elements = {
+    'setting-sfx': makeElement(true),
+    'setting-music': makeElement(true),
+    'setting-speech': makeElement(true),
+    'setting-reduced-motion': makeElement(false)
+};
+
+const originalDocument = global.document;
+const originalMathMarauder = global.MathMarauder;
+global.document = {
+    addEventListener() {},
+    getElementById(id) {
+        return elements[id] || makeElement(false);
+    }
+};
+global.MathMarauder = {};
+require('../js/game.js');
+
+{
+    const game = new MathMarauder.Game();
+    const spoken = [];
+    game._speech = { speak: (text) => spoken.push(text) };
+    game._narrateSpell('starbolt');
+    game._narrateSpell('dragon-guard');
+    game._narrateSpell('mirror-spark');
+    game._narrateSpell('time-gem');
+    assert.deepStrictEqual(spoken, [
+        'Starbolt surge.',
+        'Dragon Guard shield.',
+        'Mirror Spark hint.',
+        'Time Gem phase shift.'
+    ]);
+    assert.strictEqual(game._joinSpeech(game._spellNarrationText('mirror-spark'), 'Try again.'), 'Mirror Spark hint. Try again.');
+}
+
+{
+    const game = new MathMarauder.Game();
+    const musicCalls = [];
+    game._save = {
+        settings: {
+            sfx: true,
+            music: true,
+            speech: true,
+            reducedMotion: false
+        }
+    };
+    game._audio = {
+        setMuted() {},
+        setMusicEnabled: (enabled, startNow) => musicCalls.push([enabled, startNow])
+    };
+    game._speech = { setEnabled() {} };
+    game._ui = { applySettings() {} };
+    game._saveManager = { save() {} };
+    game._applySettings();
+    assert.deepStrictEqual(musicCalls, [[true, false]]);
+
+    elements['setting-music'].checked = false;
+    game._saveSettingsFromControls();
+    assert.deepStrictEqual(musicCalls, [[true, false], [false, true]]);
+}
+
+global.document = originalDocument;
+global.MathMarauder = originalMathMarauder;

--- a/math-marauder/tests/game-audio-speech.test.js
+++ b/math-marauder/tests/game-audio-speech.test.js
@@ -25,6 +25,35 @@ global.document = {
 global.MathMarauder = {};
 require('../js/game.js');
 
+function stubGameForAnswer() {
+    const game = new MathMarauder.Game();
+    game._currentProblem = { correct: 12, factKey: 'mul:3:4' };
+    game._firstTry = true;
+    game._progression = { recordAnswer() {} };
+    game._encounter = {};
+    game._raid = {
+        hearts: 3,
+        shields: 1,
+        streak: 0,
+        promptsAnswered: 0,
+        correctFirstTry: 0,
+        longestStreak: 0
+    };
+    game._ui = {
+        markAnswer() {},
+        showSpell() {},
+        announce() {},
+        setAnswers() {},
+        updateHud() {}
+    };
+    game._speech = { speak() {} };
+    game._currentRoom = {};
+    game._syncScene = () => {};
+    game.presentProblem = () => {};
+    game._finishMonsterStep = () => {};
+    return game;
+}
+
 {
     const game = new MathMarauder.Game();
     const spoken = [];
@@ -41,6 +70,79 @@ require('../js/game.js');
     ]);
     assert.strictEqual(game._joinSpeech(game._spellNarrationText('mirror-spark'), 'Try again.'), 'Mirror Spark hint. Try again.');
 }
+
+{
+    const game = stubGameForAnswer();
+    const calls = [];
+    game._audio = {
+        playCorrect: () => calls.push('correct'),
+        playWrong: () => calls.push('wrong'),
+        playHit: () => calls.push('hit')
+    };
+    MathMarauder.GameRules = {
+        resolveAnswer: () => ({
+            hearts: 3,
+            shields: 1,
+            streak: 1,
+            promptsAnswered: 1,
+            correctFirstTry: 1,
+            longestStreak: 1,
+            monsterHp: 1
+        })
+    };
+    game.handleAnswer(12, 0);
+    assert.deepStrictEqual(calls, ['correct']);
+}
+
+{
+    const game = stubGameForAnswer();
+    const calls = [];
+    game._audio = {
+        playCorrect: () => calls.push('correct'),
+        playWrong: () => calls.push('wrong'),
+        playHit: () => calls.push('hit')
+    };
+    MathMarauder.GameRules = {
+        resolveAnswer: () => ({
+            hearts: 3,
+            shields: 0,
+            streak: 0,
+            promptsAnswered: 1,
+            correctFirstTry: 0,
+            longestStreak: 0,
+            monsterHp: 1,
+            spellTriggered: 'mirror-spark',
+            hintText: ''
+        })
+    };
+    game.handleAnswer(10, 0);
+    assert.deepStrictEqual(calls, ['wrong']);
+}
+
+{
+    const game = stubGameForAnswer();
+    const calls = [];
+    game._audio = {
+        playCorrect: () => calls.push('correct'),
+        playWrong: () => calls.push('wrong'),
+        playHit: () => calls.push('hit')
+    };
+    MathMarauder.GameRules = {
+        resolveAnswer: () => ({
+            hearts: 3,
+            shields: 1,
+            streak: 3,
+            promptsAnswered: 1,
+            correctFirstTry: 1,
+            longestStreak: 3,
+            monsterHp: 1,
+            spellTriggered: 'starbolt'
+        })
+    };
+    game.handleAnswer(12, 0);
+    assert.deepStrictEqual(calls, ['correct', 'hit']);
+}
+
 
 {
     const game = new MathMarauder.Game();


### PR DESCRIPTION
## Summary
- Add real Math Marauder music playback through Web Audio while keeping creation lazy for Safari user-gesture requirements.
- Narrate spell names when spell banners appear, including combined wrong-answer narration so hints do not cancel spell names.
- Make SFX more audible by strengthening effect envelopes and ducking music while effects play.
- Respect the Sound effects toggle by skipping muted SFX entirely so music does not pulse when SFX are off.

## Validation
- `node math-marauder/scripts/run-tests.js`
- JS syntax checks with `node --check` for Math Marauder scripts/tests and `.github/scripts/update-index.js`
- `git diff --check`