### PR TITLE
Claude's Math Marauder: Sessions 1–2 (scaffold + math engine)

### DIFF
--- a/.claude/agents/marauder-web-review/agent.md
+++ b/.claude/agents/marauder-web-review/agent.md
@@ -1,0 +1,97 @@
+---
+name: marauder-web-review
+description: Senior web engineer code reviewer for claudes-math-marauder sessions. Use after implementing a session to catch bugs before committing.
+model: claude-sonnet-4-6
+memory: project
+---
+
+You are a senior web engineer reviewing a just-implemented claudes-math-marauder session. The game is a fantasy math roguelike teaching multiplication and division to a 10-year-old with ADHD and dyslexia accommodations. It uses vanilla JS (no frameworks, no bundler), renders on HTML5 Canvas 2D, and targets iPad Safari with a Bluetooth keyboard. It lives at claudes-math-marauder/ within a multi-game repo.
+
+Review the changed files for the following, reporting each issue as CRITICAL / WARN / INFO with file:line references and concrete fixes:
+
+1. **Combat correctness** — Core learning loop must be bug-free:
+   - Does every orb shuffle use the run-seeded `rng` (no `Math.random()` in combat code)?
+   - Are distractors always unique (no duplicates), and always include the correct answer?
+   - Does `mastery.recordResolve` correctly update `box`, `streak`, `shaky`, `avgMs`?
+   - Are stretch facts gated on `box >= 4 && totalCorrect >= 6`?
+   - Is `SaveManager.save()` called once per fight (VICTORY/DEFEAT_RETRY), never per-problem?
+
+2. **Game loop correctness** — 60fps on iPad 9:
+   - Does only `game.js` own `requestAnimationFrame`? No manager starts its own RAF?
+   - Is `dt` capped at 50ms?
+   - Are animations driven by `dt` (not frame count)?
+   - Is DPR scaling applied correctly on resize (no blur on Retina)?
+
+3. **Touch & pointer input** — iPad Safari with Bluetooth keyboard:
+   - Are orbs ≥ 96px hit-targets? Numpad buttons ≥ 72px?
+   - Are `pointerdown` / `pointermove` / `pointerup` used (not `touchstart`)?
+   - Is `touch-action: none` set on canvas?
+   - Do physical keyboard shortcuts work in the ultimate overlay (digits, Backspace, Enter, Escape)?
+
+4. **Timer / async safety** — No memory leaks, no stale callbacks:
+   - Does every manager with `setTimeout` follow the lifecycle pattern (constructor nulls, `cancel()` clears all, save cb before `cancel()`, re-entry guard)?
+   - Is `_lessonComplete` guard set on `onFightComplete` (reachable from both VICTORY and DEFEAT_RETRY)?
+   - Are detached-element timers guarded with `el.isConnected`?
+   - Are focus-trap Escape handlers guarded with `classList.contains('open')`?
+
+5. **State machine** — Clean transitions, no stuck states:
+   - Does `setState()` cancel all active managers before transitioning?
+   - Does pause halt speech and animations?
+   - Does `cancel()` on every active manager get called from `showHub()` / screen transitions?
+
+6. **Combat module purity** — Node-testable:
+   - Do `js/combat/*.js` files contain zero DOM / canvas / audio imports?
+   - Can `node scripts/test-*.js` run without a browser environment?
+
+7. **Save system** — No data loss:
+   - Does `SaveManager._defaults()` include every key `game.js` reads from progress?
+   - Is schema migration complete (every v→v+1 migration populates missing keys from defaults)?
+   - Is save write batched (not per-problem)?
+   - Does `load()` fall back to backup on corrupt primary?
+
+8. **Mastery engine** — Leitner correctness:
+   - Are box updates bounded (1–5)?
+   - Does `isMastered()` require `box >= 4 && totalCorrect >= 6`?
+   - Is `recencyDamping` applied to avoid over-weighting recent facts?
+   - Are stretch-fact ranges correct: 5×N N∈[13,30], 10×N N∈[13,30], 2×N N∈[13,50]?
+
+9. **Audio** — iOS Safari compliance:
+   - Is `AudioContext` created lazily inside a user-gesture handler (never in a constructor)?
+   - Is scheduling chained after `ctx.resume().then(...)`?
+   - Is `speechSynthesis.cancel()` followed by a 50ms timeout before `speak()`?
+   - Is `'speechSynthesis' in window` feature-detected?
+   - Are there no harsh sounds (sudden loud oscillators, square waves above 0.3 gain)?
+
+10. **ARIA** — Correct screen-reader behavior:
+    - Are `aria-hidden` attributes always explicit `"true"` / `"false"` (never `removeAttribute`)?
+    - Is `aria-pressed` only on toggle buttons (not action buttons, not listbox options)?
+    - Is `role="group"` used for grids of buttons (not `role="list"`)?
+    - Does dynamic `aria-label` update whenever `textContent` changes on labelled elements?
+    - Is there no `aria-live` + `aria-hidden` or `aria-live` + `aria-label` on the same element?
+    - Do modal overlays: `role="dialog" aria-modal="true" aria-label="..."`?
+    - Does focus return to the trigger element on modal close?
+
+11. **Performance** — No hot-path allocs or DOM thrash:
+    - Is `SaveManager.load()` cached on state entry (not called per-frame)?
+    - Is the LRU canvas cache bounded to ≤ 30 canvases?
+    - Are particles recycled from a pool (no per-burst allocation)?
+    - No `createElement` / `innerHTML` during the RAF update/draw cycle?
+
+12. **Accessibility** — Non-negotiable for the target audience:
+    - OpenDyslexic font loaded via `<link>` (not `@import`), Comic Sans fallback?
+    - Minimum 16px font, 1.5× line height?
+    - Cream background #F5F0E8, dark text #2C2416, secondary text #595143 or darker?
+    - WCAG AA contrast (4.5:1) on all text elements?
+    - All interactive elements ≥ 44×44px (orbs 96px, numpad 72px)?
+    - `prefers-reduced-motion` honored (animations skip / instant)?
+    - No `user-scalable=no` in viewport meta?
+    - No flashing / strobing effects?
+
+13. **Edge cases** — Don't let the kid hit a crash:
+    - Corrupt save → graceful fallback to defaults?
+    - 0 mastery on first run → `selectProblem` never returns null?
+    - 100% mastery → stretch facts offered correctly?
+    - Rapid-tap / double-tap on orbs → no double-resolve?
+    - Web Speech unavailable → no crash, no stuck state?
+    - AudioContext blocked by browser policy → no crash?
+    - Resize during a fight → canvas rescaled, hit-test recalculated?

--- a/.claude/hooks/validate-marauder-data-hook.sh
+++ b/.claude/hooks/validate-marauder-data-hook.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# PostToolUse hook: auto-validate claudes-math-marauder data JSON files after edits.
+# Exits 2 (blocking with feedback) when validation reports CRITICAL errors.
+
+input=$(cat)
+
+fp=$(python3 -c "
+import json, sys
+try:
+    d = json.load(sys.stdin)
+    print(d.get('tool_input', {}).get('file_path', ''))
+except Exception:
+    print('')
+" 2>/dev/null <<< "$input")
+
+if [[ "$fp" == *"claudes-math-marauder/data/"* && "$fp" == *.json ]]; then
+    result=$(node claudes-math-marauder/scripts/validate-data.js 2>&1)
+    echo "$result"
+    if echo "$result" | grep -q "CRITICAL"; then
+        exit 2
+    fi
+fi

--- a/.claude/rules/marauder.md
+++ b/.claude/rules/marauder.md
@@ -1,0 +1,108 @@
+---
+paths:
+  - "claudes-math-marauder/**"
+---
+
+# Claude's Math Marauder — Architecture Rules
+
+## Single RAF Chain — game.js Owns the Loop
+
+Only `game.js` drives `requestAnimationFrame`. All other managers expose passive `update(dt)` and `draw(ctx, w, h)` methods called from the loop. No manager, renderer, or audio module may start its own `requestAnimationFrame`.
+
+## Timer Lifecycle Pattern
+
+Every manager with `setTimeout`/`setInterval` must follow this pattern exactly:
+
+```js
+constructor() {
+  this._mainTimer = null;   // declare ALL timer IDs as null
+  this._shakeTimer = null;  // even short cosmetic timers
+  this.onComplete = null;
+}
+cancel() {
+  clearTimeout(this._mainTimer);  this._mainTimer = null;
+  clearTimeout(this._shakeTimer); this._shakeTimer = null;
+  this.onComplete = null;         // prevent stale callbacks
+}
+complete() {
+  const cb = this.onComplete;   // save BEFORE cancel() nulls it
+  this.cancel();
+  if (cb) cb();
+}
+start(...) { this.cancel(); /* then init */ }
+```
+
+## Combat Determinism
+
+Combat is deterministic given `(runSeed, masteryStateAtFightStart, inputSequence)`. **Never call `Math.random()` in combat code** — always use the run-seeded PRNG passed as `rng`. Required for the replay harness (Session 13). Distractors are shuffled via Fisher-Yates with the run-seeded PRNG.
+
+## Mastery Save Cadence
+
+Update mastery in-memory per problem. **Commit to `SaveManager.save()` once per fight at VICTORY or DEFEAT_RETRY** (batch write). Never call `SaveManager.save()` per problem — it's in the hot path.
+
+## Combat Module Purity
+
+Modules under `js/combat/` must **not** import DOM, canvas, or audio modules. They are pure logic so Node tests can `require()` them. Visual effects, audio cues, and DOM updates live in `fight.js`'s callbacks, called by `FightManager`.
+
+## Re-entry Guard on `onFightComplete`
+
+`onFightComplete` (and similar terminal callbacks) is reachable from both the VICTORY path and the DEFEAT_RETRY path. Set a boolean guard immediately on entry:
+
+```js
+if (this._lessonComplete) return;
+this._lessonComplete = true;
+```
+
+Reset in `start()`. Cancel all related timers on entry.
+
+## Visibility Classes — No `style.display`
+
+Never assign `style.display` in JS to show or hide elements. Use:
+- `.active` for screens
+- `.open` for overlays and panels
+- `.hidden` for internal elements
+
+`container.innerHTML = ''` to clear a container is fine — that's not a visibility toggle.
+
+## Web Speech (iOS Safari)
+
+`cancel()` silences an immediately-following `speak()` on iOS. Always delay:
+```js
+speechSynthesis.cancel();
+setTimeout(() => speechSynthesis.speak(utterance), 50);
+```
+Feature-detect: `if (!('speechSynthesis' in window)) return`.
+
+## Web Audio (iOS Safari)
+
+`AudioContext` must be created lazily inside a user-gesture handler — never in a constructor. Chain scheduling inside `.then()`:
+```js
+ctx.resume().then(() => scheduleOscillator());
+```
+
+## ARIA Rules
+
+- `aria-hidden` always explicit `"true"` / `"false"` — never `removeAttribute('aria-hidden')` on overlays
+- `aria-pressed` only on **toggle buttons** with persistent binary state — not on action buttons
+- Use `role="group"` (not `role="list"`) for grids of buttons to avoid AT list-count errors
+- Dynamic `aria-label`: whenever `textContent` changes on a labelled element, also call `setAttribute('aria-label', ...)`
+- No `aria-live` on elements that also toggle `aria-hidden`
+- No `aria-live` + `aria-label` on the same element
+
+## Focus Trap Escape Guard
+
+Focus trap keydown handlers must check `el.classList.contains('open')` before acting on Escape:
+```js
+if (e.key === 'Escape') {
+  if (overlay.classList.contains('open')) doClose();
+  return;
+}
+```
+
+## `SaveManager._defaults()` Completeness
+
+Every key that `game.js` reads from progress must exist in `SaveManager._defaults()`. Add new keys in the same commit that reads them.
+
+## Stretch-Fact Eligibility
+
+Stretch facts require the family to be mastered: `box >= 4 && totalCorrect >= 6`. Never offer stretch facts from un-mastered families.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -19,6 +19,10 @@
           {
             "type": "command",
             "command": "bash .claude/hooks/validate-petstore-data-hook.sh"
+          },
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/validate-marauder-data-hook.sh"
           }
         ]
       }

--- a/.claude/skills/marauder-checklist/SKILL.md
+++ b/.claude/skills/marauder-checklist/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: marauder-checklist
+description: Pre-implementation checklist for claudes-math-marauder sessions. Prints the coding rules most likely to cause bugs. Run this before writing any session code.
+---
+
+Read the session file, then confirm each rule below before writing code.
+
+## Spec Code Has Bugs — Fix Before Implementing
+
+Session specs often contain code samples that violate CLAUDE.md rules. Before using any code sample from the spec, scan it for these patterns and replace them:
+
+| Spec pattern | Fix |
+|---|---|
+| `style.display = 'none'` / `'block'` / `'flex'` | Use a CSS class instead (`.active`, `.open`, `.hidden`) |
+| `onclick="..."` HTML attribute | Remove attr; bind with `addEventListener` in JS |
+| `.onclick = () => ...` | Use `addEventListener` — no stacking risk |
+| `.sort(() => Math.random() - 0.5)` | Fisher-Yates using run-seeded `rng` |
+| `new AudioContext()` in constructor | Create lazily on first use; `ctx.resume().then(() => schedule())` |
+| Independent `requestAnimationFrame` in a manager | Only `game.js` owns the RAF loop — expose `update(dt)` and `draw(ctx, w, h)` |
+| `touchstart` / `touchmove` / `touchend` | Use Pointer Events: `pointerdown` / `pointermove` / `pointerup` |
+| `Math.random()` in combat modules | Use run-seeded `rng` passed as dependency |
+| `escHtml()` on `setAttribute('aria-label', ...)` | Don't escape — `setAttribute` doesn't parse HTML entities |
+| `aria-pressed` on non-toggle elements | Only on persistent binary-state toggle buttons |
+| `role="listitem"` on `<button>` | Remove — overrides implicit button role |
+| `aria-live` + `aria-hidden` on same element | Remove `aria-live`; use `role="status"` only |
+| `aria-live` + `aria-label` on same element | Remove `aria-label` — live regions announce `textContent` |
+| `SaveManager.load()` per frame | Cache on state entry |
+
+---
+
+## Single RAF Rule
+
+`game.js` owns the RAF loop. All managers get `update(dt)` / `draw(ctx, w, h)` called from it.
+
+---
+
+## Timer Lifecycle Pattern
+
+```js
+constructor() {
+  this._mainTimer = null;    // declare ALL timer IDs as null
+  this.onComplete = null;
+}
+cancel() {
+  clearTimeout(this._mainTimer); this._mainTimer = null;
+  this.onComplete = null;
+}
+complete() {
+  const cb = this.onComplete;  // save BEFORE cancel() nulls it
+  this.cancel();
+  if (cb) cb();
+}
+start(...) { this.cancel(); /* then init */ }
+```
+
+---
+
+## Web Audio — iOS Safari
+
+```js
+// Lazy context — never in constructor
+_getCtx() { if (!this._ctx) this._ctx = new AudioContext(); return this._ctx; }
+// Chain after resume
+this._getCtx().resume().then(() => this._scheduleOscillator(...));
+```
+
+---
+
+## Web Speech — iOS Safari
+
+```js
+speechSynthesis.cancel();
+setTimeout(() => speechSynthesis.speak(utterance), 50);
+if (!('speechSynthesis' in window)) return;
+```
+
+---
+
+## ARIA Checklist
+
+- [ ] Overlays: `role="dialog" aria-modal="true" aria-label="..."` (not `<aside>`)
+- [ ] First focusable element in modal: close button (✕)
+- [ ] Focus trap: Tab / Shift-Tab cycle within modal; Escape closes
+- [ ] `aria-hidden` explicit `"true"` / `"false"` — never `removeAttribute` on overlays
+- [ ] `aria-pressed` only on toggle buttons
+- [ ] `role="group"` for grids of buttons (not `role="list"`)
+- [ ] Dynamic `aria-label` updated alongside `textContent`
+- [ ] No `aria-live` on elements that toggle `aria-hidden`
+
+---
+
+## Visibility — No `style.display`
+
+Use `.active` (screens), `.open` (overlays), `.hidden` (internal). Never `style.display = ...`.
+
+---
+
+## Combat Purity
+
+`js/combat/*.js` modules must never import DOM / canvas / audio. Tests run in Node.
+
+---
+
+## Mastery Save Cadence
+
+Write `SaveManager.save()` **once per fight** at VICTORY/DEFEAT_RETRY. Never per-problem.
+
+---
+
+## Stretch-Fact Gate
+
+Stretch facts: only offer when family has `box >= 4 && totalCorrect >= 6`.
+
+---
+
+## Re-entry Guard
+
+Any function reachable from two timer paths needs:
+```js
+if (this._lessonComplete) return;
+this._lessonComplete = true;
+```
+
+---
+
+## `SaveManager._defaults()` Completeness
+
+Every key game.js reads must be in `_defaults()`. Add new keys in the same commit.
+
+---
+
+## No `user-scalable=no` in Viewport
+
+WCAG 1.4.4 — users with dyslexia rely on browser zoom.

--- a/.claude/skills/validate-marauder-data/SKILL.md
+++ b/.claude/skills/validate-marauder-data/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: validate-marauder-data
+description: Validate all claudes-math-marauder data/*.json files for schema integrity, referential consistency, and contrast rules.
+---
+
+Run `node claudes-math-marauder/scripts/validate-data.js` and fix any reported CRITICAL or WARN errors before committing.
+
+If the script exits non-zero, read the output and fix each reported issue. Re-run until it exits 0.

--- a/.github/scripts/update-index.js
+++ b/.github/scripts/update-index.js
@@ -93,6 +93,12 @@ const manualGameConfig = {
     icon: '🦄🐾✨',
     title: "Lizzie's Petstore",
     description: 'Design magical creatures from mix-and-match parts, dress them up, and care for your imaginary pets!'
+  },
+  'claudes-math-marauder': {
+    icon: '🤖⚔️📐',
+    title: "Claude's Math Marauder",
+    description: 'Claude built this fantasy roguelike where you cast multiplication and division spells to defeat goblins, dragons, and liches.',
+    category: 'learning',
   }
 };
 

--- a/claudes-math-marauder/css/style.css
+++ b/claudes-math-marauder/css/style.css
@@ -1,0 +1,207 @@
+/* ===== Design System ===== */
+:root {
+  --bg: #F5F0E8;
+  --text: #2C2416;
+  --text-secondary: #595143;
+  --accent-ink: #1a1a1a;
+  --accent-comic-red: #c93434;
+  --accent-comic-blue: #2c5fb3;
+  --accent-comic-yellow: #f0d840;
+  --panel-stroke: 4px;
+  --font-base: 20px;
+  --font-numerals: 64px;
+  --font-stack: "OpenDyslexic", "Comic Sans MS", cursive;
+  --line-height: 1.5;
+}
+
+/* ===== Reset & Base ===== */
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
+html, body {
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  height: 100%;
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--font-stack);
+  font-size: var(--font-base);
+  line-height: var(--line-height);
+  overflow: hidden;
+}
+
+/* ===== Canvas ===== */
+#game-canvas {
+  display: block;
+  position: fixed;
+  inset: 0;
+  width: 100vw;
+  height: 100vh;
+  touch-action: none;
+  z-index: 0;
+}
+
+#transition-canvas-wrap {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 1000;
+}
+#transition-canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+/* ===== Screens ===== */
+.screen {
+  display: none;
+  position: fixed;
+  inset: 0;
+  z-index: 10;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: var(--bg);
+}
+/* ID + class so specificity beats a naked .screen { display: none } */
+#title-screen.active,
+#hub-screen.active,
+#run-map-screen.active,
+#fight-screen.active,
+#results-screen.active,
+#paused-screen.active {
+  display: flex;
+}
+
+/* ===== Overlays ===== */
+.overlay {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(44, 36, 22, 0.55);
+  z-index: 100;
+  align-items: center;
+  justify-content: center;
+}
+.overlay.open {
+  display: flex;
+}
+.overlay[aria-hidden="true"] {
+  pointer-events: none;
+}
+
+/* ===== Panel (comic-style bordered card) ===== */
+.panel {
+  background: var(--bg);
+  border: var(--panel-stroke) solid var(--accent-ink);
+  border-radius: 16px;
+  padding: 32px;
+  max-width: 90vw;
+  max-height: 90vh;
+  overflow-y: auto;
+}
+
+/* ===== Buttons ===== */
+button {
+  font-family: var(--font-stack);
+  font-size: var(--font-base);
+  min-width: 44px;
+  min-height: 44px;
+  padding: 10px 20px;
+  background: var(--accent-comic-yellow);
+  color: var(--text);
+  border: var(--panel-stroke) solid var(--accent-ink);
+  border-radius: 12px;
+  cursor: pointer;
+  transition: transform 80ms;
+}
+button:active { transform: scale(0.96); }
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  transform: none;
+}
+button.primary {
+  font-size: calc(var(--font-base) * 1.1);
+  padding: 14px 32px;
+  background: var(--accent-comic-yellow);
+}
+button.secondary {
+  background: var(--bg);
+}
+button.danger {
+  background: var(--accent-comic-red);
+  color: #fff;
+}
+
+/* ===== Focus ring ===== */
+*:focus-visible {
+  outline: 3px solid var(--text);
+  outline-offset: 2px;
+}
+
+/* ===== Visibility helpers ===== */
+.hidden { display: none; }
+.locked { opacity: 0.5; cursor: not-allowed; }
+
+/* ===== HUD root ===== */
+#hud-root {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 50;
+  pointer-events: none;
+}
+
+/* ===== Toast root ===== */
+#toast-root {
+  position: fixed;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 200;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  pointer-events: none;
+}
+.toast {
+  background: var(--text);
+  color: var(--bg);
+  font-family: var(--font-stack);
+  font-size: 18px;
+  padding: 10px 20px;
+  border-radius: 10px;
+  border: 2px solid var(--accent-ink);
+  max-width: 80vw;
+  text-align: center;
+}
+
+/* ===== Title screen ===== */
+#title-screen h1 {
+  font-size: clamp(32px, 6vw, 64px);
+  font-weight: 900;
+  letter-spacing: 2px;
+  text-align: center;
+  margin-bottom: 8px;
+}
+#title-screen .subtitle {
+  font-size: 18px;
+  color: var(--text-secondary);
+  margin-bottom: 40px;
+}
+
+/* ===== Reduced motion ===== */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/claudes-math-marauder/index.html
+++ b/claudes-math-marauder/index.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Claude's Math Marauder</title>
+  <link rel="stylesheet" href="https://fonts.cdnfonts.com/css/opendyslexic" crossorigin="anonymous">
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+
+  <canvas id="game-canvas" aria-hidden="true"></canvas>
+  <!-- role="status" implies aria-live="polite"; aria-atomic="false" is intentional so sub-updates announce incrementally -->
+  <div id="hud-root" role="status" aria-atomic="false"></div>
+  <div id="overlay-root"></div>
+  <div id="toast-root" role="status"></div>
+  <div id="transition-canvas-wrap"><canvas id="transition-canvas"></canvas></div>
+
+  <!-- TITLE screen -->
+  <section id="title-screen" class="screen active" aria-label="Title screen">
+    <h1>Claude's Math Marauder</h1>
+    <p class="subtitle">A game by Claude</p>
+    <button id="start-button" class="primary" aria-label="Begin game">Begin</button>
+  </section>
+
+  <!-- HUB screen — populated by hub.js -->
+  <section id="hub-screen" class="screen" aria-label="Wizard's Tower"></section>
+
+  <!-- RUN MAP screen — populated by mapScreen.js -->
+  <section id="run-map-screen" class="screen" aria-label="Run map"></section>
+
+  <!-- FIGHT screen — populated by fight.js / bossFight.js -->
+  <section id="fight-screen" class="screen" aria-label="Combat"></section>
+
+  <!-- RESULTS screen — populated by resultsCard.js -->
+  <section id="results-screen" class="screen" aria-label="Results"></section>
+
+  <!-- PAUSED screen -->
+  <section id="paused-screen" class="screen" aria-label="Game paused">
+    <h2>Paused</h2>
+    <button id="resume-button" class="primary" aria-label="Resume game">Resume</button>
+  </section>
+
+  <!-- Plain defer (not type="module") — all files use UMD globals so Node tests can require() them without a bundler -->
+  <script src="js/save.js" defer></script>
+  <script src="js/util/rng.js" defer></script>
+  <script src="js/util/shuffle.js" defer></script>
+  <script src="js/util/escape.js" defer></script>
+  <script src="js/ui/toast.js" defer></script>
+  <script src="js/game.js" defer></script>
+</body>
+</html>

--- a/claudes-math-marauder/index.html
+++ b/claudes-math-marauder/index.html
@@ -41,12 +41,23 @@
     <button id="resume-button" class="primary" aria-label="Resume game">Resume</button>
   </section>
 
-  <!-- Plain defer (not type="module") — all files use UMD globals so Node tests can require() them without a bundler -->
+  <!--
+    Script load order (all defer, UMD globals — no bundler required):
+      1. Utilities: save, rng, shuffle, escape, toast
+      2. Combat logic (pure, no DOM): factKeys → mastery → problemGen → distractors
+      3. Game orchestration: game.js last (reads all globals)
+  -->
   <script src="js/save.js" defer></script>
   <script src="js/util/rng.js" defer></script>
   <script src="js/util/shuffle.js" defer></script>
   <script src="js/util/escape.js" defer></script>
   <script src="js/ui/toast.js" defer></script>
+  <!-- Combat modules (Sessions 1–2) -->
+  <script src="js/combat/factKeys.js" defer></script>
+  <script src="js/combat/mastery.js" defer></script>
+  <script src="js/combat/problemGen.js" defer></script>
+  <script src="js/combat/distractors.js" defer></script>
+  <!-- Future sessions will add: fight.js, bossFight.js, mapGen.js, hub.js, etc. -->
   <script src="js/game.js" defer></script>
 </body>
 </html>

--- a/claudes-math-marauder/js/combat/distractors.js
+++ b/claudes-math-marauder/js/combat/distractors.js
@@ -5,11 +5,11 @@
   // problem: { kind, a, b, answer }
   // rng: run-seeded 0..1 PRNG (must be provided — no Math.random() inside combat modules)
   function generateDistractors(problem, rng) {
-    var correct = problem.answer;
-    var candidates = new Set();
+    const correct = problem.answer;
+    const candidates = new Set();
 
     if (problem.kind === 'mul') {
-      var a = problem.a, b = problem.b;
+      const a = problem.a, b = problem.b;
       candidates.add(a * (b + 1));
       candidates.add(a * (b - 1));
       candidates.add((a + 1) * b);
@@ -22,7 +22,7 @@
       candidates.add(correct + 2);
       candidates.add(correct - 2);
     } else {
-      var dividend = problem.a, divisor = problem.b;
+      const dividend = problem.a, divisor = problem.b;
       candidates.add(correct + 1);
       candidates.add(correct - 1);
       candidates.add(correct + 2);
@@ -34,7 +34,7 @@
     }
 
     // Filter: non-negative integers, not equal to correct, plausible range
-    var filtered = Array.from(candidates).filter(function(v) {
+    const filtered = Array.from(candidates).filter(function(v) {
       return Number.isInteger(v) && v >= 0 && v !== correct && v <= 999;
     });
 
@@ -42,22 +42,22 @@
     filtered.sort(function(x, y) { return Math.abs(x - correct) - Math.abs(y - correct); });
 
     // Take a pool then shuffle so distractor order isn't always the same
-    var pool = filtered.slice(0, Math.max(6, filtered.length));
-    for (var i = pool.length - 1; i > 0; i--) {
-      var j = Math.floor(rng() * (i + 1));
-      var tmp = pool[i]; pool[i] = pool[j]; pool[j] = tmp;
+    const pool = filtered.slice(0, Math.max(6, filtered.length));
+    for (let i = pool.length - 1; i > 0; i--) {
+      const j = Math.floor(rng() * (i + 1));
+      const tmp = pool[i]; pool[i] = pool[j]; pool[j] = tmp;
     }
 
-    var distractors = [];
-    for (var vi = 0; vi < pool.length; vi++) {
+    const distractors = [];
+    for (let vi = 0; vi < pool.length; vi++) {
       if (distractors.length === 3) break;
       if (!distractors.includes(pool[vi])) distractors.push(pool[vi]);
     }
 
     // Pathological fallback: answer=0 or very few valid candidates
-    var pad = 1;
+    let pad = 1;
     while (distractors.length < 3) {
-      var fallback = correct + pad;
+      const fallback = correct + pad;
       if (fallback !== correct && fallback >= 0 && !distractors.includes(fallback)) {
         distractors.push(fallback);
       }
@@ -65,18 +65,18 @@
       if (pad > 150) break;  // safety valve
     }
 
-    var orbs = [correct].concat(distractors);
+    const orbs = [correct].concat(distractors);
 
     // Final shuffle so correct answer isn't always position 0
-    for (var oi = orbs.length - 1; oi > 0; oi--) {
-      var oj = Math.floor(rng() * (oi + 1));
-      var otmp = orbs[oi]; orbs[oi] = orbs[oj]; orbs[oj] = otmp;
+    for (let oi = orbs.length - 1; oi > 0; oi--) {
+      const oj = Math.floor(rng() * (oi + 1));
+      const otmp = orbs[oi]; orbs[oi] = orbs[oj]; orbs[oj] = otmp;
     }
 
     return orbs;
   }
 
-  var exp = { generateDistractors };
+  const exp = { generateDistractors };
   if (typeof module !== 'undefined' && module.exports) module.exports = exp;
   else global.Distractors = exp;
 })(typeof window !== 'undefined' ? window : globalThis);

--- a/claudes-math-marauder/js/combat/distractors.js
+++ b/claudes-math-marauder/js/combat/distractors.js
@@ -1,0 +1,82 @@
+(function(global) {
+  'use strict';
+
+  // Returns exactly 4 numbers: the correct answer + 3 close-miss distractors, shuffled.
+  // problem: { kind, a, b, answer }
+  // rng: run-seeded 0..1 PRNG (must be provided — no Math.random() inside combat modules)
+  function generateDistractors(problem, rng) {
+    var correct = problem.answer;
+    var candidates = new Set();
+
+    if (problem.kind === 'mul') {
+      var a = problem.a, b = problem.b;
+      candidates.add(a * (b + 1));
+      candidates.add(a * (b - 1));
+      candidates.add((a + 1) * b);
+      candidates.add((a - 1) * b);
+      candidates.add(correct + 1);
+      candidates.add(correct - 1);
+      candidates.add(correct + 10);
+      candidates.add(correct - 10);
+      candidates.add(a + b);       // common kid mistake: confuse + with ×
+      candidates.add(correct + 2);
+      candidates.add(correct - 2);
+    } else {
+      var dividend = problem.a, divisor = problem.b;
+      candidates.add(correct + 1);
+      candidates.add(correct - 1);
+      candidates.add(correct + 2);
+      candidates.add(correct - 2);
+      candidates.add(dividend - divisor);         // confuse − with ÷
+      if (divisor > 1) candidates.add(Math.floor(dividend / (divisor - 1)));
+      candidates.add(Math.floor(dividend / (divisor + 1)));
+      candidates.add(dividend - correct);          // off-by-one on quotient
+    }
+
+    // Filter: non-negative integers, not equal to correct, plausible range
+    var filtered = Array.from(candidates).filter(function(v) {
+      return Number.isInteger(v) && v >= 0 && v !== correct && v <= 999;
+    });
+
+    // Sort by closeness to correct answer (prefer close-miss distractors)
+    filtered.sort(function(x, y) { return Math.abs(x - correct) - Math.abs(y - correct); });
+
+    // Take a pool then shuffle so distractor order isn't always the same
+    var pool = filtered.slice(0, Math.max(6, filtered.length));
+    for (var i = pool.length - 1; i > 0; i--) {
+      var j = Math.floor(rng() * (i + 1));
+      var tmp = pool[i]; pool[i] = pool[j]; pool[j] = tmp;
+    }
+
+    var distractors = [];
+    for (var vi = 0; vi < pool.length; vi++) {
+      if (distractors.length === 3) break;
+      if (!distractors.includes(pool[vi])) distractors.push(pool[vi]);
+    }
+
+    // Pathological fallback: answer=0 or very few valid candidates
+    var pad = 1;
+    while (distractors.length < 3) {
+      var fallback = correct + pad;
+      if (fallback !== correct && fallback >= 0 && !distractors.includes(fallback)) {
+        distractors.push(fallback);
+      }
+      pad++;
+      if (pad > 150) break;  // safety valve
+    }
+
+    var orbs = [correct].concat(distractors);
+
+    // Final shuffle so correct answer isn't always position 0
+    for (var oi = orbs.length - 1; oi > 0; oi--) {
+      var oj = Math.floor(rng() * (oi + 1));
+      var otmp = orbs[oi]; orbs[oi] = orbs[oj]; orbs[oj] = otmp;
+    }
+
+    return orbs;
+  }
+
+  var exp = { generateDistractors };
+  if (typeof module !== 'undefined' && module.exports) module.exports = exp;
+  else global.Distractors = exp;
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/claudes-math-marauder/js/combat/factKeys.js
+++ b/claudes-math-marauder/js/combat/factKeys.js
@@ -1,0 +1,37 @@
+(function(global) {
+  'use strict';
+
+  // Canonical key: always smaller×larger so 7×8 and 8×7 collapse to the same key
+  function mulKey(a, b) {
+    const lo = Math.min(a, b);
+    const hi = Math.max(a, b);
+    return 'mul:' + lo + 'x' + hi;
+  }
+
+  // Division key: larger/smaller so divKey(56,7) === divKey(7,56) === "div:56/7"
+  function divKey(dividend, divisor) {
+    const hi = Math.max(dividend, divisor);
+    const lo = Math.min(dividend, divisor);
+    return 'div:' + hi + '/' + lo;
+  }
+
+  function parseFactKey(key) {
+    const m = /^mul:(\d+)x(\d+)$/.exec(key);
+    if (m) return { kind: 'mul', a: +m[1], b: +m[2] };
+    const d = /^div:(\d+)\/(\d+)$/.exec(key);
+    if (d) return { kind: 'div', dividend: +d[1], divisor: +d[2] };
+    return null;
+  }
+
+  // Returns the canonical family string for a key, e.g. "mul:7x8" → "x7"
+  function familyOf(key) {
+    const f = parseFactKey(key);
+    if (!f) return null;
+    if (f.kind === 'mul') return 'x' + Math.min(f.a, f.b);
+    return 'x' + f.divisor;
+  }
+
+  const exp = { mulKey, divKey, parseFactKey, familyOf };
+  if (typeof module !== 'undefined' && module.exports) module.exports = exp;
+  else global.FactKeys = exp;
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/claudes-math-marauder/js/combat/mastery.js
+++ b/claudes-math-marauder/js/combat/mastery.js
@@ -37,8 +37,8 @@
     if (correct) {
       s.totalCorrect++;
       s.streak++;
-      // Fast = under 2× the mastered average (fall back to 8 s if no baseline)
-      const fastThreshold = (masteredAvgMs != null ? masteredAvgMs : 4000) * 2;
+      // Fast = under 2× the mastered average (fall back to 6 s if no baseline)
+      const fastThreshold = (masteredAvgMs != null ? masteredAvgMs : 6000) * 2;
       if (timeMs < fastThreshold) s.box = Math.min(5, s.box + 1);
       s.avgMs = s.avgMs === 0 ? timeMs : Math.round(s.avgMs * 0.7 + timeMs * 0.3);
     } else {

--- a/claudes-math-marauder/js/combat/mastery.js
+++ b/claudes-math-marauder/js/combat/mastery.js
@@ -1,0 +1,80 @@
+(function(global) {
+  'use strict';
+
+  const BOX_WEIGHT = { 1: 5, 2: 4, 3: 3, 4: 2, 5: 1 };
+  const SHAKY_MULTIPLIER = 2.5;
+  const RECENCY_WINDOW = 5;
+  const RECENCY_DAMPING = 0.3;
+  const MASTERED_BOX = 4;
+  const MASTERED_MIN_CORRECT = 6;
+
+  function getOrCreate(masteryMap, key) {
+    if (!masteryMap[key]) {
+      masteryMap[key] = {
+        box: 1, lastSeenAt: 0, totalAsked: 0,
+        totalCorrect: 0, avgMs: 0, streak: 0, shaky: false,
+      };
+    }
+    return masteryMap[key];
+  }
+
+  function isMastered(stat) {
+    return !!(stat && stat.box >= MASTERED_BOX && stat.totalCorrect >= MASTERED_MIN_CORRECT);
+  }
+
+  // Update Leitner state for one resolved problem.
+  // masteredAvgMs: average answer-time across currently-mastered facts, or null if none yet.
+  function recordResolve(masteryMap, key, ctx) {
+    const correct = ctx.correct;
+    const timeMs = ctx.timeMs;
+    const now = ctx.now;
+    const masteredAvgMs = ctx.masteredAvgMs;
+
+    const s = getOrCreate(masteryMap, key);
+    s.totalAsked++;
+    s.lastSeenAt = now;
+
+    if (correct) {
+      s.totalCorrect++;
+      s.streak++;
+      // Fast = under 2× the mastered average (fall back to 8 s if no baseline)
+      const fastThreshold = (masteredAvgMs != null ? masteredAvgMs : 4000) * 2;
+      if (timeMs < fastThreshold) s.box = Math.min(5, s.box + 1);
+      s.avgMs = s.avgMs === 0 ? timeMs : Math.round(s.avgMs * 0.7 + timeMs * 0.3);
+    } else {
+      s.streak = 0;
+      s.box = Math.max(1, s.box - 2);
+      s.shaky = true;
+    }
+
+    // Shake clears after 3 consecutive correct
+    if (correct && s.streak >= 3) s.shaky = false;
+
+    return s;
+  }
+
+  // Average answer-time across all currently-mastered facts; null if none mastered yet.
+  function masteredAvgMs(masteryMap) {
+    const stats = Object.values(masteryMap).filter(isMastered);
+    if (stats.length === 0) return null;
+    const sum = stats.reduce(function(acc, s) { return acc + (s.avgMs || 0); }, 0);
+    return Math.round(sum / stats.length);
+  }
+
+  // Per-fact selection weight. key and recentKeys must both be provided for recency damping.
+  function pullWeight(key, stat, recentKeys) {
+    const box = stat ? stat.box : 1;
+    const w = BOX_WEIGHT[box] !== undefined ? BOX_WEIGHT[box] : 1;
+    const sh = stat && stat.shaky ? SHAKY_MULTIPLIER : 1.0;
+    const rd = recentKeys && recentKeys.includes(key) ? RECENCY_DAMPING : 1.0;
+    return w * sh * rd;
+  }
+
+  const exp = {
+    recordResolve, isMastered, masteredAvgMs, pullWeight, getOrCreate,
+    BOX_WEIGHT, MASTERED_BOX, MASTERED_MIN_CORRECT, SHAKY_MULTIPLIER,
+    RECENCY_DAMPING, RECENCY_WINDOW,
+  };
+  if (typeof module !== 'undefined' && module.exports) module.exports = exp;
+  else global.Mastery = exp;
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/claudes-math-marauder/js/combat/problemGen.js
+++ b/claudes-math-marauder/js/combat/problemGen.js
@@ -1,24 +1,24 @@
 (function(global) {
   'use strict';
 
-  var FK = (typeof require !== 'undefined') ? require('./factKeys.js') : global.FactKeys;
-  var M  = (typeof require !== 'undefined') ? require('./mastery.js')  : global.Mastery;
+  const FK = (typeof require !== 'undefined') ? require('./factKeys.js') : global.FactKeys;
+  const M  = (typeof require !== 'undefined') ? require('./mastery.js')  : global.Mastery;
 
   // Build the eligible fact-key pool for a realm.
   // For each enabled family x_n (weight > 0), includes:
   //   mul: n×0, n×1, ..., n×12
   //   div: (n*k)÷n for k=1..12  (canonical "how many n's in n*k" form)
   function buildEligibleKeys(factFamilyWeights) {
-    var out = [];
+    const out = [];
     Object.entries(factFamilyWeights).forEach(function(entry) {
-      var fam = entry[0], w = entry[1];
+      const fam = entry[0], w = entry[1];
       if (w <= 0) return;
-      var n = +fam.slice(1);
+      const n = +fam.slice(1);
       // Multiplication facts
-      for (var k = 0; k <= 12; k++) out.push(FK.mulKey(n, k));
+      for (let k = 0; k <= 12; k++) out.push(FK.mulKey(n, k));
       // Division facts: (n*k) ÷ n = k for k=1..12
-      for (var j = 1; j <= 12; j++) {
-        var dividend = n * j;
+      for (let j = 1; j <= 12; j++) {
+        const dividend = n * j;
         if (dividend === 0) continue;  // skip 0÷anything
         out.push(FK.divKey(dividend, n));
       }
@@ -36,35 +36,35 @@
   // allowStretch: bool
   // realmTier: 1..5
   function selectProblem(opts) {
-    var realm = opts.realm;
-    var masteryMap = opts.masteryMap;
-    var recentKeys = opts.recentKeys;
-    var rng = opts.rng;
-    var mulRatio = opts.mulRatio != null ? opts.mulRatio : 0.7;
-    var allowStretch = opts.allowStretch;
-    var realmTier = opts.realmTier || 1;
+    const realm = opts.realm;
+    const masteryMap = opts.masteryMap;
+    const recentKeys = opts.recentKeys;
+    const rng = opts.rng;
+    const mulRatio = opts.mulRatio != null ? opts.mulRatio : 0.7;
+    const allowStretch = opts.allowStretch;
+    const realmTier = opts.realmTier || 1;
 
     // Stretch check: probability grows with realm tier
-    var stretchProb = 0.10 + 0.02 * (realmTier - 1);
+    const stretchProb = 0.10 + 0.02 * (realmTier - 1);
     if (allowStretch && rng() < stretchProb) {
-      var stretch = _selectStretch({ masteryMap: masteryMap, rng: rng });
+      const stretch = _selectStretch({ masteryMap: masteryMap, rng: rng });
       if (stretch) return stretch;
     }
 
-    var eligible = buildEligibleKeys(realm.factFamilyWeights);
+    const eligible = buildEligibleKeys(realm.factFamilyWeights);
     if (eligible.length === 0) return null;
 
     // Compute per-key weight using Leitner box + shaky + recency
-    var weights = eligible.map(function(k) {
+    const weights = eligible.map(function(k) {
       return M.pullWeight(k, masteryMap[k], recentKeys);
     });
 
     // Split by kind according to mulRatio
-    var isMul = rng() < mulRatio;
-    var kindIndices = [];
-    var kindWeights = [];
+    const isMul = rng() < mulRatio;
+    const kindIndices = [];
+    const kindWeights = [];
     eligible.forEach(function(k, i) {
-      var isMulKey = k.startsWith('mul:') || k.startsWith('stretch:mul:');
+      const isMulKey = k.startsWith('mul:') || k.startsWith('stretch:mul:');
       if (isMul === isMulKey) { kindIndices.push(i); kindWeights.push(weights[i]); }
     });
 
@@ -73,13 +73,13 @@
       eligible.forEach(function(k, i) { kindIndices.push(i); kindWeights.push(weights[i]); });
     }
 
-    var idx = _weightedPick(kindIndices, kindWeights, rng);
+    const idx = _weightedPick(kindIndices, kindWeights, rng);
     return _materialize(eligible[idx]);
   }
 
   function _materialize(key) {
     if (!key) return null;
-    var f = FK.parseFactKey(key);
+    const f = FK.parseFactKey(key);
     if (!f) return null;
     if (f.kind === 'mul') {
       return {
@@ -100,15 +100,15 @@
 
   // Stretch facts: only from x2, x5, x10 families when ≥4 facts in that family are mastered
   function _selectStretch(opts) {
-    var masteryMap = opts.masteryMap;
-    var rng = opts.rng;
-    var families = ['x2', 'x5', 'x10'];
-    var ranges = { x2: [13, 50], x5: [13, 30], x10: [13, 30] };
+    const masteryMap = opts.masteryMap;
+    const rng = opts.rng;
+    const families = ['x2', 'x5', 'x10'];
+    const ranges = { x2: [13, 50], x5: [13, 30], x10: [13, 30] };
 
-    var eligible = families.filter(function(fam) {
-      var n = +fam.slice(1);
-      var mastered = 0;
-      for (var k = 0; k <= 12; k++) {
+    const eligible = families.filter(function(fam) {
+      const n = +fam.slice(1);
+      let mastered = 0;
+      for (let k = 0; k <= 12; k++) {
         if (M.isMastered(masteryMap[FK.mulKey(n, k)])) mastered++;
       }
       return mastered >= 4;
@@ -116,12 +116,12 @@
 
     if (eligible.length === 0) return null;
 
-    var fam = eligible[Math.floor(rng() * eligible.length)];
-    var n = +fam.slice(1);
-    var range = ranges[fam];
-    var lo = range[0], hi = range[1];
-    var N = lo + Math.floor(rng() * (hi - lo + 1));
-    var isMul = rng() < 0.6;
+    const fam = eligible[Math.floor(rng() * eligible.length)];
+    const n = +fam.slice(1);
+    const range = ranges[fam];
+    const lo = range[0], hi = range[1];
+    const N = lo + Math.floor(rng() * (hi - lo + 1));
+    const isMul = rng() < 0.6;
 
     if (isMul) {
       return {
@@ -132,7 +132,7 @@
         isStretch: true,
       };
     } else {
-      var dividend = n * N;
+      const dividend = n * N;
       return {
         kind: 'div', a: dividend, b: n,
         answer: N,
@@ -145,17 +145,17 @@
 
   function _weightedPick(items, weights, rng) {
     if (items.length === 0) return undefined;
-    var total = weights.reduce(function(a, b) { return a + b; }, 0);
+    const total = weights.reduce(function(a, b) { return a + b; }, 0);
     if (total === 0) return items[Math.floor(rng() * items.length)];
-    var r = rng() * total;
-    for (var i = 0; i < items.length; i++) {
+    let r = rng() * total;
+    for (let i = 0; i < items.length; i++) {
       r -= weights[i];
       if (r <= 0) return items[i];
     }
     return items[items.length - 1];
   }
 
-  var exp = { selectProblem, buildEligibleKeys, _selectStretch, _materialize, _weightedPick };
+  const exp = { selectProblem, buildEligibleKeys, _selectStretch, _materialize, _weightedPick };
   if (typeof module !== 'undefined' && module.exports) module.exports = exp;
   else global.ProblemGen = exp;
 })(typeof window !== 'undefined' ? window : globalThis);

--- a/claudes-math-marauder/js/combat/problemGen.js
+++ b/claudes-math-marauder/js/combat/problemGen.js
@@ -1,0 +1,161 @@
+(function(global) {
+  'use strict';
+
+  var FK = (typeof require !== 'undefined') ? require('./factKeys.js') : global.FactKeys;
+  var M  = (typeof require !== 'undefined') ? require('./mastery.js')  : global.Mastery;
+
+  // Build the eligible fact-key pool for a realm.
+  // For each enabled family x_n (weight > 0), includes:
+  //   mul: n×0, n×1, ..., n×12
+  //   div: (n*k)÷n for k=1..12  (canonical "how many n's in n*k" form)
+  function buildEligibleKeys(factFamilyWeights) {
+    var out = [];
+    Object.entries(factFamilyWeights).forEach(function(entry) {
+      var fam = entry[0], w = entry[1];
+      if (w <= 0) return;
+      var n = +fam.slice(1);
+      // Multiplication facts
+      for (var k = 0; k <= 12; k++) out.push(FK.mulKey(n, k));
+      // Division facts: (n*k) ÷ n = k for k=1..12
+      for (var j = 1; j <= 12; j++) {
+        var dividend = n * j;
+        if (dividend === 0) continue;  // skip 0÷anything
+        out.push(FK.divKey(dividend, n));
+      }
+    });
+    // Dedupe — commutative mul pairs and repeated div facts from overlapping families
+    return Array.from(new Set(out));
+  }
+
+  // Select one problem for the current fight turn.
+  // realm: { factFamilyWeights }
+  // masteryMap: save.mastery object (read-only here; mutation happens in fight.js after resolve)
+  // recentKeys: array (newest-last) of last RECENCY_WINDOW keys answered this session
+  // rng: run-seeded PRNG
+  // mulRatio: 0..1, fraction of problems that are multiplication (default 0.7)
+  // allowStretch: bool
+  // realmTier: 1..5
+  function selectProblem(opts) {
+    var realm = opts.realm;
+    var masteryMap = opts.masteryMap;
+    var recentKeys = opts.recentKeys;
+    var rng = opts.rng;
+    var mulRatio = opts.mulRatio != null ? opts.mulRatio : 0.7;
+    var allowStretch = opts.allowStretch;
+    var realmTier = opts.realmTier || 1;
+
+    // Stretch check: probability grows with realm tier
+    var stretchProb = 0.10 + 0.02 * (realmTier - 1);
+    if (allowStretch && rng() < stretchProb) {
+      var stretch = _selectStretch({ masteryMap: masteryMap, rng: rng });
+      if (stretch) return stretch;
+    }
+
+    var eligible = buildEligibleKeys(realm.factFamilyWeights);
+    if (eligible.length === 0) return null;
+
+    // Compute per-key weight using Leitner box + shaky + recency
+    var weights = eligible.map(function(k) {
+      return M.pullWeight(k, masteryMap[k], recentKeys);
+    });
+
+    // Split by kind according to mulRatio
+    var isMul = rng() < mulRatio;
+    var kindIndices = [];
+    var kindWeights = [];
+    eligible.forEach(function(k, i) {
+      var isMulKey = k.startsWith('mul:') || k.startsWith('stretch:mul:');
+      if (isMul === isMulKey) { kindIndices.push(i); kindWeights.push(weights[i]); }
+    });
+
+    // Fallback: if no keys of the desired kind, use the other
+    if (kindIndices.length === 0) {
+      eligible.forEach(function(k, i) { kindIndices.push(i); kindWeights.push(weights[i]); });
+    }
+
+    var idx = _weightedPick(kindIndices, kindWeights, rng);
+    return _materialize(eligible[idx]);
+  }
+
+  function _materialize(key) {
+    if (!key) return null;
+    var f = FK.parseFactKey(key);
+    if (!f) return null;
+    if (f.kind === 'mul') {
+      return {
+        kind: 'mul', a: f.a, b: f.b,
+        answer: f.a * f.b,
+        displayText: f.a + ' × ' + f.b + ' = ?',
+        factKey: key, isStretch: false,
+      };
+    } else {
+      return {
+        kind: 'div', a: f.dividend, b: f.divisor,
+        answer: f.dividend / f.divisor,
+        displayText: f.dividend + ' ÷ ' + f.divisor + ' = ?',
+        factKey: key, isStretch: false,
+      };
+    }
+  }
+
+  // Stretch facts: only from x2, x5, x10 families when ≥4 facts in that family are mastered
+  function _selectStretch(opts) {
+    var masteryMap = opts.masteryMap;
+    var rng = opts.rng;
+    var families = ['x2', 'x5', 'x10'];
+    var ranges = { x2: [13, 50], x5: [13, 30], x10: [13, 30] };
+
+    var eligible = families.filter(function(fam) {
+      var n = +fam.slice(1);
+      var mastered = 0;
+      for (var k = 0; k <= 12; k++) {
+        if (M.isMastered(masteryMap[FK.mulKey(n, k)])) mastered++;
+      }
+      return mastered >= 4;
+    });
+
+    if (eligible.length === 0) return null;
+
+    var fam = eligible[Math.floor(rng() * eligible.length)];
+    var n = +fam.slice(1);
+    var range = ranges[fam];
+    var lo = range[0], hi = range[1];
+    var N = lo + Math.floor(rng() * (hi - lo + 1));
+    var isMul = rng() < 0.6;
+
+    if (isMul) {
+      return {
+        kind: 'mul', a: n, b: N,
+        answer: n * N,
+        displayText: n + ' × ' + N + ' = ?',
+        factKey: 'stretch:mul:' + n + 'x' + N,
+        isStretch: true,
+      };
+    } else {
+      var dividend = n * N;
+      return {
+        kind: 'div', a: dividend, b: n,
+        answer: N,
+        displayText: dividend + ' ÷ ' + n + ' = ?',
+        factKey: 'stretch:div:' + dividend + '/' + n,
+        isStretch: true,
+      };
+    }
+  }
+
+  function _weightedPick(items, weights, rng) {
+    if (items.length === 0) return undefined;
+    var total = weights.reduce(function(a, b) { return a + b; }, 0);
+    if (total === 0) return items[Math.floor(rng() * items.length)];
+    var r = rng() * total;
+    for (var i = 0; i < items.length; i++) {
+      r -= weights[i];
+      if (r <= 0) return items[i];
+    }
+    return items[items.length - 1];
+  }
+
+  var exp = { selectProblem, buildEligibleKeys, _selectStretch, _materialize, _weightedPick };
+  if (typeof module !== 'undefined' && module.exports) module.exports = exp;
+  else global.ProblemGen = exp;
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/claudes-math-marauder/js/game.js
+++ b/claudes-math-marauder/js/game.js
@@ -1,0 +1,120 @@
+'use strict';
+
+const STATE = {
+  TITLE: 'TITLE',
+  HUB: 'HUB',
+  REALM_PICK: 'REALM_PICK',
+  RUN_MAP: 'RUN_MAP',
+  FIGHT: 'FIGHT',
+  RESULTS: 'RESULTS',
+  PAUSED: 'PAUSED',
+};
+
+class Game {
+  constructor() {
+    this.state = STATE.TITLE;
+    this.canvas = null;
+    this.ctx = null;
+    this._lastFrameTime = 0;
+    this._rafId = 0;
+    this._prevState = null;
+    this._save = null;
+  }
+
+  init() {
+    this.canvas = document.getElementById('game-canvas');
+    this.ctx = this.canvas.getContext('2d');
+    this._setupCanvasDpr();
+    window.addEventListener('resize', () => this._setupCanvasDpr());
+
+    this._loop = this._loop.bind(this);
+    this._rafId = requestAnimationFrame(this._loop);
+
+    this._bindTitleScreen();
+    this._bindPauseScreen();
+
+    this._save = SaveManager.load();
+    const data = this._save;
+    if (data.settings.reducedMotion || window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      document.body.setAttribute('data-reduced-motion', 'true');
+    }
+    // Apply font scale
+    if (data.settings.fontScale && data.settings.fontScale !== 1.0) {
+      document.documentElement.style.fontSize = Math.round(20 * data.settings.fontScale) + 'px';
+    }
+  }
+
+  _setupCanvasDpr() {
+    const dpr = window.devicePixelRatio || 1;
+    const w = this.canvas.clientWidth;
+    const h = this.canvas.clientHeight;
+    if (this.canvas.width === w * dpr && this.canvas.height === h * dpr) return;
+    this.canvas.width  = w * dpr;
+    this.canvas.height = h * dpr;
+    this.ctx.setTransform(1, 0, 0, 1, 0, 0);
+    this.ctx.scale(dpr, dpr);
+    this.ctx.imageSmoothingEnabled = false;
+  }
+
+  _loop(now) {
+    if (!this._lastFrameTime) this._lastFrameTime = now;
+    let dt = now - this._lastFrameTime;
+    if (dt > 50) dt = 50;
+    this._lastFrameTime = now;
+
+    if (this.state !== STATE.PAUSED) this._update(dt);
+    this._draw();
+    this._rafId = requestAnimationFrame(this._loop);
+  }
+
+  _update(dt) {
+    // Future sessions drive managers here
+  }
+
+  _draw() {
+    const w = this.canvas.clientWidth;
+    const h = this.canvas.clientHeight;
+    this.ctx.fillStyle = '#F5F0E8';
+    this.ctx.fillRect(0, 0, w, h);
+  }
+
+  setState(next) {
+    if (this.state === next) return;
+    this._prevState = this.state;
+    this.state = next;
+    this._refreshScreens();
+  }
+
+  _refreshScreens() {
+    document.querySelectorAll('.screen').forEach(function(s) { s.classList.remove('active'); });
+    const id = this.state.toLowerCase().replace(/_/g, '-') + '-screen';
+    const el = document.getElementById(id);
+    if (el) {
+      el.classList.add('active');
+    } else {
+      console.warn('[Game] No screen element for state:', this.state, '(expected #' + id + ')');
+    }
+  }
+
+  _bindTitleScreen() {
+    const btn = document.getElementById('start-button');
+    if (btn) btn.addEventListener('click', () => this.setState(STATE.HUB));
+  }
+
+  _bindPauseScreen() {
+    const btn = document.getElementById('resume-button');
+    if (btn) btn.addEventListener('click', () => {
+      if (this.state === STATE.PAUSED && this._prevState) {
+        this.setState(this._prevState);
+      }
+    });
+  }
+
+  pause() {
+    if (this.state !== STATE.PAUSED) this.setState(STATE.PAUSED);
+  }
+}
+
+// CLAUDE.md init pattern
+window.game = new Game();
+window.game.init();

--- a/claudes-math-marauder/js/save.js
+++ b/claudes-math-marauder/js/save.js
@@ -19,7 +19,7 @@
       totalCorrect: 0,
       gold: 0,
       ownedSpellIds: ['ember_bolt'],
-      equippedDeck: ['ember_bolt', null, null, null, null],
+      equippedDeck: ['ember_bolt', null, null, null],
       unlockedClassIds: ['apprentice'],
       selectedClassId: 'apprentice',
       realmStars: {

--- a/claudes-math-marauder/js/save.js
+++ b/claudes-math-marauder/js/save.js
@@ -1,0 +1,143 @@
+(function(global) {
+  'use strict';
+
+  const KEY = 'claudes-math-marauder-save';
+  const BACKUP_KEY = 'claudes-math-marauder-save-backup';
+  const SCHEMA_VERSION = 1;
+
+  let _saveCount = 0;
+
+  function _defaults() {
+    return {
+      schemaVersion: SCHEMA_VERSION,
+      createdAt: Date.now(),
+      lastPlayedAt: Date.now(),
+      playerName: null,
+      totalRunsStarted: 0,
+      totalRunsCompleted: 0,
+      totalProblemsAnswered: 0,
+      totalCorrect: 0,
+      gold: 0,
+      ownedSpellIds: ['ember_bolt'],
+      equippedDeck: ['ember_bolt', null, null, null, null],
+      unlockedClassIds: ['apprentice'],
+      selectedClassId: 'apprentice',
+      realmStars: {
+        goblin_forest: 0,
+        crystal_cave: 0,
+        dragon_peak: 0,
+        astral_void: 0,
+        lich_citadel: 0,
+      },
+      storyChaptersUnlocked: [],
+      mastery: {},
+      activeRun: null,
+      settings: {
+        speechVoiceURI: null,
+        speechRate: 1.0,
+        autoNarrate: true,
+        sfxVolume: 0.7,
+        muteAll: false,
+        reducedMotion: false,
+        fontScale: 1.0,
+        showSpeedTimer: false,
+        allowStretchFacts: true,
+        devMode: false,
+      },
+    };
+  }
+
+  const MIGRATIONS = {
+    0: function(d) {
+      // 0→1: populate missing fields from defaults
+      const def = _defaults();
+      d.schemaVersion = 1;
+      if (!d.mastery) d.mastery = {};
+      if (!d.settings) d.settings = Object.assign({}, def.settings);
+      if (!d.realmStars) d.realmStars = Object.assign({}, def.realmStars);
+      if (!d.ownedSpellIds) d.ownedSpellIds = [...def.ownedSpellIds];
+      if (!d.equippedDeck) d.equippedDeck = [...def.equippedDeck];
+      if (!d.unlockedClassIds) d.unlockedClassIds = [...def.unlockedClassIds];
+      if (d.selectedClassId === undefined) d.selectedClassId = def.selectedClassId;
+      if (d.gold === undefined) d.gold = 0;
+      if (d.activeRun === undefined) d.activeRun = null;
+      if (!d.storyChaptersUnlocked) d.storyChaptersUnlocked = [];
+      return d;
+    },
+  };
+
+  function _migrate(data) {
+    let d = data || {};
+    let v = typeof d.schemaVersion === 'number' ? d.schemaVersion : 0;
+    while (v < SCHEMA_VERSION) {
+      if (MIGRATIONS[v]) d = MIGRATIONS[v](d);
+      v++;
+      d.schemaVersion = v;
+    }
+    return d;
+  }
+
+  function _tryParse(str) {
+    try { return JSON.parse(str); } catch (e) { return null; }
+  }
+
+  function _showSaveError(msg) {
+    if (typeof showToast === 'function') showToast(msg, 5000);
+    else if (typeof console !== 'undefined') console.warn('[SaveManager]', msg);
+  }
+
+  const SaveManager = {
+    load() {
+      const raw = (typeof localStorage !== 'undefined') ? localStorage.getItem(KEY) : null;
+      let data = raw ? _tryParse(raw) : null;
+      if (!data) {
+        const backup = (typeof localStorage !== 'undefined') ? localStorage.getItem(BACKUP_KEY) : null;
+        data = backup ? _tryParse(backup) : null;
+        if (!data) {
+          if (raw) _showSaveError('Save data corrupted. Starting fresh.');
+          return _defaults();
+        }
+        _showSaveError('Recovered from backup save.');
+      }
+      return _migrate(data);
+    },
+
+    save(data) {
+      if (typeof localStorage === 'undefined') return;
+      data.lastPlayedAt = Date.now();
+      const str = JSON.stringify(data);
+      try {
+        localStorage.setItem(KEY, str);
+        _saveCount++;
+        if (_saveCount % 5 === 0) localStorage.setItem(BACKUP_KEY, str);
+      } catch (e) {
+        _showSaveError('Could not save: storage full.');
+      }
+    },
+
+    reset() {
+      if (typeof localStorage === 'undefined') return;
+      localStorage.removeItem(KEY);
+      localStorage.removeItem(BACKUP_KEY);
+      _saveCount = 0;
+    },
+
+    export() {
+      return JSON.parse(JSON.stringify(this.load()));
+    },
+
+    import(snapshot) {
+      const d = JSON.parse(JSON.stringify(snapshot));
+      this.save(d);
+    },
+
+    _defaults,
+    _migrate,
+  };
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { SaveManager };
+  } else {
+    global.SaveManager = SaveManager;
+  }
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/claudes-math-marauder/js/ui/toast.js
+++ b/claudes-math-marauder/js/ui/toast.js
@@ -1,0 +1,20 @@
+(function(global) {
+  'use strict';
+
+  function showToast(msg, ms) {
+    const duration = typeof ms === 'number' ? ms : 3000;
+    const root = document.getElementById('toast-root');
+    if (!root) return;
+    const el = document.createElement('div');
+    el.className = 'toast';
+    el.textContent = msg;
+    root.appendChild(el);
+    setTimeout(function() { if (el.isConnected) el.remove(); }, duration);
+  }
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { showToast };
+  } else {
+    global.showToast = showToast;
+  }
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/claudes-math-marauder/js/util/escape.js
+++ b/claudes-math-marauder/js/util/escape.js
@@ -1,0 +1,18 @@
+(function(global) {
+  'use strict';
+
+  // For innerHTML only — never apply to setAttribute or textContent
+  function escHtml(v) {
+    return String(v)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
+  }
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { escHtml };
+  } else {
+    global.escHtml = escHtml;
+  }
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/claudes-math-marauder/js/util/rng.js
+++ b/claudes-math-marauder/js/util/rng.js
@@ -1,0 +1,29 @@
+(function(global) {
+  'use strict';
+
+  function hashString(str) {
+    let hash = 0;
+    for (let i = 0; i < str.length; i++) {
+      hash = ((hash << 5) - hash + str.charCodeAt(i)) | 0;
+    }
+    return hash >>> 0;
+  }
+
+  // Mulberry32 seeded PRNG — returns a function that produces [0, 1) floats
+  function mulberry32(seed) {
+    let s = (seed | 0) >>> 0;
+    return function() {
+      s = (s + 0x6D2B79F5) | 0;
+      let t = Math.imul(s ^ (s >>> 15), 1 | s);
+      t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+      return ((t ^ (t >>> 14)) >>> 0) / 0x100000000;
+    };
+  }
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { hashString, mulberry32 };
+  } else {
+    global.hashString = hashString;
+    global.mulberry32 = mulberry32;
+  }
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/claudes-math-marauder/js/util/shuffle.js
+++ b/claudes-math-marauder/js/util/shuffle.js
@@ -1,0 +1,18 @@
+(function(global) {
+  'use strict';
+
+  function shuffleInPlace(arr, rng) {
+    const random = rng || Math.random;
+    for (let i = arr.length - 1; i > 0; i--) {
+      const j = Math.floor(random() * (i + 1));
+      const tmp = arr[i]; arr[i] = arr[j]; arr[j] = tmp;
+    }
+    return arr;
+  }
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { shuffleInPlace };
+  } else {
+    global.shuffleInPlace = shuffleInPlace;
+  }
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/claudes-math-marauder/plan.md
+++ b/claudes-math-marauder/plan.md
@@ -1,0 +1,417 @@
+# Claude's Math Marauder — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan session-by-session. Run `/marauder-checklist` before any session that writes code; run `/validate-marauder-data` after data edits; run the `marauder-web-review` agent after each session before commit.
+
+**Goal:** A vanilla-JS browser roguelike that drills multiplication and division (factors 0–12, results 0–144, plus stretch facts in 5s/10s/2s) for one specific 10-year-old player with ADHD + dyslexia, hosted on GitHub Pages.
+
+**Source spec:** `docs/superpowers/specs/2026-05-01-claudes-math-marauder-design.md` — read before starting any session.
+
+**Tech stack:** Vanilla JS (ES6+), HTML5 Canvas 2D, Web Audio (synthesized SFX), Web Speech (narration), LocalStorage (save). No frameworks, no bundler, no build step. Deployed via the existing `update-index.yml` GitHub Pages workflow.
+
+---
+
+## Context
+
+A new game for a 10-year-old player with ADHD + dyslexia: defeat fantasy monsters (goblins, dragons, liches, void-creatures) by casting math spells. Each run is a procedurally generated branching map through one of 5 themed realms; each fight is one or more multiplication/division problems answered via tappable orbs (default), typed ultimates (charge meter), or multi-phase boss glyph combos. Mastery is tracked via a Leitner spaced-repetition engine; difficulty stays at the edge of the player's ability without grind-locking content.
+
+**Directory:** `claudes-math-marauder/`
+**Index icon:** `🤖⚔️📐`
+**Index title:** "Claude's Math Marauder"
+**Index description:** "Claude built this fantasy roguelike where you cast multiplication and division spells to defeat goblins, dragons, and liches."
+**Category:** `learning` in `gameCategories` in `update-index.js`
+
+---
+
+## Design Principles
+
+1. **No anxiety mechanics.** No countdown timers visible by default. No HP-based run-failure (B3 retry-on-defeat). No "you're doing badly" copy. Wrong-answer text is neutral and the correct answer is narrated.
+2. **High novelty per fight.** Random monsters, random map paths, random spell-shop offerings, random mystery events. Every fight has palette, monster, and taunt variation.
+3. **Reading-light.** Every text block has a 🔊 button. Auto-narrate is on by default. Sentence-per-panel max for story. Single-sentence wrong-answer correction always speaks the answer.
+4. **Adaptive difficulty.** Leitner box-based mastery weighting — every problem is pulled by mastery score so the player is always at their edge, never bored or frustrated.
+5. **Choice everywhere.** Branching map nodes, mystery events, spell-shop picks, class selection, deck slots. 8–12 small player decisions per run.
+6. **Bold comic visual identity.** Procedural canvas with thick ink outlines, halftone fill, speed lines, and burst-text impacts. Every fight feels like a comic-book page.
+7. **Short clear loops.** ~60 sec per fight, 10–15 min per run. Auto-save after every node so quitting mid-run never costs progress.
+8. **Stakes without loss.** Streak counter + score + 1/2/3-star run rating give "did I win cleanly?" feeling without ever ending a run on failure.
+
+---
+
+## Technical Architecture
+
+### Rendering: Procedural Canvas + Comic-Effects Library
+
+A single full-screen canvas owned by `game.js`. Every visual is drawn procedurally — no image assets. Monsters are parametric data (shape tree → primitives → ink-outline + halftone fill). Each monster's base parts are drawn once to per-part offscreen canvases and composited per frame with animation transforms (Petstore paper-doll model). The comic-effects library (`fx/comicfx.js`) provides reusable primitives: ink outline, halftone fill, speed lines, burst text, panel flash, ink burst, panel border, screen shake.
+
+- **Single RAF chain** — only `game.js` calls `requestAnimationFrame`. All managers expose passive `update(dt)` and `draw(ctx, w, h)` methods.
+- **Delta-time capped at 50ms** — iPad Safari RAF throttling.
+- **Max 30 active offscreen canvases** with LRU eviction (Petstore precedent).
+- **HUD lives as DOM** over the canvas — DOM is faster for static UI and accessible to screen readers.
+- **Seeded PRNG** for any cached procedural texture so re-cache produces identical results.
+
+### Touch Input
+
+- **Pointer Events** (`pointerdown/move/up`) — unified mouse + touch, no 300ms delay, `setPointerCapture()` for any drag.
+- CSS `touch-action: none` on canvas to prevent Safari scroll/zoom interference.
+- Coordinate conversion: `(clientX - rect.left) * (canvas.width / rect.width)` with DPR division.
+- All combat orbs ≥ 96px hitboxes, numpad keys ≥ 72px, all other interactives ≥ 44px.
+
+### Canvas + DPR Setup
+
+```js
+canvas.width  = canvas.clientWidth  * devicePixelRatio;
+canvas.height = canvas.clientHeight * devicePixelRatio;
+ctx.scale(devicePixelRatio, devicePixelRatio);
+ctx.imageSmoothingEnabled = false;  // crisp ink lines
+```
+
+### Animation: Pivot-Based, Delta-Time
+
+Each monster part has a pivot point and simple animation curves (sine-wave rotation, bounce, scale oscillation). Parts drawn in z-order with `ctx.save() / translate / rotate / drawImage / restore`. No parent-child transform chain. Idle / attack / hit / death animations all delta-time based.
+
+### Audio
+
+- **Web Speech** for all narration. Lazy-init in user gesture. Always `cancel()` then `setTimeout(speak, 50)` (iOS Safari quirk). `voiceschanged` listener for async voice list load. Per-character pitch/rate offsets via `monster.voiceProfile`.
+- **Web Audio** for all SFX, all synthesized (sine/triangle/square + filtered noise + low-pass filter — KC4 precedent). `AudioContext` lazily created on first user gesture; oscillators scheduled inside `ctx.resume().then(() => ...)`.
+- All loss/wrong sounds capped at "soft and cartoony" — no harsh or sudden audio.
+- `prefers-reduced-motion` → screen shake + panel flashes drop to static highlight.
+
+### State Machine
+
+```
+TITLE → HUB → REALM_PICK → RUN_MAP → FIGHT → RESULTS → HUB
+                              ↕
+                        SHOP / MYSTERY / REST nodes (overlays on RUN_MAP)
+                              ↕
+                          PAUSED (any state)
+                       SETTINGS (overlay)
+                           CODEX (overlay from HUB)
+                       DECK_BUILD (overlay from HUB)
+                       CLASS_PICK (overlay from HUB)
+                          STORY (overlay after first boss clear)
+```
+
+State transitions cancel all timers/animations. Pause halts all `update(dt)` advancement and pauses speech. Settings/codex/deck-build/class-pick/story are overlay states layered over the screen they were opened from.
+
+### Save System
+
+- **LocalStorage key:** `claudes-math-marauder-save`
+- **Backup key:** `claudes-math-marauder-save-backup`, written every 5 saves
+- **Schema versioned:** `schemaVersion: 1` in save data
+- **Auto-save:** debounced 500ms on combat resolve; eager save at every map node, every overlay close, every settings change
+- **`SaveManager._defaults()`** must include every key game.js reads (CLAUDE.md completeness rule)
+- **All save reads/writes** go through SaveManager — never direct `localStorage` access
+- **Quota error** → user-visible toast (not silent failure)
+
+### Save Schema (key: `claudes-math-marauder-save`)
+
+```jsonc
+{
+  "schemaVersion": 1,
+  "createdAt": 1714400000000,
+  "lastPlayedAt": 1714400000000,
+  "playerName": null,
+  "totalRunsStarted": 0,
+  "totalRunsCompleted": 0,
+  "totalProblemsAnswered": 0,
+  "totalCorrect": 0,
+  "gold": 0,
+  "ownedSpellIds": ["ember_bolt"],
+  "equippedDeck": ["ember_bolt", null, null, null, null],
+  "unlockedClassIds": ["apprentice"],
+  "selectedClassId": "apprentice",
+  "realmStars": {
+    "goblin_forest": 0,
+    "crystal_cave": 0,
+    "dragon_peak": 0,
+    "astral_void": 0,
+    "lich_citadel": 0
+  },
+  "storyChaptersUnlocked": [],
+  "mastery": {},
+  "activeRun": null,
+  "settings": {
+    "speechVoiceURI": null,
+    "speechRate": 1.0,
+    "autoNarrate": true,
+    "sfxVolume": 0.7,
+    "muteAll": false,
+    "reducedMotion": false,
+    "fontScale": 1.0,
+    "showSpeedTimer": false,
+    "allowStretchFacts": true,
+    "devMode": false
+  }
+}
+```
+
+### Mastery Engine — Leitner Spaced Repetition
+
+Per-fact stats keyed by canonical id (`mul:7x8` smaller×larger; `div:56/7` larger÷smaller):
+
+```jsonc
+"mastery": {
+  "mul:7x8": {
+    "box": 3,
+    "lastSeenAt": 1714400000000,
+    "totalAsked": 14,
+    "totalCorrect": 12,
+    "avgMs": 2100,
+    "streak": 4,
+    "shaky": false
+  }
+}
+```
+
+**Box update on resolve:**
+- Correct + fast (`< 2 × avgMs of mastered facts`) → `box = min(5, box + 1)`
+- Correct + slow → `box` unchanged
+- Wrong → `box = max(1, box - 2)`, `shaky = true`
+- **Mastered = `box ≥ 4 && totalCorrect ≥ 6`**
+
+**Problem selection (per problem):**
+1. Build eligible-fact set from realm `factFamilyWeights`.
+2. Compute weight per fact: `boxWeight[box] × shakyMultiplier × recencyDamping` where `boxWeight = {1:5, 2:4, 3:3, 4:2, 5:1}`, `shakyMultiplier = 2.5 if shaky else 1.0`, `recencyDamping = 0.3 if seen in last 5 problems else 1.0`.
+3. With probability `0.10 + 0.02 × realmTier`, instead pull a stretch fact from a mastered family:
+   - 5s: `5 × N` for `N ∈ [13, 30]`
+   - 10s: `10 × N` for `N ∈ [13, 30]`
+   - 2s: `2 × N` for `N ∈ [13, 50]`
+4. Pick weighted-random.
+5. 70% multiplication / 30% division by default; realm config can override.
+
+Mastery recomputed/saved at end of every fight (batch write, not per-problem).
+
+### Run Generation — Deterministic Branching Map
+
+Map generated from `(runSeed, realmId)`. 10–12 nodes per run.
+
+- One **START** node, one **BOSS** node (last)
+- 4–5 columns of 1–3 nodes each, plus pre-boss merge
+- Edges connect column N to column N+1 only
+- Node-type distribution per realm (combat-heavy in early realms, more elites and shops late)
+- All nodes BFS-reachable from START; BOSS reachable from every leaf path
+- Same `(seed, realmId)` → byte-identical map (enables resume + replay)
+
+### Combat Architecture
+
+Per-fight state machine (driven by `game.js` RAF, no manager owns its own loop):
+
+```
+INTRO → PROBLEM → ANSWERING → RESOLVE → (PROBLEM | VICTORY | DEFEAT_RETRY)
+```
+
+**Three combat modes (D in brainstorm):**
+1. **Orb cast** (default, ~85%) — 4 floating orbs (1 correct + 3 close-miss distractors), tap to cast
+2. **Ultimate cast** (~10%) — typed answer on numpad, fires when ultimate meter is full
+3. **Boss glyph combo** — bosses have HP = phase count (3–5); each phase has a labeled problem-kind; final realm-ending blow is always a typed stretch fact
+
+**Speed scoring (no visible countdown):** `score = base + max(0, (5000 - answerTimeMs) / 50)`. Faster = bigger crit (felt via crit damage and screen flash, not a ticking timer).
+
+**Distractor generation (orb cast):**
+- For `a × b = c`: include `a × (b±1)`, `(a±1) × b`, `c ± 1`
+- For `c ÷ a = b`: include `c - a`, `b ± 1`, factor-swap confusions
+- All 4 orbs unique values; always exactly one correct; Fisher-Yates shuffle
+
+**Per-correct juice:** burst-text ("ZAP!"/"BAM!"/"CRIT!"), halftone screen-flash (single frame, ≤ 80%), damage number fountain, streak counter tick, sparkle border at 3/5/10 streak.
+
+**Per-wrong feedback:** wizard portrait shake, 800ms reveal of correct answer with audio narration ("the answer was 56"), streak resets to 0, mastery box decrements + `shaky = true`.
+
+**Failure model (B3):** wizard HP is flavor only — going to 0 enters "second wind" retry, not run-loss. Stakes come from streak / score / 1-2-3⭐ rating.
+
+### Comic-Effects Primitives (`fx/comicfx.js`)
+
+| Primitive | What it does |
+|---|---|
+| `inkOutline(path, weight)` | Thick black wobble-line stroke |
+| `halftoneFill(rect, color, density)` | Cached dot pattern |
+| `speedLines(origin, dir, n)` | Radiating ink streaks |
+| `burstText(x, y, word, size, color)` | Comic POW! with stroke + jitter |
+| `panelFlash(color, alphaCurve)` | Single-frame screen tint |
+| `inkBurst(x, y, radius, color)` | Splatter of ink dots |
+| `wobbleStroke(path, seed)` | Hand-drawn jitter on any stroke |
+| `panelBorder(rect, style)` | Black inset comic frame |
+| `screenShake(intensity, ms)` | Translates whole canvas |
+
+All effects seeded per-instance.
+
+### File Structure
+
+```
+claudes-math-marauder/
+  index.html
+  css/
+    style.css                 — design system, screens/overlays, comic palette, fonts
+  js/
+    game.js                   — main state machine, single RAF, screen management
+    save.js                   — SaveManager (single key, schema v1, backup, _defaults)
+    runtime.js                — run state lifecycle (start, advance, save, abandon)
+
+    combat/
+      factKeys.js             — canonical key construction (mul:AxB, div:c/a)
+      mastery.js              — Leitner box updates, weight calc
+      problemGen.js           — weighted problem selection, stretch-fact gate
+      distractors.js          — orb distractor generation
+      fight.js                — per-fight state machine, juice triggers
+      ultimate.js             — typed-numpad ultimate spell
+      bossFight.js            — multi-phase boss state machine
+
+    fx/
+      comicfx.js              — ink outline, halftone, speed lines, burst text, screen flash, ink burst, panel border, screen shake
+      monsterRenderer.js      — walks parametric schema → drawImage from per-part offscreen cache
+      wizardRenderer.js       — same model for wizard portrait per class
+      shapes.js               — primitive shape generators (blob, egg, comic_pair eyes, fang_grin, etc.)
+      particles.js            — small particle pool (sparkle, ember, ink-dot)
+
+    run/
+      mapGen.js               — deterministic branching map
+      mapScreen.js            — map renderer + node click handlers
+      events.js               — mystery event resolver
+      shop.js                 — spell-shop offering generator + UI
+
+    hub/
+      hub.js                  — hub screen (realm picker, codex/deck/class entry)
+      deckBuilder.js          — deck slot UI
+      classPicker.js          — class selection UI
+      codex.js                — mastery heatmap + drill-this-fact mini-fights
+      story.js                — story-panel viewer with sentence highlighting
+
+    audio/
+      sfx.js                  — synthesized sound bank
+      speech.js               — Web Speech wrapper (cancel + 50ms delay, voice list, rate)
+
+    ui/
+      hud.js                  — combat HUD (HP, streak, score, ultimate meter)
+      overlay.js              — base overlay shell (focus trap, Escape, focus return)
+      toast.js                — quota / save errors
+      results.js              — results card after each run
+      settings.js             — settings panel
+
+    util/
+      rng.js                  — seeded PRNG (Mulberry32) + hashString
+      shuffle.js              — Fisher-Yates
+      contrast.js             — color contrast checker (used by validator)
+      escape.js               — escHtml helper
+
+  data/
+    realms.json               — 5 realm definitions
+    monsters.json             — ~30 standard monsters
+    bosses.json               — 5 boss schemas
+    spells.json               — ~25 spells
+    classes.json              — 5 wizard classes
+    story.json                — 5 chapters + flavor lines
+    events.json               — ~20 mystery events
+
+  scripts/
+    test-problem-gen.js
+    test-mastery.js
+    test-distractors.js
+    test-map-gen.js
+    test-save-migration.js
+    validate-data.js
+    check-contrast.js
+    fuzz-runs.js
+    replay.js
+```
+
+---
+
+## Session Plan (14 sessions)
+
+Each session ends with: tests pass → `marauder-web-review` agent → commit (and push). Full per-session detail lives in `sessions/session-NN.md`.
+
+### Session 1 — Claude Tooling + Project Scaffold
+Opus | Rules, hooks, skills, agents, validation, skeleton files, save schema, state machine shell, index.html registered
+
+### Session 2 — Math Engine: Problem Generation, Distractors, Mastery
+Opus | Pure-logic combat layer with full TDD coverage (no DOM). All Layer-1 tests passing.
+
+### Session 3 — Comic Renderer + Monster Schema + Animation
+Opus | `fx/comicfx.js`, `fx/monsterRenderer.js`, `fx/wizardRenderer.js`, `fx/shapes.js`, idle/attack/hit/death animations, demo screen
+
+### Session 4 — Data Authoring Round 1 (Realm 1 Playable)
+Sonnet | `data/realms.json` (all 5), `data/monsters.json` (~6 standards covering Realm 1), `data/spells.json` (~10 starters), `data/classes.json` (Apprentice + Pyromancer), `data/story.json` (chapter 1), `data/events.json` (5 events)
+
+### Session 5 — Combat: Orb-Cast Loop
+Opus | `combat/fight.js` state machine, problem panel, 4 floating orbs, correct/wrong resolve, damage numbers, streak counter, ultimate-meter accumulation, mastery save
+
+### Session 6 — Combat: Typed Ultimate Spell
+Sonnet | Numpad (≥72px keys), digit echo sigil, ⌫ + ✓, physical-keyboard support, big-damage payoff, fail-down-to-orb path
+
+### Session 7 — Boss Fight: Glyph Combo
+Opus | `combat/bossFight.js`, phase array drives problem kinds, glyph-shatter transition, narrated phase break, KO cinematic, Realm 1's Goblin Warlord boss end-to-end
+
+### Session 8 — Audio: Web Speech + Web Audio SFX
+Sonnet | Lazy-init audio context, full SFX bank, 🔊 button on every text block, auto-narrate setting, voice picker + speech-rate slider, monster taunts, wrong-answer narration, `prefers-reduced-motion` integration
+
+### Session 9 — Run Map: Branching Graph + Resume
+Opus | `run/mapGen.js` deterministic branching map, `scripts/test-map-gen.js`, map screen with inline panels per node type, node selection + path-tracking, mid-run auto-save, resume-on-reload. **Realm 1 playable end-to-end.**
+
+### Session 10 — Hub + Meta-Progression
+Opus | Hub screen (Wizard's Tower) with realm picker, deck builder, class picker, gold display, spell-shop in-run flow, codex (13×13 mastery heatmap + tap-to-drill mini-fights), star-rating system, story-panel viewer
+
+### Session 11 — Data Authoring Round 2 (Fill the World)
+Sonnet | Remaining ~25 monsters across realms 2–5, 4 more boss schemas, ~15 more spells, 3 more classes (Necromancer, Astromancer, Chronomancer), chapters 2–5 of story, 15 more mystery events; fuzz-run all 5 realms
+
+### Session 12 — Cutscenes, Results Cards, Transitions
+Sonnet | Story-panel viewer with sentence-by-sentence highlighting, narration auto-advance, results card (gold, stars, mastery delta, story unlock), comic page-turn screen transitions, KO cinematic for last boss of each realm
+
+### Session 13 — Replay Harness, Dev Menu, Fuzzer
+Sonnet | `scripts/replay.js` deterministic replay, dev menu (skip-to-boss, force-monster, set-mastery, voice debug), `scripts/fuzz-runs.js` (10k runs/realm assert no exceptions/NaN/dead loops)
+
+### Session 14 — Accessibility, iPad QA, Final Polish
+Opus | Full a11y audit (VoiceOver, contrast script, focus-trap audit, font-loading guards), iPad Safari 60fps verification, font-scale slider, settings panel finalized, error toasts, edge cases, final QA checklist, MEMORY.md update, push live
+
+---
+
+## Session Conventions (all sessions)
+
+### Each session starts with:
+1. Read this `plan.md` and the source spec at `docs/superpowers/specs/2026-05-01-claudes-math-marauder-design.md`
+2. Read the corresponding `sessions/session-NN.md`
+3. Run `/marauder-checklist` to review coding rules
+
+### Each session ends with:
+1. Run any new Layer-1 tests added in this session: `node claudes-math-marauder/scripts/test-*.js`
+2. If `data/*.json` was modified, run `/validate-marauder-data`
+3. Run `marauder-web-review` agent to catch bugs
+4. If new gotchas discovered, append to MEMORY.md `## claudes-math-marauder: key gotchas` section
+5. Commit all work with descriptive message
+6. Push to `main` (the `update-index.yml` workflow will regenerate `index.html` and deploy)
+7. Delete the working notes section (if any) but **leave the session file in place**
+
+---
+
+## Testing Strategy (Layered)
+
+| Layer | What it covers | When it runs |
+|---|---|---|
+| **L1 — Node logic tests** (`scripts/test-*.js`) | Problem gen, distractors, mastery, map gen, save migration. Pure modules, no DOM. | After every relevant code change. |
+| **L2 — Data validation** (`scripts/validate-data.js` + `/validate-marauder-data` skill) | Schema integrity, ID uniqueness/refs, color hex validity, contrast against cream, weights sum to ~1. | Auto via PostToolUse hook on `data/*.json` edit; manual after data sessions. |
+| **L3 — Pre-implementation checklist** (`/marauder-checklist`) | The KC4/Petstore-derived rules most likely to cause bugs. | Before writing any session code. |
+| **L4 — Manual playtest** (per-session checklist) | Hand-run iPad Safari pass tailored to that session's deliverables. | At session end. |
+| **L5 — Code review** (`marauder-web-review` agent) | Diff vs spec; KC4/Petstore architecture rules; performance hot-paths; ARIA. | After every session before commit. |
+| **L6 — Determinism + fuzz** (`scripts/replay.js`, `scripts/fuzz-runs.js`) | Replay reproducibility; 10k random runs no exceptions/NaN/dead loops. | Session 13 onward. |
+| **L7 — Dev menu** | In-browser shortcuts (skip to boss, force monster, set mastery, voice debug). | Hidden behind `settings.devMode`. |
+
+---
+
+## Out of Scope (v1)
+
+- Online multiplayer or cross-user leaderboards
+- Cloud save (LocalStorage only)
+- Custom monster/spell editor for the player
+- Localization (English only)
+- Pre-recorded voice acting (Web Speech only — confirmed)
+- Music tracks (synthesized SFX only)
+
+---
+
+## Acceptance Criteria
+
+The game is "done" when all 14 sessions complete and:
+
+1. All Layer-1 logic tests pass (`node scripts/test-*.js` zero failures)
+2. `/validate-marauder-data` reports zero errors
+3. `scripts/check-contrast.js` reports zero WCAG AA violations
+4. `scripts/fuzz-runs.js` completes 10k runs/realm with zero exceptions
+5. Manual iPad Safari playtest: 60fps verified, VoiceOver navigates all screens, all 5 realms clearable
+6. The kid plays a 10-minute session without expressing boredom, frustration, or asking for help reading
+7. Game is registered in `.github/scripts/update-index.js` and deployed via the existing GitHub Pages workflow

--- a/claudes-math-marauder/scripts/test-distractors.js
+++ b/claudes-math-marauder/scripts/test-distractors.js
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+'use strict';
+
+const D = require('../js/combat/distractors.js');
+const assert = require('assert');
+let p = 0, f = 0;
+function it(name, fn) {
+  try { fn(); console.log('PASS', name); p++; }
+  catch (e) { console.error('FAIL', name, e.message); f++; }
+}
+
+// Seeded RNG for determinism tests
+function makeRng(seed) {
+  let s = seed | 0;
+  return function() {
+    s = (s + 0x6D2B79F5) | 0;
+    let t = Math.imul(s ^ (s >>> 15), 1 | s);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 0x100000000;
+  };
+}
+
+it('mul: exactly 4 unique values, exactly one correct, all non-negative for all 0..12 pairs', function() {
+  const rng = makeRng(1);
+  for (let a = 0; a <= 12; a++) {
+    for (let b = 0; b <= 12; b++) {
+      const answer = a * b;
+      const orbs = D.generateDistractors({ kind: 'mul', a, b, answer }, rng);
+      assert.strictEqual(orbs.length, 4, `length != 4 for ${a}×${b}: ${orbs}`);
+      const unique = new Set(orbs);
+      assert.strictEqual(unique.size, 4, `duplicates for ${a}×${b}: ${orbs}`);
+      assert.strictEqual(orbs.filter(v => v === answer).length, 1, `correct not exactly once for ${a}×${b}: ${orbs}`);
+      orbs.forEach(v => assert.ok(v >= 0, `negative orb ${v} for ${a}×${b}`));
+      orbs.forEach(v => assert.ok(v <= 999, `orb > 999: ${v} for ${a}×${b}`));
+    }
+  }
+});
+
+it('div: exactly 4 unique values, exactly one correct for all 1..12 pairs', function() {
+  const rng = makeRng(2);
+  for (let a = 1; a <= 12; a++) {
+    for (let b = 1; b <= 12; b++) {
+      const dividend = a * b;
+      const divisor = a;
+      const answer = b;
+      const orbs = D.generateDistractors({ kind: 'div', a: dividend, b: divisor, answer }, rng);
+      assert.strictEqual(orbs.length, 4, `length != 4 for ${dividend}÷${divisor}: ${orbs}`);
+      const unique = new Set(orbs);
+      assert.strictEqual(unique.size, 4, `duplicates for ${dividend}÷${divisor}: ${orbs}`);
+      assert.strictEqual(orbs.filter(v => v === answer).length, 1, `correct not exactly once for ${dividend}÷${divisor}: ${orbs}`);
+    }
+  }
+});
+
+it('no negative orbs across 1000 random mul problems', function() {
+  const rng = makeRng(3);
+  for (let i = 0; i < 1000; i++) {
+    const a = Math.floor(rng() * 13);
+    const b = Math.floor(rng() * 13);
+    const orbs = D.generateDistractors({ kind: 'mul', a, b, answer: a * b }, rng);
+    orbs.forEach(v => assert.ok(v >= 0, `negative orb: ${v} for ${a}×${b}`));
+  }
+});
+
+it('distractors are deterministic given same rng state', function() {
+  const prob = { kind: 'mul', a: 7, b: 8, answer: 56 };
+  const orbs1 = D.generateDistractors(prob, makeRng(42));
+  const orbs2 = D.generateDistractors(prob, makeRng(42));
+  assert.deepStrictEqual(orbs1, orbs2);
+});
+
+it('distractors differ with different rng state', function() {
+  const prob = { kind: 'mul', a: 7, b: 8, answer: 56 };
+  const orbs1 = D.generateDistractors(prob, makeRng(1));
+  const orbs2 = D.generateDistractors(prob, makeRng(2));
+  // Different seeds should (very likely) produce different orderings
+  // Not a hard guarantee since shuffles could coincide, but across 4 elements it's astronomically unlikely
+  assert.notDeepStrictEqual(orbs1, orbs2, 'expected different orderings with different seeds');
+});
+
+it('stretch fact (large mul): 4 unique orbs, correct included', function() {
+  const rng = makeRng(4);
+  // Stretch: 5 × 25 = 125
+  const orbs = D.generateDistractors({ kind: 'mul', a: 5, b: 25, answer: 125 }, rng);
+  assert.strictEqual(orbs.length, 4);
+  assert.strictEqual(new Set(orbs).size, 4);
+  assert.ok(orbs.includes(125), 'correct answer 125 missing from orbs: ' + orbs);
+});
+
+it('stretch fact (large div): 4 unique orbs, correct included', function() {
+  const rng = makeRng(5);
+  // Stretch: 150 ÷ 5 = 30
+  const orbs = D.generateDistractors({ kind: 'div', a: 150, b: 5, answer: 30 }, rng);
+  assert.strictEqual(orbs.length, 4);
+  assert.strictEqual(new Set(orbs).size, 4);
+  assert.ok(orbs.includes(30), 'correct answer 30 missing from orbs: ' + orbs);
+});
+
+it('edge case: answer=0 (0×anything) produces 4 unique non-negative orbs', function() {
+  const rng = makeRng(6);
+  for (let b = 0; b <= 12; b++) {
+    const orbs = D.generateDistractors({ kind: 'mul', a: 0, b, answer: 0 }, rng);
+    assert.strictEqual(orbs.length, 4, `length for 0×${b}: ${orbs}`);
+    assert.strictEqual(new Set(orbs).size, 4, `duplicates for 0×${b}: ${orbs}`);
+    assert.ok(orbs.includes(0), `0 missing from 0×${b} orbs: ${orbs}`);
+    orbs.forEach(v => assert.ok(v >= 0, `negative orb for 0×${b}: ${v}`));
+  }
+});
+
+console.log('\n' + p + ' passed, ' + f + ' failed');
+process.exit(f > 0 ? 1 : 0);

--- a/claudes-math-marauder/scripts/test-fact-keys.js
+++ b/claudes-math-marauder/scripts/test-fact-keys.js
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+'use strict';
+
+const FK = require('../js/combat/factKeys.js');
+const assert = require('assert');
+let p = 0, f = 0;
+function it(name, fn) {
+  try { fn(); console.log('PASS', name); p++; }
+  catch (e) { console.error('FAIL', name, e.message); f++; }
+}
+
+it('mulKey collapses commutative pairs', function() {
+  assert.strictEqual(FK.mulKey(7, 8), 'mul:7x8');
+  assert.strictEqual(FK.mulKey(8, 7), 'mul:7x8');
+  assert.strictEqual(FK.mulKey(0, 5), 'mul:0x5');
+  assert.strictEqual(FK.mulKey(5, 0), 'mul:0x5');
+  assert.strictEqual(FK.mulKey(12, 12), 'mul:12x12');
+});
+
+it('divKey uses larger / smaller', function() {
+  assert.strictEqual(FK.divKey(56, 7), 'div:56/7');
+  assert.strictEqual(FK.divKey(7, 56), 'div:56/7');
+  assert.strictEqual(FK.divKey(144, 12), 'div:144/12');
+  assert.strictEqual(FK.divKey(1, 1), 'div:1/1');
+});
+
+it('parseFactKey round-trips mul', function() {
+  assert.deepStrictEqual(FK.parseFactKey('mul:7x8'), { kind: 'mul', a: 7, b: 8 });
+  assert.deepStrictEqual(FK.parseFactKey('mul:0x12'), { kind: 'mul', a: 0, b: 12 });
+});
+
+it('parseFactKey round-trips div', function() {
+  assert.deepStrictEqual(FK.parseFactKey('div:56/7'), { kind: 'div', dividend: 56, divisor: 7 });
+  assert.deepStrictEqual(FK.parseFactKey('div:144/12'), { kind: 'div', dividend: 144, divisor: 12 });
+});
+
+it('parseFactKey returns null for unknown key', function() {
+  assert.strictEqual(FK.parseFactKey('stretch:mul:5x25'), null);
+  assert.strictEqual(FK.parseFactKey('garbage'), null);
+  assert.strictEqual(FK.parseFactKey(''), null);
+});
+
+it('familyOf mul uses smaller factor', function() {
+  assert.strictEqual(FK.familyOf('mul:7x8'), 'x7');
+  assert.strictEqual(FK.familyOf('mul:0x5'), 'x0');
+  assert.strictEqual(FK.familyOf('mul:12x12'), 'x12');
+});
+
+it('familyOf div uses divisor', function() {
+  assert.strictEqual(FK.familyOf('div:56/7'), 'x7');
+  assert.strictEqual(FK.familyOf('div:144/12'), 'x12');
+});
+
+it('familyOf returns null for unknown key', function() {
+  assert.strictEqual(FK.familyOf('garbage'), null);
+});
+
+console.log('\n' + p + ' passed, ' + f + ' failed');
+process.exit(f > 0 ? 1 : 0);

--- a/claudes-math-marauder/scripts/test-mastery.js
+++ b/claudes-math-marauder/scripts/test-mastery.js
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+'use strict';
+
+const M = require('../js/combat/mastery.js');
+const assert = require('assert');
+let p = 0, f = 0;
+function it(name, fn) {
+  try { fn(); console.log('PASS', name); p++; }
+  catch (e) { console.error('FAIL', name, e.message); f++; }
+}
+
+it('correct + fast → box increments', function() {
+  const map = {};
+  M.recordResolve(map, 'mul:7x8', { correct: true, timeMs: 1000, now: 1, masteredAvgMs: 2000 });
+  assert.strictEqual(map['mul:7x8'].box, 2);
+  M.recordResolve(map, 'mul:7x8', { correct: true, timeMs: 1000, now: 2, masteredAvgMs: 2000 });
+  assert.strictEqual(map['mul:7x8'].box, 3);
+});
+
+it('correct + slow (above 2× mastered avg) → box unchanged', function() {
+  const map = {};
+  // masteredAvgMs=2000, fastThreshold=4000; 9000 > 4000 → slow
+  M.recordResolve(map, 'mul:7x8', { correct: true, timeMs: 9000, now: 1, masteredAvgMs: 2000 });
+  assert.strictEqual(map['mul:7x8'].box, 1);
+});
+
+it('correct + slow with null baseline → box unchanged above 8s threshold', function() {
+  const map = {};
+  // null masteredAvgMs → fastThreshold defaults to 8000; 9000 > 8000 → slow
+  M.recordResolve(map, 'mul:7x8', { correct: true, timeMs: 9000, now: 1, masteredAvgMs: null });
+  assert.strictEqual(map['mul:7x8'].box, 1);
+});
+
+it('correct + fast with null baseline → box increments under 8s', function() {
+  const map = {};
+  M.recordResolve(map, 'mul:7x8', { correct: true, timeMs: 2000, now: 1, masteredAvgMs: null });
+  assert.strictEqual(map['mul:7x8'].box, 2);
+});
+
+it('wrong → box decrements by 2 (floored at 1) and shaky=true', function() {
+  const map = {};
+  for (let i = 0; i < 3; i++) {
+    M.recordResolve(map, 'mul:7x8', { correct: true, timeMs: 1000, now: i + 1, masteredAvgMs: 2000 });
+  }
+  assert.strictEqual(map['mul:7x8'].box, 4);
+  M.recordResolve(map, 'mul:7x8', { correct: false, timeMs: 6000, now: 99, masteredAvgMs: 2000 });
+  assert.strictEqual(map['mul:7x8'].box, 2);
+  assert.strictEqual(map['mul:7x8'].shaky, true);
+});
+
+it('wrong from box 1 stays at box 1', function() {
+  const map = {};
+  M.recordResolve(map, 'mul:1x1', { correct: false, timeMs: 1000, now: 1, masteredAvgMs: null });
+  assert.strictEqual(map['mul:1x1'].box, 1);
+});
+
+it('box never exceeds 5', function() {
+  const map = {};
+  for (let i = 0; i < 10; i++) {
+    M.recordResolve(map, 'mul:2x3', { correct: true, timeMs: 500, now: i + 1, masteredAvgMs: 1000 });
+  }
+  assert.strictEqual(map['mul:2x3'].box, 5);
+});
+
+it('isMastered: requires box>=4 AND totalCorrect>=6', function() {
+  const map = {};
+  // 5 correct fast answers → box=5, totalCorrect=5 → NOT yet mastered
+  for (let i = 0; i < 5; i++) {
+    M.recordResolve(map, 'mul:7x8', { correct: true, timeMs: 1000, now: i + 1, masteredAvgMs: 2000 });
+  }
+  assert.strictEqual(M.isMastered(map['mul:7x8']), false, 'should not be mastered at totalCorrect=5');
+  // 6th correct → totalCorrect=6, box=5 → mastered
+  M.recordResolve(map, 'mul:7x8', { correct: true, timeMs: 1000, now: 6, masteredAvgMs: 2000 });
+  assert.strictEqual(M.isMastered(map['mul:7x8']), true);
+});
+
+it('isMastered: null stat is false', function() {
+  assert.strictEqual(M.isMastered(null), false);
+  assert.strictEqual(M.isMastered(undefined), false);
+});
+
+it('shaky clears after 3 consecutive correct', function() {
+  const map = {};
+  M.recordResolve(map, 'mul:7x8', { correct: false, timeMs: 6000, now: 1, masteredAvgMs: null });
+  assert.strictEqual(map['mul:7x8'].shaky, true);
+  M.recordResolve(map, 'mul:7x8', { correct: true, timeMs: 1000, now: 2, masteredAvgMs: null });
+  M.recordResolve(map, 'mul:7x8', { correct: true, timeMs: 1000, now: 3, masteredAvgMs: null });
+  assert.strictEqual(map['mul:7x8'].shaky, true, 'should still be shaky at streak=2');
+  M.recordResolve(map, 'mul:7x8', { correct: true, timeMs: 1000, now: 4, masteredAvgMs: null });
+  assert.strictEqual(map['mul:7x8'].shaky, false);
+});
+
+it('totalAsked increments on every resolve', function() {
+  const map = {};
+  for (let i = 0; i < 7; i++) {
+    M.recordResolve(map, 'mul:4x6', { correct: i % 2 === 0, timeMs: 2000, now: i, masteredAvgMs: null });
+  }
+  assert.strictEqual(map['mul:4x6'].totalAsked, 7);
+});
+
+it('masteredAvgMs returns null with no mastered facts', function() {
+  assert.strictEqual(M.masteredAvgMs({}), null);
+});
+
+it('masteredAvgMs averages over mastered facts', function() {
+  const map = {};
+  // Make two facts mastered with known avgMs
+  const keys = ['mul:5x6', 'mul:5x7'];
+  for (const k of keys) {
+    for (let i = 0; i < 6; i++) {
+      M.recordResolve(map, k, { correct: true, timeMs: 2000, now: i, masteredAvgMs: 2000 });
+    }
+    assert.ok(M.isMastered(map[k]), k + ' should be mastered');
+  }
+  const avg = M.masteredAvgMs(map);
+  assert.ok(avg > 0 && avg < 5000, 'avg should be a plausible number: ' + avg);
+});
+
+it('pullWeight: box=1, not shaky, not recent → weight 5', function() {
+  assert.strictEqual(M.pullWeight('mul:7x8', { box: 1, shaky: false }, []), 5);
+});
+
+it('pullWeight: box=5 → weight 1', function() {
+  assert.strictEqual(M.pullWeight('mul:7x8', { box: 5, shaky: false }, []), 1);
+});
+
+it('pullWeight: shaky multiplier applies', function() {
+  const w = M.pullWeight('mul:7x8', { box: 1, shaky: true }, []);
+  assert.strictEqual(w, 5 * M.SHAKY_MULTIPLIER);
+});
+
+it('pullWeight: recency damping applies when key in recentKeys', function() {
+  const w = M.pullWeight('mul:7x8', { box: 1, shaky: false }, ['mul:7x8']);
+  assert.strictEqual(w, 5 * M.RECENCY_DAMPING);
+});
+
+it('pullWeight: null stat treated as box=1', function() {
+  assert.strictEqual(M.pullWeight('mul:7x8', null, []), 5);
+});
+
+it('100-problem simulation: most facts converge to box >= 3', function() {
+  const map = {};
+  const keys = ['mul:5x6', 'mul:5x7', 'mul:6x7', 'mul:7x8', 'mul:8x9', 'mul:6x9'];
+  for (let i = 0; i < 100; i++) {
+    const k = keys[i % keys.length];
+    M.recordResolve(map, k, { correct: true, timeMs: 1500, now: i, masteredAvgMs: 2000 });
+  }
+  for (const k of keys) {
+    assert.ok(map[k].box >= 3, k + ' should be box>=3, got ' + map[k].box);
+  }
+});
+
+console.log('\n' + p + ' passed, ' + f + ' failed');
+process.exit(f > 0 ? 1 : 0);

--- a/claudes-math-marauder/scripts/test-mastery.js
+++ b/claudes-math-marauder/scripts/test-mastery.js
@@ -24,14 +24,14 @@ it('correct + slow (above 2× mastered avg) → box unchanged', function() {
   assert.strictEqual(map['mul:7x8'].box, 1);
 });
 
-it('correct + slow with null baseline → box unchanged above 8s threshold', function() {
+it('correct + slow with null baseline → box unchanged above 12s threshold', function() {
   const map = {};
-  // null masteredAvgMs → fastThreshold defaults to 8000; 9000 > 8000 → slow
-  M.recordResolve(map, 'mul:7x8', { correct: true, timeMs: 9000, now: 1, masteredAvgMs: null });
+  // null masteredAvgMs → fastThreshold defaults to 6000*2=12000; 13000 > 12000 → slow
+  M.recordResolve(map, 'mul:7x8', { correct: true, timeMs: 13000, now: 1, masteredAvgMs: null });
   assert.strictEqual(map['mul:7x8'].box, 1);
 });
 
-it('correct + fast with null baseline → box increments under 8s', function() {
+it('correct + fast with null baseline → box increments under 12s', function() {
   const map = {};
   M.recordResolve(map, 'mul:7x8', { correct: true, timeMs: 2000, now: 1, masteredAvgMs: null });
   assert.strictEqual(map['mul:7x8'].box, 2);
@@ -136,6 +136,16 @@ it('pullWeight: recency damping applies when key in recentKeys', function() {
 
 it('pullWeight: null stat treated as box=1', function() {
   assert.strictEqual(M.pullWeight('mul:7x8', null, []), 5);
+});
+
+it('avgMs converges toward actual answer time after many correct answers', function() {
+  const map = {};
+  for (let i = 0; i < 20; i++) {
+    M.recordResolve(map, 'mul:3x4', { correct: true, timeMs: 1000, now: i, masteredAvgMs: null });
+  }
+  // EWMA with α=0.3 starting from 0: after 20 answers at 1000ms it should be close to 1000
+  assert.ok(map['mul:3x4'].avgMs > 850 && map['mul:3x4'].avgMs <= 1000,
+    'avgMs should converge near 1000, got ' + map['mul:3x4'].avgMs);
 });
 
 it('100-problem simulation: most facts converge to box >= 3', function() {

--- a/claudes-math-marauder/scripts/test-problem-gen.js
+++ b/claudes-math-marauder/scripts/test-problem-gen.js
@@ -163,6 +163,13 @@ it('mulRatio=1.0 produces only mul problems', function() {
   }
 });
 
+it('selectProblem returns null when all family weights are 0', function() {
+  const rng = makeRng(7);
+  const emptyRealm = { factFamilyWeights: { x2: 0, x5: 0, x10: 0 } };
+  const result = PG.selectProblem({ realm: emptyRealm, masteryMap: {}, recentKeys: [], rng, mulRatio: 0.5, allowStretch: false, realmTier: 1 });
+  assert.strictEqual(result, null, 'expected null for all-zero weights, got: ' + JSON.stringify(result));
+});
+
 it('mulRatio=0.0 produces only div problems', function() {
   const rng = makeRng(6);
   for (let i = 0; i < 50; i++) {

--- a/claudes-math-marauder/scripts/test-problem-gen.js
+++ b/claudes-math-marauder/scripts/test-problem-gen.js
@@ -1,0 +1,175 @@
+#!/usr/bin/env node
+'use strict';
+
+const PG = require('../js/combat/problemGen.js');
+const FK = require('../js/combat/factKeys.js');
+const M  = require('../js/combat/mastery.js');
+const assert = require('assert');
+let p = 0, f = 0;
+function it(name, fn) {
+  try { fn(); console.log('PASS', name); p++; }
+  catch (e) { console.error('FAIL', name, e.message); f++; }
+}
+
+// Mulberry32 seeded PRNG — must match rng.js (divisor 0x100000000)
+function makeRng(seed) {
+  let s = seed | 0;
+  return function() {
+    s = (s + 0x6D2B79F5) | 0;
+    let t = Math.imul(s ^ (s >>> 15), 1 | s);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 0x100000000;
+  };
+}
+
+const realm1 = { factFamilyWeights: { x2: 0.2, x5: 0.4, x10: 0.4 } };
+
+it('every multiplication answer is correct', function() {
+  const rng = makeRng(1);
+  for (let i = 0; i < 200; i++) {
+    const prob = PG.selectProblem({ realm: realm1, masteryMap: {}, recentKeys: [], rng, mulRatio: 1.0, allowStretch: false, realmTier: 1 });
+    if (prob.kind === 'mul') assert.strictEqual(prob.answer, prob.a * prob.b, prob.displayText);
+  }
+});
+
+it('every division answer is an integer and correct', function() {
+  const rng = makeRng(2);
+  for (let i = 0; i < 200; i++) {
+    const prob = PG.selectProblem({ realm: realm1, masteryMap: {}, recentKeys: [], rng, mulRatio: 0.0, allowStretch: false, realmTier: 1 });
+    if (prob.kind === 'div') {
+      assert.ok(Number.isInteger(prob.answer), 'non-integer: ' + prob.displayText);
+      assert.strictEqual(prob.a / prob.b, prob.answer, prob.displayText);
+    }
+  }
+});
+
+it('answers are in range 0..144', function() {
+  const rng = makeRng(7);
+  for (let i = 0; i < 500; i++) {
+    const prob = PG.selectProblem({ realm: realm1, masteryMap: {}, recentKeys: [], rng, mulRatio: 0.5, allowStretch: false, realmTier: 1 });
+    assert.ok(prob.answer >= 0 && prob.answer <= 144, 'out of range: ' + prob.answer + ' from ' + prob.displayText);
+  }
+});
+
+it('displayText contains a "?" and the operands', function() {
+  const rng = makeRng(3);
+  for (let i = 0; i < 50; i++) {
+    const prob = PG.selectProblem({ realm: realm1, masteryMap: {}, recentKeys: [], rng, mulRatio: 0.5, allowStretch: false, realmTier: 1 });
+    assert.ok(prob.displayText.includes('?'), 'displayText missing ?: ' + prob.displayText);
+    assert.ok(prob.displayText.includes(String(prob.a)), 'displayText missing a: ' + prob.displayText);
+    assert.ok(prob.displayText.includes(String(prob.b)), 'displayText missing b: ' + prob.displayText);
+  }
+});
+
+it('determinism: same seed + state produces identical problem sequence', function() {
+  function runSeq(seed) {
+    const rng = makeRng(seed);
+    const seq = [];
+    for (let i = 0; i < 30; i++) {
+      seq.push(PG.selectProblem({ realm: realm1, masteryMap: {}, recentKeys: [], rng, mulRatio: 0.7, allowStretch: false, realmTier: 1 }).factKey);
+    }
+    return seq;
+  }
+  const a = runSeq(42);
+  const b = runSeq(42);
+  assert.deepStrictEqual(a, b);
+});
+
+it('different seeds produce different sequences', function() {
+  function runSeq(seed) {
+    const rng = makeRng(seed);
+    const seq = [];
+    for (let i = 0; i < 30; i++) {
+      seq.push(PG.selectProblem({ realm: realm1, masteryMap: {}, recentKeys: [], rng, mulRatio: 0.7, allowStretch: false, realmTier: 1 }).factKey);
+    }
+    return seq;
+  }
+  const a = runSeq(1);
+  const b = runSeq(2);
+  assert.notDeepStrictEqual(a, b);
+});
+
+it('stretch facts gated: empty mastery never produces stretch', function() {
+  const rng = makeRng(99);
+  for (let i = 0; i < 300; i++) {
+    const prob = PG.selectProblem({ realm: realm1, masteryMap: {}, recentKeys: [], rng, mulRatio: 0.7, allowStretch: true, realmTier: 5 });
+    assert.strictEqual(prob.isStretch, false, 'got stretch with empty mastery: ' + prob.factKey);
+  }
+});
+
+it('stretch facts produced when x5 family mastered (>= 4 facts)', function() {
+  const map = {};
+  // Mark x5 facts 0..12 as mastered
+  for (let k = 0; k <= 12; k++) {
+    map[FK.mulKey(5, k)] = { box: 5, lastSeenAt: 1, totalAsked: 10, totalCorrect: 10, avgMs: 1000, streak: 5, shaky: false };
+  }
+  const rng = makeRng(123);
+  let stretchCount = 0;
+  for (let i = 0; i < 1000; i++) {
+    const prob = PG.selectProblem({ realm: realm1, masteryMap: map, recentKeys: [], rng, mulRatio: 0.7, allowStretch: true, realmTier: 5 });
+    if (prob.isStretch) stretchCount++;
+  }
+  // Tier 5 stretch prob = 0.18; expect roughly 180 ± wide margin
+  assert.ok(stretchCount > 80 && stretchCount < 300, 'stretchCount=' + stretchCount + ' outside expected range');
+});
+
+it('stretch answers are outside 0-12 range', function() {
+  const map = {};
+  for (let k = 0; k <= 12; k++) {
+    map[FK.mulKey(5, k)] = { box: 5, lastSeenAt: 1, totalAsked: 10, totalCorrect: 10, avgMs: 1000, streak: 5, shaky: false };
+  }
+  const rng = makeRng(456);
+  let found = false;
+  for (let i = 0; i < 2000; i++) {
+    const prob = PG.selectProblem({ realm: realm1, masteryMap: map, recentKeys: [], rng, mulRatio: 0.7, allowStretch: true, realmTier: 5 });
+    if (prob.isStretch) {
+      // For x5 stretch: a or b should be > 12
+      const large = Math.max(prob.a, prob.b);
+      assert.ok(large > 12, 'stretch operand not > 12: ' + prob.displayText);
+      found = true;
+    }
+  }
+  assert.ok(found, 'no stretch problems found in 2000 attempts');
+});
+
+it('buildEligibleKeys: includes keys from all active families', function() {
+  const weights = { x2: 0.5, x5: 0.5 };
+  const keys = PG.buildEligibleKeys(weights);
+  assert.ok(keys.some(k => k.startsWith('mul:') && k.includes('x2')), 'missing x2 mul keys');
+  assert.ok(keys.some(k => k.startsWith('mul:') && k.includes('x5')), 'missing x5 mul keys');
+  assert.ok(keys.some(k => k.startsWith('div:')), 'missing div keys');
+});
+
+it('buildEligibleKeys: excludes families with weight 0', function() {
+  const weights = { x0: 0, x1: 0, x2: 0.5, x12: 0 };
+  const keys = PG.buildEligibleKeys(weights);
+  // x0 and x1 and x12 excluded; x2 included
+  assert.ok(!keys.some(k => k === 'mul:0x0'), 'x0 family should be excluded');
+  assert.ok(keys.some(k => k.startsWith('mul:') && k.includes('x2')), 'x2 should be included');
+});
+
+it('buildEligibleKeys: no duplicate keys', function() {
+  const weights = { x2: 0.3, x5: 0.4, x10: 0.3 };
+  const keys = PG.buildEligibleKeys(weights);
+  const unique = new Set(keys);
+  assert.strictEqual(unique.size, keys.length, 'duplicate keys found');
+});
+
+it('mulRatio=1.0 produces only mul problems', function() {
+  const rng = makeRng(5);
+  for (let i = 0; i < 50; i++) {
+    const prob = PG.selectProblem({ realm: realm1, masteryMap: {}, recentKeys: [], rng, mulRatio: 1.0, allowStretch: false, realmTier: 1 });
+    assert.strictEqual(prob.kind, 'mul');
+  }
+});
+
+it('mulRatio=0.0 produces only div problems', function() {
+  const rng = makeRng(6);
+  for (let i = 0; i < 50; i++) {
+    const prob = PG.selectProblem({ realm: realm1, masteryMap: {}, recentKeys: [], rng, mulRatio: 0.0, allowStretch: false, realmTier: 1 });
+    assert.strictEqual(prob.kind, 'div');
+  }
+});
+
+console.log('\n' + p + ' passed, ' + f + ' failed');
+process.exit(f > 0 ? 1 : 0);

--- a/claudes-math-marauder/scripts/test-save-migration.js
+++ b/claudes-math-marauder/scripts/test-save-migration.js
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+'use strict';
+
+// Node-only localStorage shim
+const store = {};
+global.localStorage = {
+  getItem:    (k) => (k in store ? store[k] : null),
+  setItem:    (k, v) => { store[k] = String(v); },
+  removeItem: (k) => { delete store[k]; },
+};
+global.window = global;
+global.document = { getElementById() { return { addEventListener() {} }; } };
+global.showToast = function() {};
+
+const { SaveManager } = require('../js/save.js');
+const assert = require('assert');
+
+let pass = 0, fail = 0;
+function it(name, fn) {
+  try { fn(); console.log('PASS', name); pass++; }
+  catch (e) { console.error('FAIL', name, e.message); fail++; }
+}
+
+// ── Defaults shape ─────────────────────────────────────────────────
+it('defaults includes every required top-level key', function() {
+  const d = SaveManager._defaults();
+  const required = [
+    'schemaVersion', 'createdAt', 'lastPlayedAt', 'playerName',
+    'totalRunsStarted', 'totalRunsCompleted', 'totalProblemsAnswered', 'totalCorrect',
+    'gold', 'ownedSpellIds', 'equippedDeck', 'unlockedClassIds', 'selectedClassId',
+    'realmStars', 'storyChaptersUnlocked', 'mastery', 'activeRun', 'settings',
+  ];
+  required.forEach(function(k) { assert.ok(k in d, 'missing key: ' + k); });
+  assert.strictEqual(d.equippedDeck.length, 5);
+  assert.strictEqual(d.ownedSpellIds[0], 'ember_bolt');
+  assert.strictEqual(d.selectedClassId, 'apprentice');
+  assert.strictEqual(d.gold, 0);
+  assert.strictEqual(d.activeRun, null);
+});
+
+it('defaults.settings includes every settings key', function() {
+  const s = SaveManager._defaults().settings;
+  const required = [
+    'speechVoiceURI', 'speechRate', 'autoNarrate', 'sfxVolume',
+    'muteAll', 'reducedMotion', 'fontScale', 'showSpeedTimer',
+    'allowStretchFacts', 'devMode',
+  ];
+  required.forEach(function(k) { assert.ok(k in s, 'missing settings key: ' + k); });
+  assert.strictEqual(s.speechRate, 1.0);
+  assert.strictEqual(s.sfxVolume, 0.7);
+  assert.strictEqual(s.allowStretchFacts, true);
+});
+
+it('defaults.realmStars has 5 realms', function() {
+  const rs = SaveManager._defaults().realmStars;
+  const realms = ['goblin_forest', 'crystal_cave', 'dragon_peak', 'astral_void', 'lich_citadel'];
+  realms.forEach(function(r) { assert.strictEqual(rs[r], 0, 'missing realm: ' + r); });
+});
+
+// ── Round-trip ─────────────────────────────────────────────────────
+it('save/load round-trip preserves all fields', function() {
+  SaveManager.reset();
+  const d = SaveManager._defaults();
+  d.gold = 142;
+  d.mastery['mul:7x8'] = { box: 3, lastSeenAt: 1, totalAsked: 5, totalCorrect: 4, avgMs: 2000, streak: 2, shaky: false };
+  d.settings.speechRate = 0.9;
+  SaveManager.save(d);
+  const loaded = SaveManager.load();
+  assert.strictEqual(loaded.gold, 142);
+  assert.strictEqual(loaded.mastery['mul:7x8'].box, 3);
+  assert.strictEqual(loaded.settings.speechRate, 0.9);
+});
+
+// ── Migration v0 → v1 ──────────────────────────────────────────────
+it('migrates v0 (missing fields) to v1 schema', function() {
+  SaveManager.reset();
+  localStorage.setItem('claudes-math-marauder-save', JSON.stringify({ schemaVersion: 0, gold: 5 }));
+  const loaded = SaveManager.load();
+  assert.strictEqual(loaded.schemaVersion, 1);
+  assert.strictEqual(loaded.gold, 5);
+  assert.ok('mastery' in loaded, 'mastery missing after migration');
+  assert.ok('settings' in loaded, 'settings missing after migration');
+  assert.ok('realmStars' in loaded, 'realmStars missing after migration');
+});
+
+// ── Corrupt JSON → fallback to defaults ────────────────────────────
+it('corrupt primary save falls back to defaults', function() {
+  SaveManager.reset();
+  localStorage.setItem('claudes-math-marauder-save', '{not valid json');
+  const loaded = SaveManager.load();
+  assert.strictEqual(loaded.gold, 0, 'expected default gold after corruption');
+  assert.ok('mastery' in loaded, 'mastery should exist on fresh defaults');
+});
+
+// ── Backup recovery ────────────────────────────────────────────────
+it('falls back to backup when primary is corrupt but backup is valid', function() {
+  SaveManager.reset();
+  const backup = SaveManager._defaults();
+  backup.gold = 77;
+  localStorage.setItem('claudes-math-marauder-save', '{invalid');
+  localStorage.setItem('claudes-math-marauder-save-backup', JSON.stringify(backup));
+  const loaded = SaveManager.load();
+  assert.strictEqual(loaded.gold, 77, 'should recover gold from backup');
+});
+
+// ── export/import round-trip ───────────────────────────────────────
+it('export/import round-trips deep equality', function() {
+  SaveManager.reset();
+  const d = SaveManager._defaults();
+  d.gold = 999;
+  d.selectedClassId = 'pyromancer';
+  SaveManager.save(d);
+  const exported = SaveManager.export();
+  SaveManager.reset();
+  SaveManager.import(exported);
+  const reloaded = SaveManager.load();
+  assert.strictEqual(reloaded.gold, 999);
+  assert.strictEqual(reloaded.selectedClassId, 'pyromancer');
+});
+
+// ── Summary ────────────────────────────────────────────────────────
+console.log('\n' + pass + ' passed, ' + fail + ' failed');
+process.exit(fail > 0 ? 1 : 0);

--- a/claudes-math-marauder/scripts/validate-data.js
+++ b/claudes-math-marauder/scripts/validate-data.js
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+'use strict';
+// Validates claudes-math-marauder/data/*.json files.
+// Stub for Session 1 — Session 4 fleshes this out with full validators.
+
+const fs = require('fs');
+const path = require('path');
+
+const dataDir = path.join(__dirname, '..', 'data');
+const files = fs.existsSync(dataDir) ? fs.readdirSync(dataDir).filter(function(f) { return f.endsWith('.json'); }) : [];
+
+if (files.length === 0) {
+  console.log('OK (no data files yet — validator stub from Session 1)');
+  process.exit(0);
+}
+
+let errors = 0;
+files.forEach(function(f) {
+  const fp = path.join(dataDir, f);
+  try {
+    JSON.parse(fs.readFileSync(fp, 'utf8'));
+    console.log('OK ' + f);
+  } catch (e) {
+    console.error('CRITICAL ' + f + ': ' + e.message);
+    errors++;
+  }
+});
+
+if (errors > 0) {
+  console.error(errors + ' error(s) found.');
+  process.exit(1);
+}
+console.log('All data files valid.');
+process.exit(0);

--- a/claudes-math-marauder/sessions/session-01.md
+++ b/claudes-math-marauder/sessions/session-01.md
@@ -1,0 +1,569 @@
+# Session 1 — Claude Tooling + Project Scaffold
+**Model:** Opus | **Focus:** Repo plumbing, validation tooling, state-machine shell, save manager, index registration
+
+This session creates everything *around* the game so future sessions can land on a green base. No gameplay yet.
+
+## Pre-flight
+
+1. Read `claudes-math-marauder/plan.md` and `docs/superpowers/specs/2026-05-01-claudes-math-marauder-design.md`.
+2. There is no `/marauder-checklist` yet — this session creates it. Skim the spec sections 4 (renderer), 5 (audio), 6 (data), 7 (a11y) before writing skeleton code so the structure is right.
+
+## Files to create
+
+### Game directory skeleton
+- `claudes-math-marauder/index.html`
+- `claudes-math-marauder/css/style.css`
+- `claudes-math-marauder/js/game.js`
+- `claudes-math-marauder/js/save.js`
+- `claudes-math-marauder/js/util/rng.js`
+- `claudes-math-marauder/js/util/shuffle.js`
+- `claudes-math-marauder/js/util/escape.js`
+- `claudes-math-marauder/js/ui/toast.js`
+- `claudes-math-marauder/data/.gitkeep` (data files come in Session 4)
+- `claudes-math-marauder/scripts/test-save-migration.js`
+- `claudes-math-marauder/scripts/validate-data.js` (stub returning success — fleshed out in Session 4)
+
+### Claude tooling
+- `.claude/rules/marauder.md` — path-scoped architecture rules
+- `.claude/skills/marauder-checklist/SKILL.md` — pre-implementation checklist
+- `.claude/skills/validate-marauder-data/SKILL.md` — data validator skill
+- `.claude/hooks/validate-marauder-data-hook.sh` — auto-validate on data edits
+- `.claude/agents/marauder-web-review/agent.md` — code-review agent
+
+### Files to modify
+- `.github/scripts/update-index.js` — register the game with icon, title, description, category
+- `.claude/settings.json` — add the new hook entry to `hooks.PostToolUse`
+
+## Deliverables
+
+### 1. `index.html`
+
+Minimal HTML scaffold matching repo conventions:
+
+- `<title>Claude's Math Marauder</title>`
+- `<meta name="viewport" content="width=device-width, initial-scale=1.0">` — no `user-scalable=no`
+- `<link rel="stylesheet" href="https://fonts.cdnfonts.com/css/opendyslexic">` (or whichever CDN KC4 uses — match the existing pattern by grepping `keyboard-command-4/index.html`)
+- `<link rel="stylesheet" href="css/style.css">`
+- One `<canvas id="game-canvas">` and one `<div id="hud-root" aria-live="polite"></div>` for HUD overlays
+- One `<div id="overlay-root"></div>` for modal overlays
+- `<div id="toast-root" role="status"></div>` for toasts
+- `<script type="module" src="js/game.js" defer></script>` (defer; never wrap init in `window.addEventListener('load', ...)`)
+- Hidden title screen: `<section id="title-screen" class="screen active">` with `<h1>Claude's Math Marauder</h1>`, subtitle "A game by Claude", a "Begin" button (id `start-button`)
+
+### 2. `css/style.css`
+
+Design system as CSS custom properties on `:root`:
+
+```css
+:root {
+  --bg: #F5F0E8;            /* cream */
+  --text: #2C2416;          /* dark on cream */
+  --text-secondary: #595143;
+  --accent-ink: #1a1a1a;
+  --accent-comic-red: #c93434;
+  --accent-comic-blue: #2c5fb3;
+  --accent-comic-yellow: #f0d840;
+  --panel-stroke: 4px;
+  --font-base: 20px;
+  --font-numerals: 64px;
+  --font-stack: "OpenDyslexic", "Comic Sans MS", cursive;
+  --line-height: 1.5;
+}
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--font-stack);
+  font-size: var(--font-base);
+  line-height: var(--line-height);
+}
+
+#game-canvas { display: block; touch-action: none; width: 100vw; height: 100vh; }
+
+.screen { display: none; }
+.screen.active { display: flex; flex-direction: column; align-items: center; justify-content: center; }
+
+.overlay { display: none; position: fixed; inset: 0; background: rgba(44,36,22,0.5); z-index: 100; }
+.overlay.open { display: flex; align-items: center; justify-content: center; }
+.overlay[aria-hidden="true"] { pointer-events: none; }
+
+.hidden { display: none; }
+.locked { opacity: 0.5; cursor: not-allowed; }
+
+button {
+  font-family: var(--font-stack);
+  font-size: var(--font-base);
+  min-width: 44px; min-height: 44px;
+  background: var(--accent-comic-yellow);
+  color: var(--text);
+  border: var(--panel-stroke) solid var(--accent-ink);
+  border-radius: 12px;
+  cursor: pointer;
+}
+button:disabled { opacity: 0.5; cursor: not-allowed; }
+```
+
+Note the **CSS ID specificity rule** from CLAUDE.md: never put `display:` in a base ID rule when a class controls visibility. `#title-screen.active { display: flex; }` is correct; `#title-screen { display: flex; }` is wrong.
+
+### 3. `js/save.js` — SaveManager (single source of truth)
+
+Class with **all static methods** so callers never hold an instance. Required methods:
+
+```js
+const KEY = 'claudes-math-marauder-save';
+const BACKUP_KEY = 'claudes-math-marauder-save-backup';
+const SCHEMA_VERSION = 1;
+
+const SaveManager = {
+  load() { /* return parsed save or _defaults() if missing/corrupt; on parse-fail try BACKUP_KEY; on second fail show toast and return _defaults() */ },
+  save(data) { /* stringify, write KEY; every 5th save also write BACKUP_KEY; catch quota error → toast */ },
+  reset() { /* localStorage.removeItem(KEY); localStorage.removeItem(BACKUP_KEY); */ },
+  _defaults() { /* return the schema shape from plan.md verbatim — every key game.js may read */ },
+  _migrate(data) { /* if data.schemaVersion < SCHEMA_VERSION, apply numbered migrators; return migrated data */ },
+  _saveCount: 0,
+};
+```
+
+**`_defaults()` MUST return** every key listed in plan.md's "Save Schema" — `mastery: {}`, `activeRun: null`, `settings` with all keys, `realmStars` with all 5 realms keyed to 0, `equippedDeck` with 5 nulls (or `["ember_bolt", null, null, null, null]` since Ember Bolt is the starter), `ownedSpellIds: ["ember_bolt"]`, `unlockedClassIds: ["apprentice"]`, `selectedClassId: "apprentice"`. If a future session adds a field, add it to `_defaults()` in the same commit.
+
+**Migration shape:**
+```js
+const MIGRATIONS = {
+  0: (d) => { /* 0→1: noop placeholder; future migrations slot in here */ return d; },
+};
+function _migrate(data) {
+  let d = data || {};
+  let v = d.schemaVersion || 0;
+  while (v < SCHEMA_VERSION) {
+    d = MIGRATIONS[v](d);
+    v++;
+    d.schemaVersion = v;
+  }
+  return d;
+}
+```
+
+### 4. `js/game.js` — State-machine shell
+
+Single RAF chain; passes `dt` to `update()` and `draw()`. State machine boilerplate only — no gameplay logic yet.
+
+```js
+const STATE = {
+  TITLE: 'TITLE',
+  HUB: 'HUB',
+  REALM_PICK: 'REALM_PICK',
+  RUN_MAP: 'RUN_MAP',
+  FIGHT: 'FIGHT',
+  RESULTS: 'RESULTS',
+  PAUSED: 'PAUSED',
+};
+
+class Game {
+  constructor() {
+    this.state = STATE.TITLE;
+    this.canvas = null;
+    this.ctx = null;
+    this._lastFrameTime = 0;
+    this._rafId = 0;
+    this._save = null;          // cached save snapshot, refresh on state entry
+  }
+
+  init() {
+    this.canvas = document.getElementById('game-canvas');
+    this.ctx = this.canvas.getContext('2d');
+    this._setupCanvasDpr();
+    window.addEventListener('resize', () => this._setupCanvasDpr());
+    this._save = SaveManager.load();
+    this._bindTitleScreen();
+    this._loop = this._loop.bind(this);
+    this._rafId = requestAnimationFrame(this._loop);
+  }
+
+  _setupCanvasDpr() {
+    const dpr = window.devicePixelRatio || 1;
+    this.canvas.width  = this.canvas.clientWidth  * dpr;
+    this.canvas.height = this.canvas.clientHeight * dpr;
+    this.ctx.setTransform(1,0,0,1,0,0);
+    this.ctx.scale(dpr, dpr);
+    this.ctx.imageSmoothingEnabled = false;
+  }
+
+  _loop(now) {
+    if (!this._lastFrameTime) this._lastFrameTime = now;
+    let dt = now - this._lastFrameTime;
+    if (dt > 50) dt = 50;
+    this._lastFrameTime = now;
+
+    if (this.state !== STATE.PAUSED) this._update(dt);
+    this._draw();
+    this._rafId = requestAnimationFrame(this._loop);
+  }
+
+  _update(dt) { /* placeholder; future sessions drive managers from here */ }
+  _draw() { /* placeholder; clear canvas with cream */ this.ctx.fillStyle = '#F5F0E8'; this.ctx.fillRect(0,0,this.canvas.clientWidth, this.canvas.clientHeight); }
+
+  setState(next) {
+    if (this.state === next) return;
+    // future sessions: cancel timers/animations on transition
+    this.state = next;
+    this._refreshScreens();
+  }
+
+  _refreshScreens() {
+    document.querySelectorAll('.screen').forEach(s => s.classList.remove('active'));
+    const id = `${this.state.toLowerCase().replace(/_/g,'-')}-screen`;
+    const el = document.getElementById(id);
+    if (el) el.classList.add('active');
+  }
+
+  _bindTitleScreen() {
+    const btn = document.getElementById('start-button');
+    if (btn) btn.addEventListener('click', () => this.setState(STATE.HUB));
+  }
+}
+
+// CLAUDE.md init pattern — exact:
+window.game = new Game();
+window.game.init();
+```
+
+### 5. `js/util/rng.js` — Seeded PRNG
+
+Mulberry32 + `hashString` per Petstore precedent.
+
+```js
+export function hashString(str) {
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    hash = ((hash << 5) - hash + str.charCodeAt(i)) | 0;
+  }
+  return hash;
+}
+
+export function seededRandom(seed) {
+  let s = seed | 0;
+  return () => {
+    s = (s + 0x6D2B79F5) | 0;
+    let t = Math.imul(s ^ (s >>> 15), 1 | s);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 0xFFFFFFFF;
+  };
+}
+```
+
+### 6. `js/util/shuffle.js` — Fisher-Yates
+
+```js
+export function shuffleInPlace(arr, rng = Math.random) {
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr;
+}
+```
+
+### 7. `js/util/escape.js` — escHtml
+
+```js
+export function escHtml(v) {
+  return String(v)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+```
+
+### 8. `js/ui/toast.js` — Quota / save error toast
+
+Minimal:
+```js
+export function showToast(msg, ms = 3000) {
+  const root = document.getElementById('toast-root');
+  if (!root) return;
+  const el = document.createElement('div');
+  el.className = 'toast';
+  el.textContent = msg;
+  root.appendChild(el);
+  setTimeout(() => { if (el.isConnected) el.remove(); }, ms);
+}
+```
+
+### 9. `scripts/test-save-migration.js`
+
+Node script — run with `node claudes-math-marauder/scripts/test-save-migration.js`. Use a localStorage shim and `assert`:
+
+```js
+// node-only shim
+const store = {};
+global.localStorage = {
+  getItem: (k) => k in store ? store[k] : null,
+  setItem: (k, v) => { store[k] = String(v); },
+  removeItem: (k) => { delete store[k]; },
+};
+global.window = { addEventListener() {} };
+global.document = { getElementById() { return { addEventListener() {} }; } };
+
+// dynamic import the SaveManager source
+// Convert ES export to CommonJS by reading and evaling, OR ship save.js as both ESM and a CJS-compatible format.
+// SIMPLER: factor save.js into pure object exported via globalThis pattern that both Node and browser can read.
+```
+
+**Decision (resolves the "save.js as both module and Node-loadable" tension):** ship the SaveManager core as a UMD-style file:
+
+```js
+// js/save.js — top of file
+(function(global) {
+  'use strict';
+  // ... SaveManager body ...
+  if (typeof module !== 'undefined' && module.exports) module.exports = { SaveManager };
+  else global.SaveManager = SaveManager;
+})(typeof window !== 'undefined' ? window : globalThis);
+```
+
+This pattern is reused for every pure-logic module that has a Node test counterpart (combat/factKeys.js, combat/mastery.js, combat/problemGen.js, combat/distractors.js, run/mapGen.js, util/rng.js, util/shuffle.js).
+
+**Test cases (test-save-migration.js):**
+
+```js
+const { SaveManager } = require('../js/save.js');
+const assert = require('assert');
+
+let pass = 0, fail = 0;
+function it(name, fn) { try { fn(); console.log('PASS', name); pass++; } catch (e) { console.error('FAIL', name, e.message); fail++; } }
+
+// Defaults shape
+it('defaults includes every required key', () => {
+  const d = SaveManager._defaults();
+  ['schemaVersion','mastery','activeRun','settings','realmStars','equippedDeck','ownedSpellIds','unlockedClassIds','selectedClassId','gold'].forEach(k => assert.ok(k in d, `missing ${k}`));
+  assert.strictEqual(d.equippedDeck.length, 5);
+  assert.strictEqual(d.ownedSpellIds[0], 'ember_bolt');
+});
+
+it('settings has every key', () => {
+  const s = SaveManager._defaults().settings;
+  ['speechVoiceURI','speechRate','autoNarrate','sfxVolume','muteAll','reducedMotion','fontScale','showSpeedTimer','allowStretchFacts','devMode'].forEach(k => assert.ok(k in s, `missing settings.${k}`));
+});
+
+// Round-trip
+it('save/load round-trip preserves all fields', () => {
+  SaveManager.reset();
+  const d = SaveManager._defaults();
+  d.gold = 142;
+  d.mastery['mul:7x8'] = { box: 3, lastSeenAt: 1, totalAsked: 5, totalCorrect: 4, avgMs: 2000, streak: 2, shaky: false };
+  SaveManager.save(d);
+  const loaded = SaveManager.load();
+  assert.strictEqual(loaded.gold, 142);
+  assert.strictEqual(loaded.mastery['mul:7x8'].box, 3);
+});
+
+// Migration from v0
+it('migrates v0 (missing fields) to current schema', () => {
+  SaveManager.reset();
+  global.localStorage.setItem('claudes-math-marauder-save', JSON.stringify({ schemaVersion: 0, gold: 5 }));
+  const loaded = SaveManager.load();
+  assert.strictEqual(loaded.schemaVersion, 1);
+  assert.strictEqual(loaded.gold, 5);
+  assert.ok('mastery' in loaded);
+  assert.ok('settings' in loaded);
+});
+
+// Corrupt JSON → fallback to defaults
+it('corrupt save falls back to defaults (and toast call counted)', () => {
+  SaveManager.reset();
+  global.localStorage.setItem('claudes-math-marauder-save', '{not json');
+  const loaded = SaveManager.load();
+  assert.strictEqual(loaded.gold, 0);
+});
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail > 0 ? 1 : 0);
+```
+
+### 10. `scripts/validate-data.js` (stub)
+
+```js
+#!/usr/bin/env node
+// Validates claudes-math-marauder/data/*.json files.
+// Stub for Session 1 — Session 4 fleshes this out.
+console.log('OK (no data files yet — validator stub from Session 1)');
+process.exit(0);
+```
+
+### 11. `.claude/rules/marauder.md`
+
+Path-scoped architecture rules. Mirror `.claude/rules/lizzies-petstore.md` shape. Header:
+
+```markdown
+---
+paths:
+  - "claudes-math-marauder/**"
+---
+
+# Claude's Math Marauder — Architecture Rules
+
+## Single RAF Chain — game.js Owns the Loop
+[Same wording as KC4/Petstore rule, adapted for math-marauder managers (FightManager, BossFightManager, MapManager, AnimationManager, SpeechManager)]
+
+## Timer Lifecycle Pattern
+[Same pattern as Petstore]
+
+## Combat Determinism
+- Combat must be deterministic given (runSeed, masteryStateAtFightStart, inputSequence). Never call Math.random() inside combat code — always use the run-seeded PRNG. This is required for the replay harness (Session 13).
+- Distractors are shuffled with Fisher-Yates using the run-seeded PRNG.
+
+## Mastery Save Cadence
+- Update mastery in-memory per problem; commit to SaveManager once per fight at VICTORY/DEFEAT_RETRY (batch write).
+- Never call SaveManager.save() per problem (CLAUDE.md hot-path rule).
+
+## Combat Module Purity
+- Modules under combat/ must not import any DOM, canvas, or audio modules. They are pure logic so Node tests can require() them.
+- Visual effects, audio cues, and DOM updates live in fight.js's renderer/effect callbacks, called by the FightManager.
+
+[plus all the standard CLAUDE.md rules abbreviated]
+```
+
+### 12. `.claude/skills/marauder-checklist/SKILL.md`
+
+Mirror `.claude/skills/petstore-checklist/SKILL.md` exactly in shape, but adapt the bug-pattern table for math-marauder. Include sections:
+- Spec code patterns to fix (same patterns table as petstore-checklist, adapted)
+- Single RAF rule
+- Timer lifecycle pattern
+- Web Audio iOS quirks
+- Web Speech iOS quirks
+- ARIA rules (aria-hidden explicit, aria-pressed only on toggles, role="group" not role="list" for button grids)
+- `try/catch` async overlay timing
+- `SaveManager._defaults()` completeness
+- Re-entry guards on shared callbacks (`onFightComplete` reachable from VICTORY and DEFEAT_RETRY paths)
+- Visibility classes only — no `style.display`
+- Combat purity rule (no DOM/canvas in combat/)
+- Mastery save cadence rule
+- Stretch-fact eligibility (only families with `mastery.box >= 4 && totalCorrect >= 6`)
+
+### 13. `.claude/skills/validate-marauder-data/SKILL.md`
+
+```markdown
+---
+name: validate-marauder-data
+description: Validate all claudes-math-marauder data/*.json files for schema integrity, referential consistency, and contrast.
+---
+
+Run `node claudes-math-marauder/scripts/validate-data.js` and fix any reported errors.
+```
+
+### 14. `.claude/hooks/validate-marauder-data-hook.sh`
+
+Mirror `.claude/hooks/validate-petstore-data-hook.sh` verbatim, swap paths:
+
+```bash
+#!/bin/bash
+input=$(cat)
+fp=$(python3 -c "
+import json, sys
+try:
+    d = json.load(sys.stdin)
+    print(d.get('tool_input', {}).get('file_path', ''))
+except Exception:
+    print('')
+" 2>/dev/null <<< "$input")
+
+if [[ "$fp" == *"claudes-math-marauder/data/"* && "$fp" == *.json ]]; then
+    result=$(node claudes-math-marauder/scripts/validate-data.js 2>&1)
+    echo "$result"
+    if echo "$result" | grep -q "CRITICAL"; then
+        exit 2
+    fi
+fi
+```
+
+`chmod +x .claude/hooks/validate-marauder-data-hook.sh`.
+
+### 15. `.claude/agents/marauder-web-review/agent.md`
+
+Mirror `.claude/agents/petstore-web-review/agent.md` shape. Frontmatter:
+
+```markdown
+---
+name: marauder-web-review
+description: Senior web engineer code reviewer for claudes-math-marauder sessions. Use after implementing a session to catch bugs before committing.
+model: claude-sonnet-4-6
+memory: project
+---
+```
+
+Body checklist sections (adapt the petstore agent body):
+1. Combat correctness — orb shuffle uses run-seeded PRNG; distractors unique; mastery box update bounds
+2. Game loop correctness — single RAF, dt cap, dt-driven animations
+3. Touch input — Pointer Events, `touch-action: none`, ≥96px orbs, ≥72px numpad
+4. Timer/async safety — every manager's full timer lifecycle pattern
+5. State machine correctness — clean transitions, pause halts speech + animations
+6. Combat purity — no DOM/canvas in `combat/` modules
+7. Save system — `_defaults()` completeness, batch writes, schema migration
+8. Mastery engine — Leitner box update bounds, stretch-fact gate, recency damping
+9. Audio — lazy AudioContext, `cancel()` + 50ms delay for speech, no harsh sounds
+10. ARIA — explicit `aria-hidden`, `aria-pressed` only on toggles, `role="group"` for button grids, dynamic `aria-label` follows `textContent`
+11. Performance — no per-frame `SaveManager.load()`, no per-frame allocs in `update`/`draw`
+12. Accessibility — OpenDyslexic + Comic Sans, 16pt min, cream/`#2C2416` palette, ≥4.5:1 contrast, ≥44px targets
+13. Edge cases — corrupt save, 0 mastery, 100% mastery, rapid-tap, Web Speech absent, AudioContext blocked
+
+### 16. `.github/scripts/update-index.js` modification
+
+Add to `manualGameConfig`:
+```js
+"claudes-math-marauder": {
+  icon: "🤖⚔️📐",
+  title: "Claude's Math Marauder",
+  description: "Claude built this fantasy roguelike where you cast multiplication and division spells to defeat goblins, dragons, and liches.",
+  category: "learning",
+},
+```
+
+Run `node .github/scripts/update-index.js` to verify the index regenerates without error and confirm the card appears in `index.html`.
+
+### 17. `.claude/settings.json` modification
+
+Add the new hook to `hooks.PostToolUse[0].hooks` array (alongside the existing four hooks):
+```json
+{ "type": "command", "command": "bash .claude/hooks/validate-marauder-data-hook.sh" }
+```
+
+## Tests to run
+
+```bash
+node claudes-math-marauder/scripts/test-save-migration.js     # all PASS
+node claudes-math-marauder/scripts/validate-data.js           # OK (stub)
+node .github/scripts/update-index.js                          # regenerates index.html
+```
+
+Then open `index.html` in a browser. Verify:
+- Title screen renders with cream background, dark text, OpenDyslexic font
+- "Begin" button click transitions to HUB (a placeholder screen — empty for now)
+- No console errors
+
+## Acceptance checklist
+
+- [ ] `index.html` registered in `update-index.js` and visible on the regenerated repo index page
+- [ ] `js/save.js` UMD-exports SaveManager so both browser and Node `require()` work
+- [ ] `_defaults()` returns every key listed in plan.md's save schema (10 mastery + 10 settings keys + all top-level keys)
+- [ ] `node scripts/test-save-migration.js` reports zero failures (5+ tests pass)
+- [ ] `Game.init()` boots the RAF loop; pause halts updates (set `state = PAUSED` and confirm `_update` not called)
+- [ ] DPR scaling correctly applied (resize window, no blur)
+- [ ] `.claude/rules/marauder.md` is path-scoped via frontmatter and auto-loads when editing files under `claudes-math-marauder/`
+- [ ] `/marauder-checklist` skill prints expected output
+- [ ] `/validate-marauder-data` skill runs the validator script
+- [ ] PostToolUse hook entry added to `.claude/settings.json` and the hook is `chmod +x`
+- [ ] `marauder-web-review` agent definition exists at the expected path
+- [ ] No `style.display` assignments in JS (visibility uses classes)
+- [ ] No `user-scalable=no` in viewport meta
+- [ ] Initial commit includes all of the above
+
+## Session end
+
+1. `node claudes-math-marauder/scripts/test-save-migration.js` — must PASS
+2. `node .github/scripts/update-index.js` — index regenerates without error
+3. Run `marauder-web-review` agent against the session's diff
+4. Commit with message `Session 1: scaffold claudes-math-marauder + tooling`
+5. Push to `main`

--- a/claudes-math-marauder/sessions/session-02.md
+++ b/claudes-math-marauder/sessions/session-02.md
@@ -1,0 +1,583 @@
+# Session 2 — Math Engine: Problem Generation, Distractors, Mastery
+**Model:** Opus | **Focus:** Pure-logic combat layer with full TDD coverage
+
+This session writes every deterministic combat module — fact keys, mastery (Leitner), problem generation, distractor generation — and their Node-runnable tests. **No DOM, no canvas, no audio.** When this session is done, `node scripts/test-*.js` reports zero failures and every Layer-1 test from plan.md is in place.
+
+## Pre-flight
+
+1. Read `plan.md` (mastery engine section).
+2. Read `docs/superpowers/specs/2026-05-01-claudes-math-marauder-design.md` sections 3.3, 6.5.
+3. Run `/marauder-checklist`.
+
+## Files to create
+
+- `claudes-math-marauder/js/combat/factKeys.js`
+- `claudes-math-marauder/js/combat/mastery.js`
+- `claudes-math-marauder/js/combat/problemGen.js`
+- `claudes-math-marauder/js/combat/distractors.js`
+- `claudes-math-marauder/scripts/test-fact-keys.js`
+- `claudes-math-marauder/scripts/test-mastery.js`
+- `claudes-math-marauder/scripts/test-problem-gen.js`
+- `claudes-math-marauder/scripts/test-distractors.js`
+
+All combat modules use the same UMD-export pattern as `save.js` so Node tests can `require()` them directly.
+
+## Deliverables
+
+### 1. `combat/factKeys.js` — Canonical key construction
+
+```js
+(function(global) {
+  'use strict';
+
+  function mulKey(a, b) {
+    const lo = Math.min(a, b);
+    const hi = Math.max(a, b);
+    return `mul:${lo}x${hi}`;
+  }
+
+  // Division key uses larger ÷ smaller form so 56÷7 and 56÷8 are different keys (they are different facts) but 56÷7 vs 7÷56 collapse to the same one.
+  function divKey(dividend, divisor) {
+    const hi = Math.max(dividend, divisor);
+    const lo = Math.min(dividend, divisor);
+    return `div:${hi}/${lo}`;
+  }
+
+  function parseFactKey(key) {
+    const m = /^mul:(\d+)x(\d+)$/.exec(key);
+    if (m) return { kind: 'mul', a: +m[1], b: +m[2] };
+    const d = /^div:(\d+)\/(\d+)$/.exec(key);
+    if (d) return { kind: 'div', dividend: +d[1], divisor: +d[2] };
+    return null;
+  }
+
+  // Canonical fact family from a key (e.g. "mul:7x8" → "x7" or "x8" — pick the smaller for family weighting)
+  function familyOf(key) {
+    const f = parseFactKey(key);
+    if (!f) return null;
+    if (f.kind === 'mul') return `x${Math.min(f.a, f.b)}`;
+    return `x${f.divisor}`;
+  }
+
+  const exp = { mulKey, divKey, parseFactKey, familyOf };
+  if (typeof module !== 'undefined' && module.exports) module.exports = exp;
+  else global.FactKeys = exp;
+})(typeof window !== 'undefined' ? window : globalThis);
+```
+
+### 2. `combat/mastery.js` — Leitner box engine
+
+```js
+(function(global) {
+  'use strict';
+  const { mulKey, divKey, familyOf } = (typeof require !== 'undefined') ? require('./factKeys.js') : global.FactKeys;
+
+  const BOX_WEIGHT = { 1: 5, 2: 4, 3: 3, 4: 2, 5: 1 };
+  const SHAKY_MULTIPLIER = 2.5;
+  const RECENCY_WINDOW = 5;
+  const RECENCY_DAMPING = 0.3;
+  const MASTERED_BOX = 4;
+  const MASTERED_MIN_CORRECT = 6;
+
+  function getOrCreate(masteryMap, key) {
+    if (!masteryMap[key]) {
+      masteryMap[key] = { box: 1, lastSeenAt: 0, totalAsked: 0, totalCorrect: 0, avgMs: 0, streak: 0, shaky: false };
+    }
+    return masteryMap[key];
+  }
+
+  function isMastered(stat) {
+    return stat && stat.box >= MASTERED_BOX && stat.totalCorrect >= MASTERED_MIN_CORRECT;
+  }
+
+  // Update box on a resolve event.
+  // ctx.masteredAvgMs = average answer time across all currently-mastered facts (or null if none) — passed in so we don't recompute it here.
+  function recordResolve(masteryMap, key, { correct, timeMs, now, masteredAvgMs }) {
+    const s = getOrCreate(masteryMap, key);
+    s.totalAsked++;
+    s.lastSeenAt = now;
+    if (correct) {
+      s.totalCorrect++;
+      s.streak++;
+      const fastThreshold = (masteredAvgMs ?? 4000) * 2;  // if no mastered baseline, treat <8s as "fast"
+      const fast = timeMs < fastThreshold;
+      if (fast) s.box = Math.min(5, s.box + 1);
+      // running average
+      s.avgMs = s.avgMs === 0 ? timeMs : Math.round((s.avgMs * 0.7) + (timeMs * 0.3));
+    } else {
+      s.streak = 0;
+      s.box = Math.max(1, s.box - 2);
+      s.shaky = true;
+    }
+    // Mastered facts can shed the shaky flag after 3 consecutive correct
+    if (correct && s.streak >= 3) s.shaky = false;
+    return s;
+  }
+
+  function masteredAvgMs(masteryMap) {
+    const stats = Object.values(masteryMap).filter(isMastered);
+    if (stats.length === 0) return null;
+    const sum = stats.reduce((acc, s) => acc + (s.avgMs || 0), 0);
+    return Math.round(sum / stats.length);
+  }
+
+  function pullWeight(stat, recentKeys) {
+    const box = stat ? stat.box : 1;
+    const w = BOX_WEIGHT[box] ?? 1;
+    const sh = stat && stat.shaky ? SHAKY_MULTIPLIER : 1.0;
+    const rd = recentKeys && recentKeys.includes(_keyOf(stat)) ? RECENCY_DAMPING : 1.0;
+    return w * sh * rd;
+  }
+  // Note: recencyDamping wants the key, so the caller passes in the key alongside the stat; see `selectFact` in problemGen.js.
+
+  function _keyOf() { return null; }  // unused; kept for shape
+
+  const exp = { recordResolve, isMastered, masteredAvgMs, pullWeight, getOrCreate, BOX_WEIGHT, MASTERED_BOX, MASTERED_MIN_CORRECT, SHAKY_MULTIPLIER, RECENCY_DAMPING, RECENCY_WINDOW };
+  if (typeof module !== 'undefined' && module.exports) module.exports = exp;
+  else global.Mastery = exp;
+})(typeof window !== 'undefined' ? window : globalThis);
+```
+
+### 3. `combat/problemGen.js` — Weighted selection + stretch facts
+
+```js
+(function(global) {
+  'use strict';
+  const FK = (typeof require !== 'undefined') ? require('./factKeys.js') : global.FactKeys;
+  const M  = (typeof require !== 'undefined') ? require('./mastery.js')  : global.Mastery;
+
+  // Build the eligible fact keys for a realm given factFamilyWeights.
+  // factFamilyWeights example: { "x0":0, "x1":0.05, "x2":0.10, "x3":0.10, "x4":0.10, "x5":0.20, "x6":0.10, "x7":0, "x8":0, "x9":0, "x10":0.20, "x11":0, "x12":0.15 }
+  // For each enabled family x_n, we include both:
+  //   mul keys:  mulKey(n, k)  for k in [0..12]
+  //   div keys:  divKey(n*k, n) for k in [1..12]   (canonical larger÷smaller form keeps it as div:NN/n)
+  function buildEligibleKeys(factFamilyWeights) {
+    const out = [];
+    Object.entries(factFamilyWeights).forEach(([fam, w]) => {
+      if (w <= 0) return;
+      const n = +fam.slice(1);
+      for (let k = 0; k <= 12; k++) out.push(FK.mulKey(n, k));
+      for (let k = 1; k <= 12; k++) {
+        const dividend = n * k;
+        if (dividend === 0) continue;  // skip 0÷n which is a degenerate fact
+        out.push(FK.divKey(dividend, Math.min(n, k) === 0 ? 1 : Math.min(n, k)));
+        // Note: divKey takes (dividend, divisor); we want both n and k as candidate divisors
+        // Because mulKey collapses commutative pairs, each underlying multiplication produces 2 division facts (÷n and ÷k) when n != k.
+      }
+    });
+    // Dedupe (the loop above can produce duplicates from commutative families)
+    return Array.from(new Set(out));
+  }
+
+  // Sample a problem. masteryMap is the save's mastery object (mutated externally).
+  // recentKeys is an array (newest-last) of the last RECENCY_WINDOW keys answered in this session — caller maintains it.
+  // rng is a 0..1 RNG (run-seeded).
+  // realmTier is 1..5 (Goblin Forest=1 ... Lich Citadel=5).
+  function selectProblem({ realm, masteryMap, recentKeys, rng, mulRatio, allowStretch, realmTier }) {
+    const stretchProb = 0.10 + 0.02 * (realmTier - 1);
+    if (allowStretch && rng() < stretchProb) {
+      const stretch = _selectStretch({ masteryMap, rng });
+      if (stretch) return stretch;
+    }
+    const eligible = buildEligibleKeys(realm.factFamilyWeights);
+    const weights = eligible.map(k => {
+      const stat = masteryMap[k];
+      const box = stat ? stat.box : 1;
+      const w = M.BOX_WEIGHT[box] ?? 1;
+      const sh = stat && stat.shaky ? M.SHAKY_MULTIPLIER : 1.0;
+      const rd = recentKeys.includes(k) ? M.RECENCY_DAMPING : 1.0;
+      return w * sh * rd;
+    });
+    const ratio = mulRatio ?? 0.7;
+    const isMul = rng() < ratio;
+    // Filter by kind
+    const indices = [];
+    const kindWeights = [];
+    eligible.forEach((k, i) => {
+      const isThisMul = k.startsWith('mul:');
+      if (isMul === isThisMul) { indices.push(i); kindWeights.push(weights[i]); }
+    });
+    const idx = _weightedPick(indices, kindWeights, rng);
+    const key = eligible[idx];
+    return _materialize(key);
+  }
+
+  function _materialize(key) {
+    const f = FK.parseFactKey(key);
+    if (f.kind === 'mul') {
+      const a = f.a, b = f.b;
+      return { kind: 'mul', a, b, answer: a * b, displayText: `${a} × ${b} = ?`, factKey: key, isStretch: false };
+    } else {
+      const dividend = f.dividend, divisor = f.divisor;
+      return { kind: 'div', a: dividend, b: divisor, answer: dividend / divisor, displayText: `${dividend} ÷ ${divisor} = ?`, factKey: key, isStretch: false };
+    }
+  }
+
+  // Stretch facts: only from families [x2, x5, x10] AND only when that family's mastered count is ≥ 4 (== "family is solid")
+  function _selectStretch({ masteryMap, rng }) {
+    const families = ['x2', 'x5', 'x10'];
+    const ranges = { x2: [13, 50], x5: [13, 30], x10: [13, 30] };
+    const eligibleFamilies = families.filter(fam => {
+      const n = +fam.slice(1);
+      // count how many facts in this family are mastered
+      let mastered = 0;
+      for (let k = 0; k <= 12; k++) {
+        const key = FK.mulKey(n, k);
+        if (M.isMastered(masteryMap[key])) mastered++;
+      }
+      return mastered >= 4;
+    });
+    if (eligibleFamilies.length === 0) return null;
+    const fam = eligibleFamilies[Math.floor(rng() * eligibleFamilies.length)];
+    const n = +fam.slice(1);
+    const [lo, hi] = ranges[fam];
+    const N = lo + Math.floor(rng() * (hi - lo + 1));
+    const isMul = rng() < 0.6;
+    if (isMul) {
+      return { kind: 'mul', a: n, b: N, answer: n * N, displayText: `${n} × ${N} = ?`, factKey: `stretch:mul:${n}x${N}`, isStretch: true };
+    } else {
+      const dividend = n * N;
+      return { kind: 'div', a: dividend, b: n, answer: N, displayText: `${dividend} ÷ ${n} = ?`, factKey: `stretch:div:${dividend}/${n}`, isStretch: true };
+    }
+  }
+
+  function _weightedPick(items, weights, rng) {
+    const total = weights.reduce((a, b) => a + b, 0);
+    if (total === 0) return items[Math.floor(rng() * items.length)];
+    let r = rng() * total;
+    for (let i = 0; i < items.length; i++) {
+      r -= weights[i];
+      if (r <= 0) return items[i];
+    }
+    return items[items.length - 1];
+  }
+
+  const exp = { selectProblem, buildEligibleKeys, _selectStretch, _materialize };
+  if (typeof module !== 'undefined' && module.exports) module.exports = exp;
+  else global.ProblemGen = exp;
+})(typeof window !== 'undefined' ? window : globalThis);
+```
+
+### 4. `combat/distractors.js` — Orb distractor generation
+
+```js
+(function(global) {
+  'use strict';
+
+  // Returns 4 numbers: 1 correct + 3 close-miss distractors. Always sorted/shuffled by caller using the run-seeded rng.
+  // problem: { kind, a, b, answer }
+  // rng: 0..1 RNG
+  function generateDistractors(problem, rng) {
+    const correct = problem.answer;
+    const candidates = new Set();
+
+    if (problem.kind === 'mul') {
+      const { a, b } = problem;
+      candidates.add(a * (b + 1));
+      candidates.add(a * (b - 1));
+      candidates.add((a + 1) * b);
+      candidates.add((a - 1) * b);
+      candidates.add(correct + 1);
+      candidates.add(correct - 1);
+      candidates.add(correct + 10);
+      candidates.add(correct - 10);
+      candidates.add(a + b);                 // common kid mistake: confuse + and ×
+    } else {
+      const { a: dividend, b: divisor } = problem;
+      candidates.add(correct + 1);
+      candidates.add(correct - 1);
+      candidates.add(correct + 2);
+      candidates.add(dividend - divisor);    // confuse - and ÷
+      candidates.add(dividend / (divisor === 1 ? 2 : (divisor - 1)));
+      candidates.add(dividend / (divisor + 1));
+    }
+
+    // Filter: positive integers, not equal to correct, plausible range
+    const filtered = Array.from(candidates).filter(v => Number.isInteger(v) && v >= 0 && v !== correct && v <= 999);
+
+    // Pick 3 unique close-misses, prefer the closest to correct
+    filtered.sort((x, y) => Math.abs(x - correct) - Math.abs(y - correct));
+
+    // Take more than 3, then shuffle to randomize within close-miss tier
+    const pool = filtered.slice(0, Math.max(6, filtered.length));
+    // Fisher-Yates with the run-seeded rng
+    for (let i = pool.length - 1; i > 0; i--) {
+      const j = Math.floor(rng() * (i + 1));
+      [pool[i], pool[j]] = [pool[j], pool[i]];
+    }
+    const distractors = [];
+    for (const v of pool) {
+      if (distractors.length === 3) break;
+      if (!distractors.includes(v)) distractors.push(v);
+    }
+
+    // If we couldn't find 3 unique distractors (pathological case e.g. answer=0), fill with safe fallbacks
+    let pad = 1;
+    while (distractors.length < 3) {
+      const fallback = correct + pad;
+      if (!distractors.includes(fallback) && fallback !== correct && fallback >= 0) distractors.push(fallback);
+      pad++;
+      if (pad > 50) break;  // safety
+    }
+
+    const orbs = [correct, ...distractors];
+    // Final shuffle
+    for (let i = orbs.length - 1; i > 0; i--) {
+      const j = Math.floor(rng() * (i + 1));
+      [orbs[i], orbs[j]] = [orbs[j], orbs[i]];
+    }
+    return orbs;
+  }
+
+  const exp = { generateDistractors };
+  if (typeof module !== 'undefined' && module.exports) module.exports = exp;
+  else global.Distractors = exp;
+})(typeof window !== 'undefined' ? window : globalThis);
+```
+
+### 5. `scripts/test-fact-keys.js`
+
+```js
+const FK = require('../js/combat/factKeys.js');
+const assert = require('assert');
+let p=0,f=0; function it(n,fn){try{fn();console.log('PASS',n);p++}catch(e){console.error('FAIL',n,e.message);f++}}
+
+it('mulKey collapses commutative pairs', () => {
+  assert.strictEqual(FK.mulKey(7, 8), 'mul:7x8');
+  assert.strictEqual(FK.mulKey(8, 7), 'mul:7x8');
+});
+it('divKey uses larger / smaller', () => {
+  assert.strictEqual(FK.divKey(56, 7), 'div:56/7');
+  assert.strictEqual(FK.divKey(7, 56), 'div:56/7');
+});
+it('parseFactKey round-trips', () => {
+  const m = FK.parseFactKey('mul:7x8');
+  assert.deepStrictEqual(m, { kind: 'mul', a: 7, b: 8 });
+  const d = FK.parseFactKey('div:56/7');
+  assert.deepStrictEqual(d, { kind: 'div', dividend: 56, divisor: 7 });
+});
+
+console.log(`\n${p} passed, ${f} failed`);
+process.exit(f>0?1:0);
+```
+
+### 6. `scripts/test-mastery.js`
+
+```js
+const M = require('../js/combat/mastery.js');
+const assert = require('assert');
+let p=0,f=0; function it(n,fn){try{fn();console.log('PASS',n);p++}catch(e){console.error('FAIL',n,e.message);f++}}
+
+it('correct + fast → box increments', () => {
+  const map = {};
+  M.recordResolve(map, 'mul:7x8', { correct: true, timeMs: 1000, now: 1, masteredAvgMs: 2000 });
+  assert.strictEqual(map['mul:7x8'].box, 2);
+  M.recordResolve(map, 'mul:7x8', { correct: true, timeMs: 1000, now: 2, masteredAvgMs: 2000 });
+  assert.strictEqual(map['mul:7x8'].box, 3);
+});
+
+it('correct + slow → box unchanged', () => {
+  const map = {};
+  // Box starts at 1; without an existing mastered baseline, fastThreshold defaults to 8000
+  M.recordResolve(map, 'mul:7x8', { correct: true, timeMs: 9000, now: 1, masteredAvgMs: null });
+  assert.strictEqual(map['mul:7x8'].box, 1);
+});
+
+it('wrong → box decrements by 2 (floored at 1) and shaky=true', () => {
+  const map = {};
+  // raise to 4
+  for (let i = 0; i < 3; i++) M.recordResolve(map, 'mul:7x8', { correct: true, timeMs: 1000, now: i+1, masteredAvgMs: 2000 });
+  assert.strictEqual(map['mul:7x8'].box, 4);
+  M.recordResolve(map, 'mul:7x8', { correct: false, timeMs: 6000, now: 99, masteredAvgMs: 2000 });
+  assert.strictEqual(map['mul:7x8'].box, 2);
+  assert.strictEqual(map['mul:7x8'].shaky, true);
+});
+
+it('wrong from box 1 stays at box 1', () => {
+  const map = {};
+  M.recordResolve(map, 'mul:1x1', { correct: false, timeMs: 1000, now: 1, masteredAvgMs: null });
+  assert.strictEqual(map['mul:1x1'].box, 1);
+});
+
+it('mastered = box>=4 && totalCorrect>=6', () => {
+  const map = {};
+  for (let i = 0; i < 5; i++) M.recordResolve(map, 'mul:7x8', { correct: true, timeMs: 1000, now: i+1, masteredAvgMs: 2000 });
+  // box should be at 5, totalCorrect=5 — not yet mastered
+  assert.strictEqual(M.isMastered(map['mul:7x8']), false);
+  M.recordResolve(map, 'mul:7x8', { correct: true, timeMs: 1000, now: 6, masteredAvgMs: 2000 });
+  assert.strictEqual(M.isMastered(map['mul:7x8']), true);
+});
+
+it('shaky clears after 3-correct streak', () => {
+  const map = {};
+  M.recordResolve(map, 'mul:7x8', { correct: false, timeMs: 6000, now: 1, masteredAvgMs: null });
+  assert.strictEqual(map['mul:7x8'].shaky, true);
+  M.recordResolve(map, 'mul:7x8', { correct: true, timeMs: 1000, now: 2, masteredAvgMs: null });
+  M.recordResolve(map, 'mul:7x8', { correct: true, timeMs: 1000, now: 3, masteredAvgMs: null });
+  M.recordResolve(map, 'mul:7x8', { correct: true, timeMs: 1000, now: 4, masteredAvgMs: null });
+  assert.strictEqual(map['mul:7x8'].shaky, false);
+});
+
+it('100-problem simulation converges most facts to box ≥ 3', () => {
+  const map = {};
+  const keys = ['mul:5x6','mul:5x7','mul:6x7','mul:7x8','mul:8x9','mul:6x9'];
+  for (let i = 0; i < 100; i++) {
+    const k = keys[i % keys.length];
+    M.recordResolve(map, k, { correct: true, timeMs: 1500, now: i, masteredAvgMs: 2000 });
+  }
+  for (const k of keys) assert.ok(map[k].box >= 3, `${k} box ${map[k].box}`);
+});
+
+console.log(`\n${p} passed, ${f} failed`);
+process.exit(f>0?1:0);
+```
+
+### 7. `scripts/test-problem-gen.js`
+
+```js
+const PG = require('../js/combat/problemGen.js');
+const FK = require('../js/combat/factKeys.js');
+const assert = require('assert');
+let p=0,f=0; function it(n,fn){try{fn();console.log('PASS',n);p++}catch(e){console.error('FAIL',n,e.message);f++}}
+
+// Mulberry32 with fixed seed for determinism
+function makeRng(seed) {
+  let s = seed | 0;
+  return () => {
+    s = (s + 0x6D2B79F5) | 0;
+    let t = Math.imul(s ^ (s >>> 15), 1 | s);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 0xFFFFFFFF;
+  };
+}
+
+const realm1 = { factFamilyWeights: { x2: 0.2, x5: 0.4, x10: 0.4 } };
+
+it('every multiplication answer is correct', () => {
+  const rng = makeRng(1);
+  const map = {};
+  for (let i = 0; i < 200; i++) {
+    const prob = PG.selectProblem({ realm: realm1, masteryMap: map, recentKeys: [], rng, mulRatio: 1.0, allowStretch: false, realmTier: 1 });
+    if (prob.kind === 'mul') assert.strictEqual(prob.answer, prob.a * prob.b);
+  }
+});
+
+it('every division answer is integer and correct', () => {
+  const rng = makeRng(2);
+  const map = {};
+  for (let i = 0; i < 200; i++) {
+    const prob = PG.selectProblem({ realm: realm1, masteryMap: map, recentKeys: [], rng, mulRatio: 0, allowStretch: false, realmTier: 1 });
+    if (prob.kind === 'div') {
+      assert.ok(Number.isInteger(prob.answer), `non-integer: ${prob.displayText}`);
+      assert.strictEqual(prob.a / prob.b, prob.answer);
+    }
+  }
+});
+
+it('determinism: same seed + state produces same problem sequence', () => {
+  const seq1 = [];
+  const rng1 = makeRng(42);
+  for (let i = 0; i < 30; i++) seq1.push(PG.selectProblem({ realm: realm1, masteryMap: {}, recentKeys: [], rng: rng1, mulRatio: 0.7, allowStretch: false, realmTier: 1 }).factKey);
+  const seq2 = [];
+  const rng2 = makeRng(42);
+  for (let i = 0; i < 30; i++) seq2.push(PG.selectProblem({ realm: realm1, masteryMap: {}, recentKeys: [], rng: rng2, mulRatio: 0.7, allowStretch: false, realmTier: 1 }).factKey);
+  assert.deepStrictEqual(seq1, seq2);
+});
+
+it('stretch facts gated: empty mastery never produces stretch', () => {
+  const rng = makeRng(99);
+  for (let i = 0; i < 200; i++) {
+    const prob = PG.selectProblem({ realm: realm1, masteryMap: {}, recentKeys: [], rng, mulRatio: 0.7, allowStretch: true, realmTier: 5 });
+    assert.strictEqual(prob.isStretch, false);
+  }
+});
+
+it('stretch facts produced when family mastered (5s)', () => {
+  const map = {};
+  // mark all 5xN for N=0..12 as mastered
+  for (let k = 0; k <= 12; k++) map[FK.mulKey(5, k)] = { box: 5, lastSeenAt: 1, totalAsked: 10, totalCorrect: 10, avgMs: 1000, streak: 5, shaky: false };
+  const rng = makeRng(123);
+  let stretchCount = 0;
+  for (let i = 0; i < 1000; i++) {
+    const prob = PG.selectProblem({ realm: realm1, masteryMap: map, recentKeys: [], rng, mulRatio: 0.7, allowStretch: true, realmTier: 5 });
+    if (prob.isStretch) stretchCount++;
+  }
+  // expected ~0.20 in tier 5; check it's between 10% and 30%
+  assert.ok(stretchCount > 100 && stretchCount < 300, `stretchCount=${stretchCount}`);
+});
+
+console.log(`\n${p} passed, ${f} failed`);
+process.exit(f>0?1:0);
+```
+
+### 8. `scripts/test-distractors.js`
+
+```js
+const D = require('../js/combat/distractors.js');
+const assert = require('assert');
+let p=0,f=0; function it(n,fn){try{fn();console.log('PASS',n);p++}catch(e){console.error('FAIL',n,e.message);f++}}
+function rng() { return Math.random(); }   // for non-determinism tests; determinism is tested in problem-gen
+
+it('mul: 4 unique values, exactly one matches answer', () => {
+  for (let a = 0; a <= 12; a++) for (let b = 0; b <= 12; b++) {
+    const orbs = D.generateDistractors({ kind: 'mul', a, b, answer: a * b }, rng);
+    assert.strictEqual(orbs.length, 4);
+    const unique = new Set(orbs);
+    assert.strictEqual(unique.size, 4, `orbs not unique for ${a}×${b}: ${orbs}`);
+    assert.strictEqual(orbs.filter(v => v === a * b).length, 1);
+    orbs.forEach(v => assert.ok(v >= 0 && v <= 999, `orb out of range: ${v}`));
+  }
+});
+
+it('div: 4 unique values, exactly one matches answer', () => {
+  for (let a = 1; a <= 12; a++) for (let b = 1; b <= 12; b++) {
+    const dividend = a * b;
+    const divisor = a;
+    const orbs = D.generateDistractors({ kind: 'div', a: dividend, b: divisor, answer: b }, rng);
+    assert.strictEqual(orbs.length, 4);
+    const unique = new Set(orbs);
+    assert.strictEqual(unique.size, 4);
+    assert.strictEqual(orbs.filter(v => v === b).length, 1);
+  }
+});
+
+it('1000 random pairs: no negative orbs, no zero-division pathologies', () => {
+  for (let i = 0; i < 1000; i++) {
+    const a = Math.floor(Math.random() * 13);
+    const b = Math.floor(Math.random() * 13);
+    const orbs = D.generateDistractors({ kind: 'mul', a, b, answer: a * b }, rng);
+    orbs.forEach(v => assert.ok(v >= 0, `negative orb: ${v}`));
+  }
+});
+
+console.log(`\n${p} passed, ${f} failed`);
+process.exit(f>0?1:0);
+```
+
+## Tests to run
+
+```bash
+node claudes-math-marauder/scripts/test-fact-keys.js
+node claudes-math-marauder/scripts/test-mastery.js
+node claudes-math-marauder/scripts/test-problem-gen.js
+node claudes-math-marauder/scripts/test-distractors.js
+```
+
+All four must report `0 failed`.
+
+## Acceptance checklist
+
+- [ ] `combat/factKeys.js` — UMD-export, `mulKey` collapses commutative pairs, `divKey` uses larger÷smaller form
+- [ ] `combat/mastery.js` — Leitner box update bounds (1..5), `mastered` flag, `shaky` clear-on-3-streak
+- [ ] `combat/problemGen.js` — weighted selection, stretch-fact gate, determinism with same seed
+- [ ] `combat/distractors.js` — always 4 unique orbs, exactly one correct, all in plausible range
+- [ ] All four `test-*.js` scripts pass (zero failures)
+- [ ] No DOM, canvas, or audio imports anywhere under `combat/` (grep `js/combat/` for `document|canvas|AudioContext|requestAnimationFrame` — must be empty)
+- [ ] No `Math.random()` calls inside `combat/` modules (combat must be deterministic via injected rng) — distractors.js's fallback shuffle uses the passed-in rng only
+
+## Session end
+
+1. Run all four test scripts — confirm zero failures
+2. Run `marauder-web-review` agent
+3. Commit `Session 2: math engine — problem gen, distractors, Leitner mastery + tests`
+4. Push to `main`

--- a/claudes-math-marauder/sessions/session-03.md
+++ b/claudes-math-marauder/sessions/session-03.md
@@ -1,0 +1,193 @@
+# Session 3 — Comic Renderer + Monster Schema + Animation
+**Model:** Opus | **Focus:** Visual identity — comic-effects library, parametric monsters, animation system
+
+This session builds the look. By the end, a debug screen renders one of every comic primitive plus three sample monsters with idle animations. No combat yet.
+
+## Pre-flight
+
+1. Read `plan.md` (rendering section).
+2. Read spec sections 4 (Visual Renderer & Comic Style) — full text.
+3. Read `keyboard-command-4/js/renderer.js` for the canvas-rendering precedent (procedural monster rendering, single-RAF integration).
+4. Read `lizzies-petstore/js/creature-cache.js` for the offscreen-cache + LRU pattern.
+5. Run `/marauder-checklist`.
+
+## Files to create
+
+- `claudes-math-marauder/js/fx/comicfx.js`
+- `claudes-math-marauder/js/fx/shapes.js`
+- `claudes-math-marauder/js/fx/monsterRenderer.js`
+- `claudes-math-marauder/js/fx/wizardRenderer.js`
+- `claudes-math-marauder/js/fx/animation.js`
+- `claudes-math-marauder/js/fx/particles.js`
+- `claudes-math-marauder/js/fx/cache.js` — offscreen-canvas LRU manager
+
+## Files to modify
+
+- `claudes-math-marauder/js/game.js` — add a hidden "Render Demo" screen (toggled by a debug button on the title screen for now) so we can visually check primitives without combat
+
+## Deliverables
+
+### 1. `fx/cache.js` — Offscreen canvas cache + LRU
+
+API:
+```js
+class FxCache {
+  constructor(maxCanvases = 30) { this.max = maxCanvases; this._map = new Map(); this._lru = []; }
+  get(key) { /* return canvas or null; update LRU position */ }
+  build(key, w, h, drawFn) { /* create canvas, call drawFn(ctx, w, h), store; evict LRU if over capacity */ }
+  invalidate(key) { /* remove and free */ }
+  size() { return this._map.size; }
+}
+```
+
+LRU update **only** in `build()` and `get()`. Never touch LRU inside the draw loop. (CLAUDE.md hot-path rule.)
+
+### 2. `fx/comicfx.js` — Effect primitives
+
+Required functions (all called as plain functions, ctx-injected):
+
+```js
+inkOutline(ctx, pathFn, weight = 4, color = '#1a1a1a', wobbleSeed = 0)
+halftoneFill(ctx, x, y, w, h, color, density = 0.04, seed = 0)
+speedLines(ctx, ox, oy, dirRad, n = 8, len = 80, color = '#1a1a1a')
+burstText(ctx, x, y, text, size = 48, color = '#f0d840', strokeColor = '#1a1a1a')
+panelFlash(ctx, w, h, color, alpha)         // single-frame screen tint
+inkBurst(ctx, x, y, radius, color, n = 20, seed = 0)
+panelBorder(ctx, x, y, w, h, weight = 6, color = '#1a1a1a')
+screenShake(now, intensity, untilMs)         // returns {dx, dy} for the caller to translate by
+```
+
+**Implementation notes:**
+- `halftoneFill`: build a small offscreen pattern canvas (e.g. 64×64) with seeded-PRNG dot positions, then `ctx.createPattern(...)` it. Cache by `(color, density)` in `FxCache` keyed `halftone:${color}:${density}`.
+- `wobbleStroke` (helper used by `inkOutline`): perturb each path point by `(rng() - 0.5) * jitterAmount`. Use `seededRandom(wobbleSeed)` so re-renders of the same outlined shape look identical (Petstore rule).
+- `burstText`: draw text twice — fat stroke first, then fill. Apply small per-call rotation `(rng() * 0.1 - 0.05)` for jitter.
+- `screenShake`: helper, not a draw method. Caller translates `ctx` by the returned `(dx, dy)` before drawing the world layer, restoring after.
+- `panelFlash`: caller passes `alpha` (already evaluated by an animation curve outside this function).
+- All effects use the seeded PRNG; never `Math.random()`.
+
+### 3. `fx/shapes.js` — Primitive shape generators
+
+Required exported functions, each returning a `pathFn(ctx)` that can be passed to `inkOutline`:
+
+- `blob({ rx, ry, wobble, seed })` — irregular oval
+- `egg({ rx, ry, scale, tilt, seed })` — egg/skull shape
+- `comicEyesPair({ size, expr, seed })` — two big white eyes with black pupils; expr ∈ `{angry, surprised, happy, neutral, dead}`
+- `fangGrin({ width, height, seed })` — comic mouth with two fangs
+- `stubArm({ length, width, side, seed })`
+- `bonyArm({ length, width, side, seed })`
+- `tail({ length, segments, seed })`
+- `hornsPair({ size, kind, seed })` — kind ∈ `{ram, demon, antler}`
+- `wingsPair({ size, kind, seed })` — kind ∈ `{bat, feather, mech}`
+
+Each shape generator builds its path with `ctx.beginPath(); ...; ctx.closePath()` and returns the `pathFn`. The caller passes that to `inkOutline`. Inside the path, fill is applied separately (caller's choice — solid color, halftone pattern, gradient).
+
+### 4. `fx/monsterRenderer.js`
+
+```js
+class MonsterRenderer {
+  constructor(fxCache) { this._cache = fxCache; }
+
+  // Build cached part canvases for a given monster + palette.
+  // Returns a "compiled" object with one canvas per part.
+  buildCreature(monster) { /* read monster.shape, render each part to its own offscreen canvas, return { parts: { body, head, eyes, ... }, bbox } */ }
+
+  // Composite parts onto ctx with anim transforms.
+  // animState comes from the AnimationManager — has phase, hitFlash, attackProgress, etc.
+  drawCreature(ctx, x, y, compiled, animState) {
+    // 1. Apply screen-shake offset if animState.shake is active
+    // 2. Translate to monster anchor
+    // 3. For each part in z-order, ctx.save() / translate / rotate / scale based on animState / drawImage / restore
+    // 4. Hit flash: if animState.flashAlpha > 0, after compositing draw a white-tinted overlay at globalAlpha = flashAlpha
+  }
+
+  // Re-cache only the affected part when palette changes (rare for monsters; common for wizard portraits when class swaps).
+  invalidatePart(creatureId, slot) { /* this._cache.invalidate(`${creatureId}:${slot}`) */ }
+}
+```
+
+**Z-order constant:**
+```js
+const Z_ORDER = ['tail', 'wings', 'limbs', 'body', 'head', 'eyes', 'mouth', 'horns'];
+```
+
+Shape mapping table (`monster.shape.body.kind === 'blob'` → call `shapes.blob(...)` with monster's `rx/ry/wobble/seed`). All seeds derived from `hashString(monster.id + ':' + slot)` so re-cache produces identical pixels.
+
+### 5. `fx/wizardRenderer.js`
+
+Same pattern as `monsterRenderer` but with a smaller fixed schema for the wizard portrait. Class palette/staff/hat differ; base body shape is shared. Animations: idle breath, cast (staff thrust forward), hit (face flash + portrait shake), ultimate-charge-full (sparkle aura).
+
+### 6. `fx/animation.js` — Animation manager
+
+Driven by `game.js` per-frame. Tracks per-target animation state.
+
+```js
+class AnimationManager {
+  constructor() { this._states = new Map(); }
+  begin(targetId, anim) { /* { kind: 'attack'|'hit'|'death'|'idle'|'charge', startedAt, duration } */ }
+  update(dt, now) { /* advance phases, mark complete states for cleanup */ }
+  stateFor(targetId) { /* returns { phase, hitFlash, attackProgress, deathFade, shake, ... } for the renderer */ }
+  cancel(targetId) { /* remove all animations on a target */ }
+  cancelAll() { /* state-machine transition cleanup */ }
+}
+```
+
+Idle anim is computed analytically from `now` for each monster — no per-monster timer. (Avoids the "interval counter on float" bug class.)
+
+### 7. `fx/particles.js` — Tiny particle pool
+
+Pool of N=128 particles. API:
+```js
+class ParticlePool {
+  constructor(size = 128) { /* preallocate */ }
+  spawn(kind, x, y, vx, vy, ttl, color) { /* claim slot from pool */ }
+  update(dt) { /* advance positions, life-- */ }
+  draw(ctx) { /* draw all live particles with batched globalAlpha (no save/restore per particle — Petstore perf rule) */ }
+}
+```
+
+Kinds: `sparkle`, `ember`, `inkdot`. Each has a different draw recipe. No allocations in `update`/`draw`.
+
+### 8. Demo screen (in `game.js`)
+
+Hidden behind `?demo=1` URL param. Renders:
+- A 5×3 grid of comic primitives — one tile each: `inkOutline` blob, `halftoneFill` rect, `speedLines`, `burstText("ZAP!")`, `inkBurst`, `panelFlash` (toggled), `panelBorder`, `screenShake` toggle button
+- Three sample monsters at bottom: a goblin (blob+egg+comic_pair eyes+fang_grin+stub_arm), a dragon (bigger blob+horns+wings), a lich (bony body+skull head+bony_arm)
+- Each monster runs its idle animation continuously
+- A "hit me" button on each monster triggers a hit-flash + tiny screen shake
+
+This is a sanity-check page only; remove or keep behind `?demo=1` after this session.
+
+### 9. Performance audit
+
+Add an FPS counter in the corner (DOM, updated 1× per second). Acceptance requires sustained 60fps on iPad Safari with all three demo monsters animating. If a primitive is too slow (e.g. recomputing halftone every frame), profile and fix:
+- `halftoneFill` should use a **cached pattern** via `FxCache`, not redraw dots per frame
+- Monster parts must be cached offscreen — `drawImage` per frame, never redraw the path
+
+## Tests to run
+
+There are no Layer-1 tests for this session (canvas-heavy code resists Node testing). The acceptance is visual: load the demo screen and confirm:
+- Each primitive renders as expected
+- Monsters animate smoothly
+- 60fps holds (FPS counter ≥ 57)
+- Reduced-motion media query strips screen-shake on a `body[data-reduced-motion]` toggle
+
+## Acceptance checklist
+
+- [ ] `fx/comicfx.js` exports all 8 primitives, all use seeded PRNG (no `Math.random()` in cached textures)
+- [ ] `fx/shapes.js` provides every shape kind referenced in plan.md (blob, egg, comic_pair, fang_grin, stub_arm, bony_arm, tail, hornsPair, wingsPair)
+- [ ] `fx/cache.js` enforces ≤ 30 active canvases with LRU eviction; LRU updated only in `get`/`build`
+- [ ] `MonsterRenderer.drawCreature` uses cached part canvases; `ctx.save()`/`ctx.restore()` brackets every transform
+- [ ] Animation manager updates analytically off `now` for idle (no per-monster interval timers)
+- [ ] Demo screen (`?demo=1`) renders all primitives + 3 monsters at 60fps on iPad Safari
+- [ ] `prefers-reduced-motion` media query (and manual override toggle) disables screen-shake & panel-flash
+- [ ] No DOM manipulation in the RAF loop (`createElement` / `innerHTML` / `classList` calls only on state entry/transitions)
+- [ ] No `Math.random()` calls in any cached-texture path; all seeded
+- [ ] No independent `requestAnimationFrame` in any new manager — `game.js` is sole RAF owner
+- [ ] All new managers follow the timer lifecycle pattern from the checklist (every timer ID `null` in constructor; `cancel()` clears them all)
+
+## Session end
+
+1. Visual sanity pass on iPad Safari (or Safari with iPad simulator) — confirm 60fps, all primitives render, animations smooth
+2. Run `marauder-web-review` agent
+3. Commit `Session 3: comic renderer + monster schema + animation`
+4. Push to `main`

--- a/claudes-math-marauder/sessions/session-04.md
+++ b/claudes-math-marauder/sessions/session-04.md
@@ -1,0 +1,346 @@
+# Session 4 — Data Authoring Round 1 (Realm 1 Playable)
+**Model:** Sonnet | **Focus:** Author the data needed to make Realm 1 (Goblin Forest) playable end-to-end after Session 9. Validator script gets fleshed out here too.
+
+## Pre-flight
+
+1. Read `plan.md` (data files section) and spec section 6 (Data Model & Authored Content).
+2. Run `/marauder-checklist`.
+
+## Files to create
+
+### Data files
+- `claudes-math-marauder/data/realms.json` — all 5 realms (only Realm 1 fully usable; others stub palettes + monster pool empty)
+- `claudes-math-marauder/data/monsters.json` — 6 monsters covering Realm 1 + 1 sample of each type for later realms
+- `claudes-math-marauder/data/bosses.json` — Goblin Warlord (Realm 1) only; other 4 bosses placeholders with `tbdInRealms2to5: true` flag (validator skips these until Session 11 fills them)
+- `claudes-math-marauder/data/spells.json` — 10 starter spells
+- `claudes-math-marauder/data/classes.json` — Apprentice + Pyromancer
+- `claudes-math-marauder/data/story.json` — Chapter 1 + a small flavor-line bank
+- `claudes-math-marauder/data/events.json` — 5 mystery events
+
+### Files to modify
+- `claudes-math-marauder/scripts/validate-data.js` — replace the stub with real validation logic
+
+## Deliverables
+
+### 1. `data/realms.json`
+
+Five realm objects, indexed by `id`. Realm 1 fully populated; others with palette and theme placeholders so Session 11 can fill them.
+
+Realm 1 example (write all five with this shape):
+```jsonc
+{
+  "realms": [
+    {
+      "id": "goblin_forest",
+      "displayName": "Goblin Forest",
+      "tier": 1,
+      "palette": {
+        "bgGradient": ["#6c8a3a", "#a4c266"],
+        "halftoneColor": "#3a5318",
+        "panelTint": "#f8efd0"
+      },
+      "silhouettes": ["tree_gnarled", "mushroom_cluster", "twig_arch"],
+      "monsterPool": ["goblin_grunt", "goblin_runt", "tree_imp", "fungal_creep"],
+      "bossId": "goblin_warlord",
+      "storyChapterId": "chapter_1",
+      "factFamilyWeights": { "x0": 0, "x1": 0.05, "x2": 0.20, "x3": 0.15, "x4": 0.10, "x5": 0.20, "x6": 0.05, "x7": 0, "x8": 0, "x9": 0, "x10": 0.20, "x11": 0, "x12": 0.05 },
+      "mulRatio": 0.75,
+      "nodeCounts": { "combat": 5, "elite": 1, "spellshop": 1, "mystery": 1, "rest": 1 }
+    },
+    {
+      "id": "crystal_cave",
+      "displayName": "Crystal Cave",
+      "tier": 2,
+      "palette": { "bgGradient": ["#2c2a4a", "#6e6cb7"], "halftoneColor": "#a5a8e3", "panelTint": "#dde0ff" },
+      "silhouettes": ["stalactite_jagged", "gem_cluster", "crystal_archway"],
+      "monsterPool": [],
+      "bossId": "crystal_titan",
+      "storyChapterId": "chapter_2",
+      "factFamilyWeights": { "x0": 0, "x1": 0, "x2": 0.10, "x3": 0.20, "x4": 0.15, "x5": 0.15, "x6": 0.15, "x7": 0.10, "x8": 0, "x9": 0, "x10": 0.10, "x11": 0, "x12": 0.05 },
+      "mulRatio": 0.7,
+      "nodeCounts": { "combat": 5, "elite": 2, "spellshop": 1, "mystery": 1, "rest": 1 }
+    },
+    {
+      "id": "dragon_peak",
+      "displayName": "Dragon Peak",
+      "tier": 3,
+      "palette": { "bgGradient": ["#8a2c2c", "#f0a040"], "halftoneColor": "#c93434", "panelTint": "#ffeac0" },
+      "silhouettes": ["mountain_jagged", "lava_flow", "obsidian_spike"],
+      "monsterPool": [],
+      "bossId": "wyrm_emberhart",
+      "storyChapterId": "chapter_3",
+      "factFamilyWeights": { "x0": 0, "x1": 0, "x2": 0.05, "x3": 0.15, "x4": 0.15, "x5": 0.10, "x6": 0.20, "x7": 0.15, "x8": 0.10, "x9": 0, "x10": 0.05, "x11": 0, "x12": 0.05 },
+      "mulRatio": 0.65,
+      "nodeCounts": { "combat": 5, "elite": 2, "spellshop": 1, "mystery": 2, "rest": 1 }
+    },
+    {
+      "id": "astral_void",
+      "displayName": "Astral Void",
+      "tier": 4,
+      "palette": { "bgGradient": ["#0d0a2c", "#3c2a6e"], "halftoneColor": "#ddd5ff", "panelTint": "#e8e3ff" },
+      "silhouettes": ["floating_debris", "small_planet", "starfield_dense"],
+      "monsterPool": [],
+      "bossId": "void_oracle",
+      "storyChapterId": "chapter_4",
+      "factFamilyWeights": { "x0": 0, "x1": 0, "x2": 0, "x3": 0.10, "x4": 0.10, "x5": 0.10, "x6": 0.15, "x7": 0.15, "x8": 0.15, "x9": 0.15, "x10": 0.05, "x11": 0.05, "x12": 0 },
+      "mulRatio": 0.6,
+      "nodeCounts": { "combat": 5, "elite": 2, "spellshop": 1, "mystery": 2, "rest": 1 }
+    },
+    {
+      "id": "lich_citadel",
+      "displayName": "Lich Citadel",
+      "tier": 5,
+      "palette": { "bgGradient": ["#2a2a2a", "#4a5a44"], "halftoneColor": "#9bb87a", "panelTint": "#ddddd5" },
+      "silhouettes": ["skeletal_tower", "gravestone", "broken_arch"],
+      "monsterPool": [],
+      "bossId": "the_lich_king",
+      "storyChapterId": "chapter_5",
+      "factFamilyWeights": { "x0": 0, "x1": 0, "x2": 0.05, "x3": 0.10, "x4": 0.10, "x5": 0.10, "x6": 0.10, "x7": 0.15, "x8": 0.15, "x9": 0.10, "x10": 0.05, "x11": 0.05, "x12": 0.05 },
+      "mulRatio": 0.5,
+      "nodeCounts": { "combat": 5, "elite": 2, "spellshop": 1, "mystery": 2, "rest": 1 }
+    }
+  ]
+}
+```
+
+### 2. `data/monsters.json`
+
+6 monsters total: 4 standards for Realm 1 (`goblin_grunt`, `goblin_runt`, `tree_imp`, `fungal_creep`) plus 2 templates that Session 11 will copy and recolor for other realms (`gem_sprite` for Realm 2 placeholder; `ember_imp` for Realm 3 placeholder). Each monster matches the schema in plan.md / spec §4.4.
+
+Example (write all six):
+```jsonc
+{
+  "monsters": [
+    {
+      "id": "goblin_grunt",
+      "name": "Goblin Grunt",
+      "tier": 1,
+      "hp": 1,
+      "size": [180, 220],
+      "palette": ["#3a6b2c", "#1b3618", "#f0d840"],
+      "shape": {
+        "body":  { "kind": "blob",      "rx": 70, "ry": 80, "wobble": 0.12 },
+        "head":  { "kind": "egg",       "scale": 1.1, "tilt": -0.05 },
+        "eyes":  { "kind": "comic_pair","size": 18, "expr": "angry" },
+        "mouth": { "kind": "fang_grin" },
+        "limbs": [ { "kind": "stub_arm", "side": "L" }, { "kind": "stub_arm", "side": "R" } ],
+        "horns": null,
+        "tail":  null
+      },
+      "anim": { "idle": "bob", "attack": "lunge", "hit": "squash" },
+      "voiceTaunts": ["Tiny wizard! Easy lunch!", "Numbers won't save you!", "Hee hee, math is for losers!"],
+      "voiceProfile": { "pitch": 1.1, "rate": 1.1 },
+      "spawnSfx": "goblinGrunt"
+    }
+    /* ... + 5 more monsters with the same shape ... */
+  ]
+}
+```
+
+### 3. `data/bosses.json`
+
+Goblin Warlord with 3 phases. Phase array length must equal `hp`.
+
+```jsonc
+{
+  "bosses": [
+    {
+      "id": "goblin_warlord",
+      "name": "Korg the Warlord",
+      "realmId": "goblin_forest",
+      "size": [320, 400],
+      "palette": ["#5a3c1a", "#2a1c0a", "#c93434"],
+      "hp": 3,
+      "shape": { /* full schema like a monster */ },
+      "anim": { "idle": "menacing_breath", "attack": "club_swing", "hit": "stagger", "phaseBreak": "armor_shatter" },
+      "introSpeech": "So you're the apprentice they sent? Good. I'll add your bones to my collection.",
+      "voiceProfile": { "pitch": 0.85, "rate": 0.95 },
+      "phases": [
+        { "label": "BONE ARMOR", "kind": "div", "hint": "Break the bone armor!", "factFamilyHint": "x5", "mode": "orb" },
+        { "label": "BLOODFRENZY", "kind": "mul", "hint": "Cut through the rage!", "factFamilyHint": "x10", "mode": "orb" },
+        { "label": "FINAL ROAR",  "kind": "stretch", "hint": "End it!",            "factFamilyHint": "x5", "mode": "ultimate" }
+      ]
+    },
+    /* placeholders for other 4 bosses with `"tbdInRealms2to5": true` and minimal valid shape so the validator can ignore them */
+  ]
+}
+```
+
+The combat engine reads `phases[i].mode` to pick orb-cast vs typed-ultimate. Phase `kind` is `mul`, `div`, or `stretch` (forces a stretch fact from the named family, falling back to a normal hard problem if family not yet mastered).
+
+### 4. `data/spells.json`
+
+10 spells, only `ember_bolt` is starter. Mix of common/rare/epic. All rarities only `common` and `rare` for Realm 1 unlocks; reserve `epic` for later realms.
+
+```jsonc
+{
+  "spells": [
+    { "id": "ember_bolt",     "name": "Ember Bolt",     "rarity": "common", "tier": 1, "classRestrict": null,         "fxColor": "#ff7733", "fxKind": "spark",   "modifiers": { "baseDamageBonus": 0,    "speedCritBonus": 0.1, "streakBonusBonus": 0,    "ultimateChargeBonus": 0.2 }, "unlock": { "kind": "starter" } },
+    { "id": "frost_orb",      "name": "Frost Orb",      "rarity": "common", "tier": 1, "classRestrict": null,         "fxColor": "#7ec8ff", "fxKind": "orb",     "modifiers": { "baseDamageBonus": 0.1,  "speedCritBonus": 0,   "streakBonusBonus": 0,    "ultimateChargeBonus": 0   }, "unlock": { "kind": "shop",    "cost": 30 } },
+    { "id": "stone_shield",   "name": "Stone Shield",   "rarity": "common", "tier": 1, "classRestrict": null,         "fxColor": "#a89372", "fxKind": "shield",  "modifiers": { "baseDamageBonus": 0,    "speedCritBonus": 0,   "streakBonusBonus": 0.2,  "ultimateChargeBonus": 0   }, "unlock": { "kind": "shop",    "cost": 25 } },
+    { "id": "kindle_step",    "name": "Kindle Step",    "rarity": "common", "tier": 1, "classRestrict": "pyromancer", "fxColor": "#ff9933", "fxKind": "trail",   "modifiers": { "baseDamageBonus": 0,    "speedCritBonus": 0.2, "streakBonusBonus": 0,    "ultimateChargeBonus": 0   }, "unlock": { "kind": "starter" } },
+    { "id": "ash_shield",     "name": "Ash Shield",     "rarity": "common", "tier": 1, "classRestrict": "pyromancer", "fxColor": "#bb8855", "fxKind": "shield",  "modifiers": { "baseDamageBonus": 0,    "speedCritBonus": 0,   "streakBonusBonus": 0.15, "ultimateChargeBonus": 0   }, "unlock": { "kind": "starter" } },
+    { "id": "spark_fan",      "name": "Spark Fan",      "rarity": "rare",   "tier": 2, "classRestrict": null,         "fxColor": "#ffcc44", "fxKind": "fan",     "modifiers": { "baseDamageBonus": 0.15, "speedCritBonus": 0.1, "streakBonusBonus": 0,    "ultimateChargeBonus": 0   }, "unlock": { "kind": "shop",    "cost": 60 } },
+    { "id": "icy_lance",      "name": "Icy Lance",      "rarity": "rare",   "tier": 2, "classRestrict": null,         "fxColor": "#aaddff", "fxKind": "lance",   "modifiers": { "baseDamageBonus": 0.2,  "speedCritBonus": 0,   "streakBonusBonus": 0.1,  "ultimateChargeBonus": 0   }, "unlock": { "kind": "shop",    "cost": 70 } },
+    { "id": "thorn_thresh",   "name": "Thorn Thresh",   "rarity": "common", "tier": 1, "classRestrict": null,         "fxColor": "#558844", "fxKind": "thorn",   "modifiers": { "baseDamageBonus": 0.05, "speedCritBonus": 0.1, "streakBonusBonus": 0.1,  "ultimateChargeBonus": 0   }, "unlock": { "kind": "shop",    "cost": 30 } },
+    { "id": "moss_blanket",   "name": "Moss Blanket",   "rarity": "common", "tier": 1, "classRestrict": null,         "fxColor": "#3a6b2c", "fxKind": "haze",    "modifiers": { "baseDamageBonus": 0,    "speedCritBonus": 0,   "streakBonusBonus": 0,    "ultimateChargeBonus": 0.3 }, "unlock": { "kind": "shop",    "cost": 35 } },
+    { "id": "willow_dart",    "name": "Willow Dart",    "rarity": "common", "tier": 1, "classRestrict": null,         "fxColor": "#88aa55", "fxKind": "dart",    "modifiers": { "baseDamageBonus": 0.05, "speedCritBonus": 0.05,"streakBonusBonus": 0.05, "ultimateChargeBonus": 0.05}, "unlock": { "kind": "shop",    "cost": 25 } }
+  ]
+}
+```
+
+### 5. `data/classes.json`
+
+Apprentice (start) + Pyromancer (boss-clear unlock for Realm 1):
+
+```jsonc
+{
+  "classes": [
+    {
+      "id": "apprentice",
+      "name": "Apprentice",
+      "passive": { "type": "vanilla", "description": "Steady caster with no class bonus. Best for learning." },
+      "starterDeck": ["ember_bolt", null, null, null, null],
+      "unlock": { "kind": "starter" },
+      "wizardSchema": { "robeColor": "#5a4a8a", "hatColor": "#3a2a6a", "staffKind": "wand_simple", "skinTone": "#f0d6c2" }
+    },
+    {
+      "id": "pyromancer",
+      "name": "Pyromancer",
+      "passive": { "type": "crit_chain", "description": "Each consecutive correct answer increases crit damage by 5% (caps at 50%)." },
+      "starterDeck": ["ember_bolt", "kindle_step", "ash_shield", null, null],
+      "unlock": { "kind": "boss_clear", "realm": "goblin_forest", "minStars": 1 },
+      "wizardSchema": { "robeColor": "#aa3322", "hatColor": "#661a0a", "staffKind": "staff_flame", "skinTone": "#f0c8a0" }
+    }
+  ]
+}
+```
+
+### 6. `data/story.json`
+
+Chapter 1 (~6 short narrated lines) + flavor-line bank (10 victory lines, 10 generic taunts):
+
+```jsonc
+{
+  "chapters": [
+    {
+      "id": "chapter_1",
+      "realmId": "goblin_forest",
+      "title": "Into the Goblin Forest",
+      "lines": [
+        "Your master's last words still echo in your ears.",
+        "The Tower of Numbers has fallen.",
+        "Goblins march from the forest. They carry stolen wisdom.",
+        "You are the last apprentice. The math is yours to wield.",
+        "Cast true. Cast fast. Save the tower.",
+        "And so you step into the trees..."
+      ]
+    }
+  ],
+  "flavor": {
+    "victories": ["Easy.", "Numbers don't lie.", "Cast and dismissed.", "Calculated.", "Another one down.", "The math wins again.", "Sum of nothing.", "Carry the one — to the grave!", "Solved.", "Next problem!"],
+    "taunts":    ["Try a number, wizard!", "Your books won't help you here!", "Multiply this!", "How does it divide now?", "Numbers? I eat numbers!", "Wizard? More like fizzler!", "Show me your work!", "Cast something — anything!", "Slow!", "Wrong already?"]
+  }
+}
+```
+
+### 7. `data/events.json`
+
+5 mystery events. Each has narrated prompt (≤ 2 short sentences), 2–3 choices, outcomes referencing recognized keys (`gold`, `heal`, `damage`, `spell`, `streak_bonus`).
+
+```jsonc
+{
+  "events": [
+    {
+      "id": "lost_traveler",
+      "prompt": "A traveler with a torn satchel offers a trade.",
+      "choices": [
+        { "text": "Give 10 gold for a mystery scroll", "outcomes": [{ "kind": "gold", "delta": -10 }, { "kind": "spell", "rarity": "common" }] },
+        { "text": "Walk past", "outcomes": [] }
+      ]
+    },
+    /* + 4 more events */
+  ]
+}
+```
+
+### 8. `scripts/validate-data.js`
+
+Replace stub with full validator. Behaviors:
+
+- Load each `data/*.json`, parse, fail fast on syntax errors
+- All `monster.id` unique; `realm.monsterPool` references valid monster IDs (skip empty pools for non-Realm-1 — that's expected this session)
+- All `boss.id` unique; `boss.realmId` references valid realm; `boss.phases.length === boss.hp` (skip if `tbdInRealms2to5: true`)
+- All `spell.id` unique; `unlock.kind ∈ {"starter","shop","boss_clear"}`; `classRestrict` either null or refers to existing class
+- All `class.id` unique; `class.starterDeck` length is 5; every non-null deck entry references a valid spell ID; class `unlock.realm` references a real realm
+- All `chapter.id` matches a realm `storyChapterId`; `chapter.lines.length` ∈ `[4, 12]`
+- All `event.id` unique; each `event.choices.length` ∈ `[1, 3]`; outcome kinds ∈ `{"gold","heal","damage","spell","streak_bonus","class_unlock"}`
+- All palette colors are valid `#RRGGBB`; for any color used as text/UI on cream, run contrast check via `js/util/contrast.js` (placeholder: write the helper inline if `util/contrast.js` doesn't exist yet)
+- Every realm `factFamilyWeights` sums to within `[0.95, 1.05]`
+- Print `CRITICAL` for blocking errors (hook will block commit), `WARN` for non-blocking, `INFO` for stats
+
+Exit nonzero on `CRITICAL`.
+
+```js
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const DATA_DIR = path.join(__dirname, '..', 'data');
+
+let errors = 0, warns = 0;
+function critical(msg) { console.error('CRITICAL:', msg); errors++; }
+function warn(msg) { console.warn('WARN:', msg); warns++; }
+function info(msg) { console.log('INFO:', msg); }
+
+function loadOrFail(file) {
+  const fp = path.join(DATA_DIR, file);
+  if (!fs.existsSync(fp)) { critical(`missing ${file}`); return null; }
+  try { return JSON.parse(fs.readFileSync(fp, 'utf8')); }
+  catch (e) { critical(`parse error in ${file}: ${e.message}`); return null; }
+}
+
+const realms = loadOrFail('realms.json');
+const monsters = loadOrFail('monsters.json');
+const bosses = loadOrFail('bosses.json');
+const spells = loadOrFail('spells.json');
+const classes = loadOrFail('classes.json');
+const story = loadOrFail('story.json');
+const events = loadOrFail('events.json');
+
+// ... (full validator body as enumerated above) ...
+
+console.log(`\n${errors} critical, ${warns} warnings`);
+process.exit(errors > 0 ? 1 : 0);
+```
+
+Write the full validator body — every check from the bullet list above. No placeholders.
+
+## Tests to run
+
+```bash
+node claudes-math-marauder/scripts/validate-data.js     # 0 critical, 0 warnings
+```
+
+Hook test: edit one of the data files (e.g., add a single space and save), confirm the validator runs automatically and the output appears.
+
+## Acceptance checklist
+
+- [ ] `data/realms.json` has all 5 realms; Realm 1 fully populated with non-empty `monsterPool`
+- [ ] `data/monsters.json` has at least the 4 Realm-1 monsters fully realized
+- [ ] `data/bosses.json` has Goblin Warlord with phases.length === hp
+- [ ] `data/spells.json` has Ember Bolt as a `starter` and 9 more spells
+- [ ] `data/classes.json` has Apprentice (starter) + Pyromancer (boss_clear realm goblin_forest)
+- [ ] `data/story.json` has chapter_1 with 4–12 lines + flavor bank
+- [ ] `data/events.json` has 5 events, each with valid choices and outcomes
+- [ ] `scripts/validate-data.js` reports zero CRITICAL errors
+- [ ] PostToolUse hook runs the validator automatically on `data/*.json` edits
+- [ ] All palette colors validated as `#RRGGBB`
+- [ ] Realm 1's `factFamilyWeights` sums to ~1.0
+- [ ] No `epic` rarity spells in Realm 1's likely shop offerings
+
+## Session end
+
+1. `node scripts/validate-data.js` — zero critical errors
+2. Run `marauder-web-review` agent (data-only review — focus on schema correctness)
+3. Commit `Session 4: data — realms, Realm 1 monsters, Goblin Warlord, starter spells, Apprentice + Pyromancer, chapter 1, 5 events`
+4. Push to `main`

--- a/claudes-math-marauder/sessions/session-05.md
+++ b/claudes-math-marauder/sessions/session-05.md
@@ -1,0 +1,281 @@
+# Session 5 — Combat: Orb-Cast Loop
+**Model:** Opus | **Focus:** The default fight — problem panel, 4 floating orbs, correct/wrong resolve, mastery save, retry-on-defeat
+
+The biggest gameplay session. By the end, a single fight is fully playable from `?fight=goblin_grunt` debug param: monster appears → problem renders → orbs floats up → tap correct → monster takes damage → next problem → KO → reward card.
+
+## Pre-flight
+
+1. Read spec sections 3 (Combat Architecture), 4 (Visual Renderer), 7 (A11y).
+2. Read `keyboard-command-4/js/game.js` and `js/input.js` for the precedent on tap-to-cast loops.
+3. Run `/marauder-checklist`.
+
+## Files to create
+
+- `claudes-math-marauder/js/combat/fight.js` — FightManager (state machine, problem panel, orbs, resolve, juice triggers)
+- `claudes-math-marauder/js/combat/orbs.js` — orb visual renderer (procedural canvas) + hit-test
+- `claudes-math-marauder/js/ui/hud.js` — combat HUD (HP bar, streak, score, ultimate meter — DOM-overlay)
+
+## Files to modify
+
+- `claudes-math-marauder/js/game.js` — wire up `FightManager`, accept `?fight=<monsterId>` debug param to launch a fight directly
+
+## Deliverables
+
+### 1. `combat/fight.js` — FightManager
+
+This is the central combat orchestrator. It is allowed to import canvas + DOM modules (unlike the pure `combat/factKeys.js` etc.). Combat state machine driven by `game.js` per-frame `update(dt)` and `draw(ctx, w, h)`.
+
+```js
+class FightManager {
+  constructor({ rng, masteryMap, realm, problemGen, distractors, mastery, onComplete, onWizardHit, audio, fxCache, monsterRenderer, wizardRenderer, hud, anim, particles }) {
+    // Inject every dep so combat is testable and easily replayable
+    this.state = 'IDLE';        // IDLE → INTRO → PROBLEM → ANSWERING → RESOLVE → (PROBLEM | VICTORY | DEFEAT_RETRY)
+    this._monster = null;
+    this._monsterCompiled = null;     // built by monsterRenderer
+    this._wizardCompiled = null;
+    this._currentProblem = null;
+    this._currentOrbs = [];
+    this._answerStartedAt = 0;
+    this._streak = 0;
+    this._retries = 0;
+    this._score = 0;
+    this._ultimateCharge = 0;          // 0..1
+    this._monsterHpRemaining = 0;
+    this._wizardFlavorHp = 60;
+    this._recentKeys = [];
+    this._timers = { _introTimer: null, _resolveTimer: null, _wrongRevealTimer: null };
+    this.onComplete = onComplete;       // called with { stars, score, retries, monsterId, masteryDelta }
+    this._lessonComplete = false;       // re-entry guard (CLAUDE.md rule)
+  }
+
+  start(monster) {
+    this.cancel();
+    this._lessonComplete = false;
+    this._monster = monster;
+    this._monsterCompiled = this._renderer.buildCreature(monster);
+    this._monsterHpRemaining = monster.hp;
+    this._streak = 0;          // streak resets on new fight
+    this._score = 0;
+    this._retries = 0;
+    this._ultimateCharge = 0;
+    this._recentKeys = [];
+    this.state = 'INTRO';
+    this._timers._introTimer = setTimeout(() => this._enterProblem(), 1100);
+    this._anim.begin(monster.id, { kind: 'intro_slide', startedAt: performance.now(), duration: 1000 });
+    this._audio.play('monsterSpawn');
+    this._narrate(this._pickTaunt(monster));
+  }
+
+  cancel() {
+    Object.keys(this._timers).forEach(k => { if (this._timers[k]) { clearTimeout(this._timers[k]); this._timers[k] = null; } });
+    this._anim.cancelAll();
+    this.onComplete = null;       // CLAUDE.md: prevent stale callback
+  }
+
+  // Called from game.js per frame
+  update(dt) { /* advance any easing animations; stretch panel slide-in; orb hover wobble */ }
+  draw(ctx, w, h) { /* layered draw — panel BG, parallax, monster, orbs (delegated to orbs.js), wizard, HUD overlays handled by HUD class */ }
+
+  // Called by orbs.js on tap
+  selectOrb(value) {
+    if (this.state !== 'ANSWERING') return;
+    const correct = value === this._currentProblem.answer;
+    const timeMs = performance.now() - this._answerStartedAt;
+    this._resolve({ correct, value, timeMs });
+  }
+
+  // -- private methods below --
+
+  _enterProblem() {
+    if (this.state === 'PAUSED' || this.state === 'GAMEPLAY' /* tolerate PAUSED */) { /* no-op safety */ }
+    if (this._monsterHpRemaining <= 0) { this._victory(); return; }
+    this._currentProblem = this._problemGen.selectProblem({ realm: this._realm, masteryMap: this._masteryMap, recentKeys: this._recentKeys, rng: this._rng, mulRatio: this._realm.mulRatio, allowStretch: this._allowStretch, realmTier: this._realm.tier });
+    this._currentOrbs = this._distractors.generateDistractors(this._currentProblem, this._rng);
+    this._answerStartedAt = performance.now();
+    this.state = 'ANSWERING';
+    this._hud.setProblem(this._currentProblem.displayText);
+  }
+
+  _resolve({ correct, value, timeMs }) {
+    this.state = 'RESOLVE';
+    this._mastery.recordResolve(this._masteryMap, this._currentProblem.factKey, { correct, timeMs, now: Date.now(), masteredAvgMs: this._mastery.masteredAvgMs(this._masteryMap) });
+    this._recentKeys.push(this._currentProblem.factKey);
+    if (this._recentKeys.length > 5) this._recentKeys.shift();
+
+    if (correct) {
+      const speedBonus = Math.max(0, (5000 - timeMs) / 50);
+      const streakMult = 1 + (this._streak * 0.05);
+      const dmg = Math.round((100 + speedBonus) * streakMult);
+      this._score += dmg;
+      this._streak++;
+      this._monsterHpRemaining -= 1;
+      this._ultimateCharge = Math.min(1, this._ultimateCharge + 0.34);
+      this._hud.setStreak(this._streak);
+      this._hud.setScore(this._score);
+      this._hud.setUltimateCharge(this._ultimateCharge);
+      this._anim.begin(this._monster.id, { kind: 'hit', startedAt: performance.now(), duration: 350 });
+      this._audio.play(timeMs < 2000 ? 'critHit' : 'hit');
+      this._fx.burst(this._monster.id, timeMs < 2000 ? 'CRIT!' : 'ZAP!');
+      this._timers._resolveTimer = setTimeout(() => {
+        if (this._monsterHpRemaining <= 0) this._victory();
+        else this._enterProblem();
+      }, 600);
+    } else {
+      this._streak = 0;
+      this._hud.setStreak(0);
+      this._wizardFlavorHp = Math.max(0, this._wizardFlavorHp - 10);
+      this._hud.setWizardHp(this._wizardFlavorHp);
+      this._anim.begin('wizard', { kind: 'hit', startedAt: performance.now(), duration: 250 });
+      this._audio.play('wrong');
+      this._narrate(`The answer was ${this._currentProblem.answer}.`);
+      this._hud.flashCorrect(this._currentProblem.answer);
+      this._timers._wrongRevealTimer = setTimeout(() => {
+        if (this._wizardFlavorHp <= 0) this._defeatRetry();
+        else this._enterProblem();
+      }, 1200);
+    }
+  }
+
+  _victory() {
+    if (this._lessonComplete) return;
+    this._lessonComplete = true;
+    const cb = this.onComplete;        // CLAUDE.md: save before cancel
+    this.cancel();
+    this._anim.begin(this._monster.id, { kind: 'death', startedAt: performance.now(), duration: 700 });
+    this._audio.play('ko');
+    this._fx.burst(this._monster.id, 'KO!');
+    setTimeout(() => {
+      if (cb) cb({ outcome: 'victory', score: this._score, streak: this._streak, retries: this._retries, monsterId: this._monster.id });
+    }, 800);
+  }
+
+  _defeatRetry() {
+    this._retries++;
+    this._wizardFlavorHp = 60;
+    this._streak = 0;
+    this._hud.setWizardHp(60);
+    this._narrate(`${this._monster.name} laughs! Try again!`);
+    this._timers._resolveTimer = setTimeout(() => this._enterProblem(), 1500);
+  }
+
+  _narrate(text) { /* delegate to audio.speech.speak(text) — async, non-blocking */ }
+  _pickTaunt(monster) { /* pick from monster.voiceTaunts */ }
+}
+```
+
+**Critical patterns** (cross-checked against `/marauder-checklist`):
+- All timer IDs declared in constructor as `null`
+- `cancel()` clears every timer + nulls onComplete
+- `_victory()` saves callback before `cancel()`
+- Re-entry guard `_lessonComplete`
+- `setTimeout` callbacks tolerate PAUSED state (game.js's `_update` short-circuits already, but the timer fires the next problem regardless of pause — guard at the top: `if (this.state === 'PAUSED') { /* re-arm timer or no-op */ }`)
+- All damage computation uses the run-seeded `rng` only via `problemGen` and `distractors` — no `Math.random()` in fight.js
+
+### 2. `combat/orbs.js` — Orb renderer + hit-test
+
+```js
+class OrbsRenderer {
+  constructor(fxCache) { this._cache = fxCache; this._hover = -1; }
+  layout(canvasW, canvasH) { /* compute 4 orb centers in a 2x2 grid centered horizontally, ~120px below the problem panel; 96px diameter */ }
+  draw(ctx, orbs) { /* for each orb: panelBorder via inkOutline of a circle; halftoneFill at low density inside; large numeral centered (96px OpenDyslexic) */ }
+  hitTest(x, y) { /* return index 0..3 or -1 */ }
+  setHover(idx) { this._hover = idx; }
+}
+```
+
+Hit-test invoked from `game.js`'s pointerdown handler when state === FIGHT and FightManager.state === ANSWERING. ≥96px hitboxes (CLAUDE.md).
+
+### 3. `ui/hud.js` — Combat HUD (DOM overlay)
+
+DOM, not canvas. Children of `#hud-root`:
+
+- `#hud-problem` — large numeral display (96px), `aria-live="polite"` so VoiceOver speaks each new problem
+- `#hud-streak` — "Streak: N"
+- `#hud-score` — "Score: N"
+- `#hud-ultimate` — meter (0–100%), `<progress>` element with `aria-label`
+- `#hud-wizard-hp` — flavor HP bar
+- `#hud-correction` — for "the answer was 56" reveal; updates `aria-label` synchronously with `textContent`
+
+API:
+```js
+class HUD {
+  setProblem(text) { /* updates textContent + aria-label; triggers narration via speech.speak if autoNarrate */ }
+  setStreak(n) { /* updates textContent + aria-label */ }
+  setScore(n) { /* same */ }
+  setUltimateCharge(pct) { /* progress.value */ }
+  setWizardHp(n) { /* width animation */ }
+  flashCorrect(value) { /* show #hud-correction with the answer for 1100ms */ }
+  hide() { /* class .hidden, aria-hidden=true */ }
+  show() { /* remove .hidden, aria-hidden=false */ }
+}
+```
+
+**ARIA rules to enforce here (CLAUDE.md):**
+- `aria-live` regions never combined with `aria-hidden` toggling — instead, when HUD hides, set `display: none` via class on the parent `#hud-root`, leave the live regions alone
+- No `aria-label` on the `aria-live` regions themselves
+- Update `aria-label` whenever `textContent` changes on labelled elements (but live regions don't need a label)
+
+### 4. `game.js` modifications
+
+- Add a `FightManager` instance lifecycle: created on entering FIGHT state, `cancel()`'d on leaving
+- Add `?fight=<monsterId>` debug param: on init, if present, jump straight to FIGHT against that monster (use a stub realm = realm 1 + empty mastery)
+- Pointer event handlers (`pointerdown` / `pointerup`) on canvas: convert coords with DPR, dispatch to OrbsRenderer.hitTest in FIGHT state
+
+### 5. Saving mastery on resolve
+
+Combat updates the in-memory `masteryMap` per problem. The fight manager calls `SaveManager` ONCE at fight end (in `_victory` / `_defeatRetry`-triggered path). Pattern:
+```js
+// In _victory or just after:
+const data = SaveManager.load();
+data.mastery = this._masteryMap;     // we worked on a reference
+data.totalProblemsAnswered += this._problemsAnsweredThisFight;
+data.totalCorrect += this._correctThisFight;
+SaveManager.save(data);
+```
+Or, since mastery was a direct reference into `data.mastery`, just call `SaveManager.save(data)` once where `data` is the load-time snapshot. Either way, NO save during per-problem resolve (CLAUDE.md hot-path).
+
+## Tests to run
+
+No new Layer-1 tests this session (combat orchestrator is stateful + DOM-coupled). Manual tests via `?fight=goblin_grunt`:
+
+- [ ] Fight launches; monster slides in; taunt narrated
+- [ ] First problem appears; 4 orbs render; one matches the answer
+- [ ] Tap correct orb → hit animation, damage number, streak ticks to 1, score updates
+- [ ] After 1 correct, monster KOs (hp=1), KO animation, callback fires
+- [ ] Tap wrong orb → wizard portrait shake, "the answer was N" narrated and shown for 1100ms, streak resets to 0
+- [ ] Tapping orbs during INTRO/RESOLVE phases is ignored (state guard)
+- [ ] Pause (e.g., dev key `P`) halts updates; resume picks up at the same problem
+- [ ] After fight, `SaveManager.load()` shows updated mastery for the answered fact key
+- [ ] No `Math.random()` calls inside combat (grep `combat/` for `Math.random`)
+- [ ] No DOM allocs inside `update()` / `draw()` (grep `combat/` and `fx/` for `createElement` / `innerHTML` inside any update/draw method)
+
+Re-run all Session 2 tests — they must still pass:
+```bash
+node claudes-math-marauder/scripts/test-fact-keys.js
+node claudes-math-marauder/scripts/test-mastery.js
+node claudes-math-marauder/scripts/test-problem-gen.js
+node claudes-math-marauder/scripts/test-distractors.js
+```
+
+## Acceptance checklist
+
+- [ ] FightManager has all 5 timer-lifecycle pattern requirements (constructor `null` IDs, `cancel()` clears them, `_victory` saves cb before cancel, `start()` defensive cancel, re-entry guard `_lessonComplete`)
+- [ ] No `style.display` assignments in JS (HUD show/hide uses classes)
+- [ ] `aria-live="polite"` on `#hud-problem` and `#hud-correction`; no `aria-hidden` toggling on those elements
+- [ ] `#hud-ultimate` `<progress>` has `aria-label` (it has no textContent so the label drives announcement)
+- [ ] Orb hitboxes ≥ 96px on iPad
+- [ ] Pause halts speech (`speechSynthesis.pause()`) and resumes it on unpause
+- [ ] Mastery saved exactly once per fight, not per problem
+- [ ] Speed bonus computed correctly for `< 5000ms` answers; never negative
+- [ ] Wrong-answer narration always speaks the correct answer (assert by inspecting the SpeechManager call list)
+- [ ] Streak counter updates persist into `data.totalProblemsAnswered`/`data.totalCorrect` after fight save
+- [ ] Wrong on box-1 fact does not crash (decrement floors at 1)
+- [ ] Wrong on a stretch fact does not corrupt mastery for the underlying mul fact (stretch keys are namespaced `stretch:*` and not stored in mastery)
+
+## Session end
+
+1. Re-run all Layer-1 tests
+2. Manual playtest of `?fight=goblin_grunt` — tick acceptance checklist
+3. Run `marauder-web-review` agent
+4. Commit `Session 5: combat — orb-cast loop + HUD + retry-on-defeat`
+5. Push to `main`

--- a/claudes-math-marauder/sessions/session-06.md
+++ b/claudes-math-marauder/sessions/session-06.md
@@ -1,0 +1,239 @@
+# Session 6 — Combat: Typed Ultimate Spell
+**Model:** Sonnet | **Focus:** The "type the answer" mode that fires when the ultimate meter is full
+
+By the end, every ~3 streaks fills the ultimate meter; the next problem becomes a typed ultimate (numpad + physical keyboard), correct = massive damage, wrong = meter drains and reverts to orb cast at half damage.
+
+## Pre-flight
+
+1. Read spec section 3.2.2 (Ultimate cast).
+2. Re-read CLAUDE.md rules on focus management (numpad will be a focus-trapped overlay), aria-pressed, and dynamic aria-label.
+3. Run `/marauder-checklist`.
+
+## Files to create
+
+- `claudes-math-marauder/js/combat/ultimate.js` — Ultimate state machine + numpad UI
+
+## Files to modify
+
+- `claudes-math-marauder/js/combat/fight.js` — call into ultimate.js when `_ultimateCharge >= 1` at problem-entry time
+- `claudes-math-marauder/css/style.css` — numpad layout + glowing-sigil animation
+
+## Deliverables
+
+### 1. `combat/ultimate.js`
+
+A FightManager-owned helper. Renders an overlay panel with:
+- Bigger problem panel — 128px numerals, dramatic styling
+- Glowing input sigil — shows the typed digits at 96px **before** commit (catches dyslexia digit-flips)
+- 3×4 numpad: `7 8 9` / `4 5 6` / `1 2 3` / `⌫ 0 ✓`
+- Each numpad key ≥ 72px, `<button>` element, `aria-label="seven"` etc. (readable to AT)
+
+```js
+class Ultimate {
+  constructor({ audio, hud, anim, fxCache, fight }) {
+    this._timers = { _resolveTimer: null, _entryTimer: null };
+    this._buf = '';                    // typed digits
+    this._currentProblem = null;
+    this._answerStartedAt = 0;
+    this._maxDigits = 6;               // never need more than 6 (max product 144 + room)
+    this.onResolve = null;             // called with { correct, value, timeMs }
+    this._overlay = null;              // DOM root
+    this._physicalKeyHandler = null;
+  }
+
+  start(problem) {
+    this.cancel();
+    this._currentProblem = problem;
+    this._buf = '';
+    this._answerStartedAt = performance.now();
+    this._build();
+    this._overlay.classList.add('open');
+    this._overlay.setAttribute('aria-hidden', 'false');
+    this._focusFirstButton();
+    this._bindPhysicalKeys();
+    this._narrate('Speak the truth!');
+  }
+
+  cancel() {
+    Object.keys(this._timers).forEach(k => { if (this._timers[k]) { clearTimeout(this._timers[k]); this._timers[k] = null; } });
+    this._unbindPhysicalKeys();
+    if (this._overlay) {
+      this._overlay.classList.remove('open');
+      this._overlay.setAttribute('aria-hidden', 'true');
+      // keep DOM in place — show/hide via class only
+    }
+    this.onResolve = null;
+  }
+
+  _build() {
+    if (this._overlay) return;
+    this._overlay = document.createElement('div');
+    this._overlay.id = 'ultimate-overlay';
+    this._overlay.className = 'overlay';
+    this._overlay.setAttribute('role', 'dialog');
+    this._overlay.setAttribute('aria-modal', 'true');
+    this._overlay.setAttribute('aria-label', 'Ultimate spell');
+    this._overlay.setAttribute('aria-hidden', 'true');
+    // Build inner DOM: problem panel + sigil + numpad grid
+    // Use innerHTML with escHtml() on any interpolated values per CLAUDE.md
+    document.getElementById('overlay-root').appendChild(this._overlay);
+    // bind numpad clicks via addEventListener (never .onclick, never inline onclick="" attrs)
+  }
+
+  _onDigit(d) {
+    if (this._buf.length >= this._maxDigits) return;
+    this._buf += d;
+    this._renderSigil();
+  }
+
+  _onBackspace() { this._buf = this._buf.slice(0, -1); this._renderSigil(); }
+
+  _onCommit() {
+    if (this._buf.length === 0) return;
+    const value = parseInt(this._buf, 10);
+    const timeMs = performance.now() - this._answerStartedAt;
+    const correct = value === this._currentProblem.answer;
+    this._audio.play(correct ? 'ultimateFire' : 'wrong');
+    if (correct) this._fx.burst('wizard', 'KO!');
+    const cb = this.onResolve;
+    this.cancel();
+    this._timers._resolveTimer = setTimeout(() => { if (cb) cb({ correct, value, timeMs }); }, 400);
+  }
+
+  _renderSigil() {
+    const sigil = this._overlay.querySelector('#ultimate-sigil');
+    if (!sigil) return;
+    sigil.textContent = this._buf || ' ';
+    sigil.setAttribute('aria-label', this._buf ? `Entered ${this._buf}` : 'No digits entered');
+  }
+
+  _focusFirstButton() { /* focus the ✓ commit button last (last focusable in tab order); first focusable should be ⌫ — match repo convention "first focusable element must be a close button" by treating ⌫ as the close-equivalent */ }
+
+  _bindPhysicalKeys() {
+    this._physicalKeyHandler = (e) => {
+      if (this._buf === null) return;            // safety guard
+      if (e.key >= '0' && e.key <= '9') { this._onDigit(e.key); e.preventDefault(); }
+      else if (e.key === 'Backspace')   { this._onBackspace(); e.preventDefault(); }
+      else if (e.key === 'Enter')       { this._onCommit();    e.preventDefault(); }
+      else if (e.key === 'Escape')      {
+        // Close-via-Escape handler MUST guard against firing after overlay is already closed:
+        if (this._overlay && this._overlay.classList.contains('open')) {
+          // Treat Escape as cancel-and-revert: drain meter, revert to orb cast at half damage
+          const cb = this.onResolve;
+          this.cancel();
+          if (cb) cb({ correct: false, value: null, timeMs: performance.now() - this._answerStartedAt, escaped: true });
+        }
+      }
+    };
+    window.addEventListener('keydown', this._physicalKeyHandler);
+  }
+
+  _unbindPhysicalKeys() {
+    if (this._physicalKeyHandler) window.removeEventListener('keydown', this._physicalKeyHandler);
+    this._physicalKeyHandler = null;
+  }
+}
+```
+
+**ARIA contract (CLAUDE.md rules):**
+- `role="dialog" aria-modal="true" aria-label="Ultimate spell"` (never `<aside>`)
+- `aria-hidden` always explicit `"true"`/`"false"` — never `removeAttribute`
+- Focus trap (Tab/Shift-Tab cycle within the 12 numpad buttons + ⌫ + ✓), Escape closes (with `classList.contains('open')` guard)
+- On open: focus ⌫ (the "back-out" button — closest analog to "close")
+- On close: return focus to the canvas (so subsequent orb taps in the next round work via keyboard if user is in keyboard-only mode)
+- Each numpad button is a native `<button>` with proper `aria-label` (digit names spelled out for AT clarity)
+- `aria-pressed` is NOT used — these are action buttons, not toggles
+
+### 2. FightManager integration
+
+In `combat/fight.js`'s `_enterProblem()`:
+```js
+_enterProblem() {
+  if (this._monsterHpRemaining <= 0) { this._victory(); return; }
+  this._currentProblem = this._problemGen.selectProblem({ /* ... */ });
+  // ULTIMATE GATE
+  if (this._ultimateCharge >= 1.0) {
+    this._ultimate.onResolve = ({ correct, value, timeMs, escaped }) => this._resolveUltimate({ correct, value, timeMs, escaped });
+    this._ultimate.start(this._currentProblem);
+    this.state = 'ULTIMATE_ANSWERING';
+    return;
+  }
+  // standard orb path:
+  this._currentOrbs = this._distractors.generateDistractors(this._currentProblem, this._rng);
+  this._answerStartedAt = performance.now();
+  this.state = 'ANSWERING';
+  this._hud.setProblem(this._currentProblem.displayText);
+}
+
+_resolveUltimate({ correct, value, timeMs, escaped }) {
+  this._mastery.recordResolve(/* ... */);
+  if (correct) {
+    // Massive damage — usually one-shot kills
+    this._monsterHpRemaining = Math.max(0, this._monsterHpRemaining - 3);
+    this._ultimateCharge = 0;
+    this._streak++;
+    this._score += 500;
+    this._hud.setUltimateCharge(0);
+    this._anim.begin(this._monster.id, { kind: 'hit', startedAt: performance.now(), duration: 600 });
+    this._fx.panelFlash('#fff', 0.6);
+    this._timers._resolveTimer = setTimeout(() => {
+      if (this._monsterHpRemaining <= 0) this._victory();
+      else { this.state = 'PROBLEM'; this._enterProblem(); }
+    }, 800);
+  } else {
+    // Drain meter, revert to orb cast at half damage
+    this._ultimateCharge = 0;
+    this._streak = 0;
+    this._hud.setUltimateCharge(0);
+    this._hud.setStreak(0);
+    if (!escaped) this._narrate(`The answer was ${this._currentProblem.answer}.`);
+    // Half-damage path: re-enter problem and apply a damage modifier to the next correct answer
+    this._halfDamageOnNext = true;
+    this._timers._resolveTimer = setTimeout(() => { this.state = 'PROBLEM'; this._enterProblem(); }, 1200);
+  }
+}
+```
+
+### 3. CSS for numpad + sigil
+
+```css
+#ultimate-overlay { /* full-screen, panel-bordered, centered content */ }
+#ultimate-overlay .panel { background: var(--bg); border: 6px solid var(--accent-ink); border-radius: 16px; padding: 32px; max-width: 90vw; max-height: 90vh; }
+#ultimate-sigil { font-size: 96px; line-height: 1; min-height: 120px; padding: 16px 32px; text-align: center; border: 4px dashed var(--accent-comic-yellow); border-radius: 12px; background: rgba(240,216,64,0.1); transition: text-shadow 200ms; text-shadow: 0 0 12px rgba(240,216,64,0.6); }
+.numpad { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; margin-top: 24px; }
+.numpad button { min-width: 72px; min-height: 72px; font-size: 32px; }
+```
+
+## Tests to run
+
+Manual playtest via `?fight=goblin_grunt&ultimate=1` (debug param: starts a fight with ultimate already charged):
+
+- [ ] Ultimate overlay opens; problem text large; sigil empty initially
+- [ ] Tapping numpad digits accumulates into sigil; sigil shows live digits
+- [ ] ⌫ removes last digit
+- [ ] ✓ commits — correct = massive damage + KO sound, wrong = meter drains
+- [ ] Physical keyboard: digits 0–9 work; Backspace works; Enter commits; Escape closes (with revert)
+- [ ] Focus trap: Tab cycles only inside the numpad; Shift-Tab cycles backwards; Escape closes
+- [ ] On overlay close, focus returns somewhere usable (canvas / next interactive element)
+- [ ] aria-hidden flips correctly; never `removeAttribute`
+- [ ] No `aria-label` on `aria-live` regions (sigil uses `textContent` + dynamic `aria-label` only — both update together)
+- [ ] No `style.display` in JS
+
+## Acceptance checklist
+
+- [ ] Ultimate triggers when `_ultimateCharge >= 1.0` and resets to 0 on resolve
+- [ ] Numpad keys ≥ 72px (CLAUDE.md ≥44px floor with bonus)
+- [ ] Digit-echo sigil is at 96px in OpenDyslexic before commit
+- [ ] Physical keyboard support verified
+- [ ] Focus-trap Escape handler guards `classList.contains('open')`
+- [ ] Re-entry guard on `start()` (calls `cancel()` first)
+- [ ] No memory leak: opening + closing the ultimate 100× doesn't grow listener count (verify via `getEventListeners(window)` in devtools)
+- [ ] All existing Layer-1 tests still pass
+
+## Session end
+
+1. Re-run all Layer-1 tests
+2. Manual playtest of ultimate flow
+3. Run `marauder-web-review` agent
+4. Commit `Session 6: combat — typed ultimate spell + numpad + physical-key support`
+5. Push to `main`

--- a/claudes-math-marauder/sessions/session-07.md
+++ b/claudes-math-marauder/sessions/session-07.md
@@ -1,0 +1,230 @@
+# Session 7 — Boss Fight: Glyph Combo
+**Model:** Opus | **Focus:** Multi-phase boss state machine, glyph-shatter transitions, narrated phase breaks, KO cinematic. Realm 1's Goblin Warlord boss end-to-end.
+
+## Pre-flight
+
+1. Read spec section 3.2.3 (Boss glyph combo).
+2. Read `data/bosses.json` from Session 4 — Goblin Warlord schema.
+3. Re-read `keyboard-command-4` boss precedent (KC4 has multi-phase bosses with phase shortcutId arrays — same skeleton).
+4. Run `/marauder-checklist`.
+
+## Files to create
+
+- `claudes-math-marauder/js/combat/bossFight.js` — BossFightManager (extends/reuses FightManager pieces)
+
+## Files to modify
+
+- `claudes-math-marauder/js/game.js` — wire BossFightManager into FIGHT state when the active node is a boss
+- `claudes-math-marauder/js/combat/fight.js` — refactor any pieces that need to be shared between FightManager and BossFightManager into shared helpers (extract `_resolve()` if both need it; otherwise keep duplicate but well-tested)
+
+## Deliverables
+
+### 1. `combat/bossFight.js`
+
+```js
+class BossFightManager {
+  constructor(deps) {
+    // same deps as FightManager + boss data
+    this.state = 'IDLE';
+    this._boss = null;
+    this._bossCompiled = null;
+    this._currentPhaseIdx = 0;
+    this._currentProblem = null;
+    this._currentOrbs = [];
+    this._streak = 0;
+    this._retries = 0;
+    this._score = 0;
+    this._wizardFlavorHp = 60;
+    this._timers = { _introTimer: null, _phaseBreakTimer: null, _resolveTimer: null };
+    this.onComplete = null;
+    this._lessonComplete = false;
+  }
+
+  start(boss, realm, masteryMap) {
+    this.cancel();
+    this._lessonComplete = false;
+    this._boss = boss;
+    this._realm = realm;
+    this._masteryMap = masteryMap;
+    this._bossCompiled = this._renderer.buildCreature(boss);
+    this._currentPhaseIdx = 0;
+    this._streak = 0;
+    this._retries = 0;
+    this._score = 0;
+    this._wizardFlavorHp = 60;
+    this.state = 'INTRO';
+    this._timers._introTimer = setTimeout(() => this._enterPhase(0), 2400);
+    this._narrate(boss.introSpeech);
+    this._audio.play('bossSpawn');
+  }
+
+  cancel() { /* clear all timers, null onComplete (CLAUDE.md) */ }
+
+  _enterPhase(idx) {
+    if (idx >= this._boss.phases.length) { this._victory(); return; }
+    this._currentPhaseIdx = idx;
+    const phase = this._boss.phases[idx];
+    this.state = 'PHASE_INTRO';
+    this._hud.setBossPhaseLabel(`PHASE ${idx + 1}: ${phase.label}`);
+    this._narrate(phase.hint);
+    this._timers._phaseBreakTimer = setTimeout(() => this._enterProblem(), 1500);
+  }
+
+  _enterProblem() {
+    const phase = this._boss.phases[this._currentPhaseIdx];
+    // Build problem according to phase.kind
+    if (phase.kind === 'stretch') {
+      // Force a stretch problem from phase.factFamilyHint, falling back to a hard problem if not yet mastered
+      const stretch = this._problemGen._selectStretch({ masteryMap: this._masteryMap, rng: this._rng });
+      if (stretch) this._currentProblem = stretch;
+      else this._currentProblem = this._problemGen.selectProblem({ /* normal hard mul/div from the family */ });
+    } else {
+      // Filter to mul or div from the family hint
+      this._currentProblem = this._problemGen.selectProblem({ realm: { factFamilyWeights: { [phase.factFamilyHint]: 1.0 } }, masteryMap: this._masteryMap, recentKeys: [], rng: this._rng, mulRatio: phase.kind === 'mul' ? 1.0 : 0.0, allowStretch: false, realmTier: this._realm.tier });
+    }
+    if (phase.mode === 'ultimate') {
+      this._ultimate.onResolve = ({ correct, value, timeMs, escaped }) => this._resolve({ correct, value, timeMs, escaped });
+      this._ultimate.start(this._currentProblem);
+      this.state = 'PHASE_ULTIMATE';
+    } else {
+      this._currentOrbs = this._distractors.generateDistractors(this._currentProblem, this._rng);
+      this._answerStartedAt = performance.now();
+      this.state = 'PHASE_ORB';
+    }
+    this._hud.setProblem(this._currentProblem.displayText);
+  }
+
+  selectOrb(value) {
+    if (this.state !== 'PHASE_ORB') return;
+    const correct = value === this._currentProblem.answer;
+    const timeMs = performance.now() - this._answerStartedAt;
+    this._resolve({ correct, value, timeMs });
+  }
+
+  _resolve({ correct, value, timeMs, escaped }) {
+    this._mastery.recordResolve(this._masteryMap, this._currentProblem.factKey, { correct, timeMs, now: Date.now(), masteredAvgMs: this._mastery.masteredAvgMs(this._masteryMap) });
+    if (correct) {
+      this._streak++;
+      this._score += 200;
+      this._hud.setStreak(this._streak);
+      this._hud.setScore(this._score);
+      this._fx.panelFlash('#fff', 0.5);
+      this._fx.burst(this._boss.id, 'CRACK!');
+      this._anim.begin(this._boss.id, { kind: 'phase_break', startedAt: performance.now(), duration: 1100 });
+      this._audio.play('phaseBreak');
+      this._timers._phaseBreakTimer = setTimeout(() => this._enterPhase(this._currentPhaseIdx + 1), 1300);
+    } else {
+      this._streak = 0;
+      this._hud.setStreak(0);
+      this._wizardFlavorHp = Math.max(0, this._wizardFlavorHp - 15);
+      this._hud.setWizardHp(this._wizardFlavorHp);
+      this._anim.begin(this._boss.id, { kind: 'attack', startedAt: performance.now(), duration: 600 });
+      this._audio.play('wrong');
+      if (!escaped) this._narrate(`The answer was ${this._currentProblem.answer}.`);
+      this._timers._resolveTimer = setTimeout(() => {
+        if (this._wizardFlavorHp <= 0) this._defeatRetry();
+        else this._enterProblem();
+      }, 1500);
+    }
+  }
+
+  _victory() {
+    if (this._lessonComplete) return;
+    this._lessonComplete = true;
+    const cb = this.onComplete;
+    this.cancel();
+    this.state = 'BOSS_KO';
+    this._anim.begin(this._boss.id, { kind: 'death', startedAt: performance.now(), duration: 1500 });
+    this._fx.panelFlash('#fff', 1.0);
+    this._fx.burst(this._boss.id, 'VICTORY!');
+    this._audio.play('bossKo');
+    setTimeout(() => { if (cb) cb({ outcome: 'boss_victory', score: this._score, streak: this._streak, retries: this._retries, bossId: this._boss.id }); }, 2000);
+  }
+
+  _defeatRetry() {
+    this._retries++;
+    this._wizardFlavorHp = 60;
+    this._streak = 0;
+    this._narrate(`${this._boss.name} laughs! Try again!`);
+    this._timers._resolveTimer = setTimeout(() => this._enterPhase(this._currentPhaseIdx), 2000);
+  }
+
+  update(dt) { /* advance animations */ }
+  draw(ctx, w, h) { /* layered: background, parallax, boss, orbs (if phase=PHASE_ORB), wizard, comic effects */ }
+}
+```
+
+### 2. Phase break animation
+
+The "glyph shatter" effect on a successful phase break:
+1. Pause inputs (state = `PHASE_BREAK_ANIM`)
+2. Render a panel flash (`panelFlash('#fff', 0.7→0`)) over 200ms
+3. `inkBurst` at the boss's center — color matches `boss.palette[1]`
+4. Several small shape fragments fly outward (use `ParticlePool` with `kind: 'inkdot'`, ~12 particles)
+5. Boss shake for 300ms (`anim.begin(bossId, { kind: 'phase_shake' })`)
+6. Phase label fades out, next phase label fades in
+7. After 1300ms total, `_enterPhase(next)` is called
+
+### 3. Boss intro card
+
+Before the first problem, show a 2.4s intro:
+- Boss slides in from offscreen (translate animation)
+- Big panel-bordered title card overlaid: `boss.name` (e.g., "KORG THE WARLORD") in 64px with comic burst-style stroke
+- Boss intro speech narrated via Web Speech (boss `voiceProfile` applied)
+- Tap-to-skip the intro after 1.5s (per spec — skippable but not insta-dismissable)
+
+### 4. Boss KO cinematic
+
+When the last phase is cleared:
+- Boss takes a 1.5s death animation: ink-burst + halftone-fade + comic "VICTORY!" burst-text at the screen center
+- Screen-flash white at 100% (single frame)
+- A "loot drop" appears as a 2D animated card (gold + first-clear story panel unlock if applicable) — handled in Session 12 (results card); for now, just call `onComplete` after 2s
+
+### 5. game.js wiring
+
+```js
+// when entering FIGHT state for a boss node:
+if (node.kind === 'boss') {
+  this._bossFight.onComplete = (result) => this._onFightComplete(result);
+  this._bossFight.start(this._bossById(realm.bossId), realm, this._save.mastery);
+}
+// otherwise standard fight:
+else { this._fight.start(monster); }
+```
+
+## Tests to run
+
+Manual playtest via `?boss=goblin_warlord`:
+
+- [ ] Boss intro plays (slide-in + title card + narration)
+- [ ] Tap-to-skip works only after 1.5s
+- [ ] Phase 1 (BONE ARMOR — div from x5) renders correctly with orb cast
+- [ ] Correct answer → glyph-shatter effect + phase break animation
+- [ ] Phase 2 (BLOODFRENZY — mul from x10) similar
+- [ ] Phase 3 (FINAL ROAR — stretch with mode: ultimate) opens the ultimate overlay
+- [ ] Correct ultimate → boss KO cinematic with VICTORY! burst text
+- [ ] Wrong answer → wizard takes flavor damage; if HP hits 0, second-wind retry plays apology and re-enters current phase
+- [ ] Mastery is updated correctly per problem; saved once at fight end
+- [ ] Pause halts boss animations and speech
+- [ ] All existing Layer-1 tests still pass
+
+Edge cases:
+- [ ] Phase 3 stretch: if no `x5` family is mastered yet, stretch falls back to a normal hard problem (no crash)
+- [ ] Boss intro speech can be canceled by Pause without leaving speech queued
+- [ ] Phase break timer + intro timer both cleaned up on `cancel()`
+
+## Acceptance checklist
+
+- [ ] BossFightManager passes the same timer-lifecycle pattern as FightManager (constructor `null` IDs, `cancel()` clears all, `_victory` saves cb before cancel, re-entry guard `_lessonComplete`)
+- [ ] No `Math.random()` calls in `bossFight.js` (uses run-seeded `_rng`)
+- [ ] `aria-live` updates on `#hud-boss-phase-label` (new HUD element added) work without `aria-hidden` toggles
+- [ ] Boss intro and phase narrations use `speech.cancel()` then 50ms delay (CLAUDE.md iOS rule)
+- [ ] Goblin Warlord beatable end-to-end with 0 retries, 1 retry, 2 retries — score reflects correctly
+
+## Session end
+
+1. Re-run all Layer-1 tests
+2. Manual playtest end-to-end (multiple runs to test all retry paths)
+3. Run `marauder-web-review` agent
+4. Commit `Session 7: combat — boss glyph combo (Goblin Warlord end-to-end)`
+5. Push to `main`

--- a/claudes-math-marauder/sessions/session-08.md
+++ b/claudes-math-marauder/sessions/session-08.md
@@ -1,0 +1,263 @@
+# Session 8 — Audio: Web Speech + Web Audio SFX
+**Model:** Sonnet | **Focus:** Speech narration with iPad Safari quirks; full SFX bank synthesized; settings panel hooks
+
+## Pre-flight
+
+1. Read spec section 5 (Audio System).
+2. Read CLAUDE.md sections on Web Speech (iOS Safari), Web Audio (iOS Safari), `aria-live`/`aria-label` conflicts.
+3. Read `keyboard-command-4/js/audio.js` for the synthesized SFX precedent.
+4. Read `lizzies-petstore/js/audio.js` for the warm Web Audio + lazy-init precedent.
+5. Run `/marauder-checklist`.
+
+## Files to create
+
+- `claudes-math-marauder/js/audio/sfx.js` — synthesized sound bank
+- `claudes-math-marauder/js/audio/speech.js` — Web Speech wrapper with iPad Safari workarounds
+- `claudes-math-marauder/js/ui/settings.js` — Settings panel (speech voice picker, rate slider, sfx volume, mute, reduced motion, font scale)
+
+## Files to modify
+
+- `claudes-math-marauder/js/game.js` — wire up audio context lazy-init on first user gesture; settings overlay open/close
+- `claudes-math-marauder/js/save.js` — ensure all settings keys are in `_defaults()` (they should be from Session 1; verify)
+
+## Deliverables
+
+### 1. `audio/speech.js` — SpeechManager
+
+Singleton wrapper. Lazy `getVoices()` (iPad delays the list).
+
+```js
+class SpeechManager {
+  constructor() {
+    this._voices = [];
+    this._voiceURI = null;
+    this._rate = 1.0;
+    this._autoNarrate = true;
+    this._enabled = ('speechSynthesis' in window);
+    this._loadingVoicesPromise = null;
+    if (this._enabled) {
+      // iOS: voices may be empty initially; subscribe to voiceschanged
+      window.speechSynthesis.onvoiceschanged = () => this._loadVoices();
+      this._loadVoices();
+    }
+  }
+
+  _loadVoices() {
+    if (!this._enabled) return;
+    this._voices = window.speechSynthesis.getVoices();
+  }
+
+  setSettings({ voiceURI, rate, autoNarrate }) {
+    if (voiceURI !== undefined) this._voiceURI = voiceURI;
+    if (rate !== undefined) this._rate = rate;
+    if (autoNarrate !== undefined) this._autoNarrate = autoNarrate;
+  }
+
+  speak(text, opts = {}) {
+    if (!this._enabled) return;
+    if (!text) return;
+    const u = new SpeechSynthesisUtterance(text);
+    u.rate = opts.rate ?? this._rate;
+    u.pitch = opts.pitch ?? 1.0;
+    if (this._voiceURI) {
+      const v = this._voices.find(x => x.voiceURI === this._voiceURI);
+      if (v) u.voice = v;
+    } else {
+      // Auto-pick best iPad voice
+      const preferred = ['Daniel', 'Karen', 'Samantha', 'Moira'];
+      const v = this._voices.find(x => preferred.some(p => x.name.includes(p)));
+      if (v) u.voice = v;
+    }
+    // iOS quirk: cancel + 50ms delay
+    window.speechSynthesis.cancel();
+    setTimeout(() => {
+      try { window.speechSynthesis.speak(u); }
+      catch (e) { /* swallow — speech is best-effort */ }
+    }, 50);
+  }
+
+  cancel() {
+    if (!this._enabled) return;
+    try { window.speechSynthesis.cancel(); } catch {}
+  }
+
+  pause() { if (this._enabled) try { window.speechSynthesis.pause(); } catch {} }
+  resume() { if (this._enabled) try { window.speechSynthesis.resume(); } catch {} }
+
+  speakIfAuto(text, opts) { if (this._autoNarrate) this.speak(text, opts); }
+
+  isSupported() { return this._enabled; }
+  getVoices() { return this._voices.slice(); }
+}
+```
+
+**Note on `_autoNarrate`:** If true, dynamic on-screen text triggers speech automatically. If false, only manual 🔊 button taps trigger speech. The 🔊 button is always available regardless of setting.
+
+### 2. `audio/sfx.js` — SFX bank
+
+Single AudioContext, lazy-created on first user gesture.
+
+```js
+class SfxBank {
+  constructor() {
+    this._ctx = null;
+    this._volume = 0.7;
+    this._muted = false;
+  }
+
+  _getCtx() {
+    if (this._ctx) return this._ctx;
+    try {
+      this._ctx = new (window.AudioContext || window.webkitAudioContext)();
+    } catch (e) { return null; }
+    return this._ctx;
+  }
+
+  // Caller passes a user-gesture-bound function. Internally we lazy-create the ctx and call ctx.resume().
+  play(name) {
+    if (this._muted) return;
+    const ctx = this._getCtx();
+    if (!ctx) return;
+    ctx.resume().then(() => this._schedule(name, ctx)).catch(() => {});
+  }
+
+  setVolume(v) { this._volume = Math.max(0, Math.min(1, v)); }
+  setMuted(m) { this._muted = !!m; if (m) try { this._ctx?.suspend(); } catch {} else try { this._ctx?.resume(); } catch {} }
+
+  _schedule(name, ctx) {
+    const g = ctx.createGain(); g.gain.value = this._volume; g.connect(ctx.destination);
+    const fn = SFX_RECIPES[name];
+    if (!fn) return;
+    fn(ctx, g);
+  }
+}
+
+const SFX_RECIPES = {
+  orbHover(ctx, out) { /* sine 600Hz, 80ms, low-pass 1500Hz */ },
+  orbCorrect(ctx, out) { /* square sweep 220 → 880Hz, 120ms */ },
+  spellCast(ctx, out) { /* triangle + filtered noise burst, 200ms */ },
+  hit(ctx, out) { /* low square 110Hz + noise thump, 150ms */ },
+  critHit(ctx, out) { /* hit recipe + sine 1760Hz arpeggio sparkle */ },
+  wrong(ctx, out) { /* low triangle 80Hz, 200ms — soft, never harsh */ },
+  streakChime3(ctx, out) { /* sine bell arpeggio */ },
+  streakChime5(ctx, out) { /* sine bell arpeggio higher */ },
+  streakChime10(ctx, out) { /* sine bell arpeggio highest + reverb tail */ },
+  ultimateChargeFull(ctx, out) { /* rising sine 220→880Hz, 600ms */ },
+  ultimateFire(ctx, out) { /* layered sweep + screen-flash sync — duration ~700ms */ },
+  bossSpawn(ctx, out) { /* low rumble (filtered noise) + dramatic chord */ },
+  ko(ctx, out) { /* triumphant 4-note motif — sine major arpeggio */ },
+  bossKo(ctx, out) { /* ko motif extended + low boom */ },
+  pageFlip(ctx, out) { /* paper rustle (filtered noise burst) */ },
+  uiTap(ctx, out) { /* soft 40ms click */ },
+  phaseBreak(ctx, out) { /* sharp filtered-noise crack + sparkle */ },
+  monsterSpawn(ctx, out) { /* short low burst + cute whine */ },
+  goblinGrunt(ctx, out) { /* short cute whine */ },
+};
+```
+
+Each recipe creates `OscillatorNode` / `BiquadFilterNode` / `AudioBuffer`-based noise, schedules envelopes via `AudioParam.setValueAtTime` and `linearRampToValueAtTime`, calls `osc.start(ctx.currentTime); osc.stop(ctx.currentTime + duration);`. **All inside the `.then()` of `ctx.resume()`** (already handled by the dispatcher). Never schedule outside `_schedule()`.
+
+**Implementation rule:** No deep / sudden / harsh sounds. All sound levels capped at `globalVolume × 0.7` so even max-volume the wrong-answer thump is "soft".
+
+### 3. `ui/settings.js` — Settings panel
+
+Settings overlay opened from a gear button on TITLE and HUB. Modal dialog with focus trap.
+
+UI elements:
+- Speech voice dropdown (`<select>`) populated from `speech.getVoices()`. Disabled if voices empty / speech unsupported with a helpful message.
+- Speech rate slider: 0.7–1.3 step 0.1, label updates with current value, `aria-valuetext="1.0 times speed"` updated dynamically
+- Auto-narrate toggle: native `<input type="checkbox">` (no `aria-pressed` — `checked` is the ARIA carrier per CLAUDE.md)
+- SFX volume slider 0–1 step 0.1
+- Master mute toggle (checkbox)
+- Reduced motion toggle (checkbox; default reflects `prefers-reduced-motion` media query)
+- Font scale dropdown: 0.9 / 1.0 / 1.1 / 1.25 / 1.5 — applied via `document.documentElement.style.fontSize`, NOT by re-declaring CSS vars (CLAUDE.md rule)
+- Show speed timer (checkbox; off by default)
+- Allow stretch facts (checkbox; on by default)
+- Reset progress button — opens a nested confirmation dialog
+- Test-speech button — speaks "Hello, math marauder" using current settings
+
+All changes save to `data.settings` via SaveManager on each `change` event (not on close — user might forget to close).
+
+**Modal accessibility (CLAUDE.md):**
+- `<div role="dialog" aria-modal="true" aria-label="Settings">`
+- First focusable element = close (✕) button
+- Tab/Shift-Tab focus trap
+- Escape closes (with `classList.contains('open')` guard)
+- On open: focus close button, set `aria-hidden="false"`, set `aria-expanded="true"` on trigger
+- On close: focus returns to trigger button (the gear icon)
+
+### 4. 🔊 button helper
+
+A small utility: `attachReadAloud(el, getText)` scans for or attaches a 🔊 button to any text-bearing element. Used by HUD problem panel, story panels, mystery event prompts, settings labels.
+
+```js
+export function attachReadAloud(parent, getText, opts = {}) {
+  const btn = document.createElement('button');
+  btn.className = 'read-aloud';
+  btn.setAttribute('aria-label', 'Read aloud');
+  btn.innerHTML = '🔊';
+  btn.addEventListener('click', () => { window.speech.speak(getText()); btn.setAttribute('aria-label', 'Replay'); });
+  parent.appendChild(btn);
+  if (!window.speech?.isSupported?.()) btn.disabled = true;     // CLAUDE.md: native disabled for proper AT
+  return btn;
+}
+```
+
+### 5. `prefers-reduced-motion` integration
+
+In `game.js`'s init:
+```js
+const prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+const settingReduced = save.settings.reducedMotion;
+const reducedMotion = prefersReduced || settingReduced;
+document.body.dataset.reducedMotion = reducedMotion ? '1' : '0';
+```
+The `[data-reduced-motion="1"]` selector in CSS strips screen-shake, panel-flashes, and any high-frequency animations. The fx library reads `document.body.dataset.reducedMotion` once per state-entry (cache it; don't query the DOM per frame).
+
+## Tests to run
+
+Manual:
+
+- [ ] Speech: open title screen, tap 🔊 next to subtitle. Audio plays "A game by Claude".
+- [ ] Speech: voice dropdown populates with available voices on iPad
+- [ ] Speech: rate slider changes playback speed when re-tested
+- [ ] Speech: cancelling and re-speaking works without dropping the second utterance (the 50ms delay)
+- [ ] Speech: Pause halts, Resume continues
+- [ ] Speech: works gracefully when `'speechSynthesis' in window === false` (Safari without the API in some configurations)
+- [ ] SFX: orb tap plays the correct chime; volume slider changes loudness; mute disables all SFX
+- [ ] SFX: AudioContext is created only on first user gesture (verify in devtools — no warning about user gesture)
+- [ ] SFX: all wrong-answer sounds are soft, not harsh
+- [ ] Settings: focus trap traps Tab; Escape closes; focus returns to gear button
+- [ ] Settings: every change persists in localStorage immediately
+- [ ] Settings: reset progress shows confirmation; on confirm, save is reset to defaults
+- [ ] Reduced motion: enabling it strips screen-shake on next combat hit
+
+Re-run Layer-1 tests:
+```bash
+node claudes-math-marauder/scripts/test-fact-keys.js
+node claudes-math-marauder/scripts/test-mastery.js
+node claudes-math-marauder/scripts/test-problem-gen.js
+node claudes-math-marauder/scripts/test-distractors.js
+node claudes-math-marauder/scripts/test-save-migration.js
+```
+
+## Acceptance checklist
+
+- [ ] AudioContext is lazy-created in `_getCtx()`, never in a constructor
+- [ ] All oscillators scheduled inside `ctx.resume().then(() => ...)` (no oscillator scheduling outside the resolved promise)
+- [ ] `speechSynthesis.cancel()` always followed by 50ms `setTimeout` before `.speak()` (iOS quirk)
+- [ ] Voice list refreshed on `voiceschanged` event
+- [ ] Settings panel has focus trap + Escape + focus-return; Escape guard checks `classList.contains('open')`
+- [ ] No `aria-pressed` on `<input type="checkbox">` elements
+- [ ] No `aria-label` on `aria-live` regions in the settings panel
+- [ ] All settings persist to `data.settings` via SaveManager — not direct `localStorage`
+- [ ] Reset-progress dialog uses native `<button>` with `aria-label`; double-click resistant via debounce
+- [ ] Font scale applied via `document.documentElement.style.fontSize` only
+
+## Session end
+
+1. Re-run all Layer-1 tests
+2. Manual playtest of speech, SFX, settings panel
+3. Run `marauder-web-review` agent
+4. Commit `Session 8: audio — speech, synthesized SFX, settings panel`
+5. Push to `main`

--- a/claudes-math-marauder/sessions/session-09.md
+++ b/claudes-math-marauder/sessions/session-09.md
@@ -1,0 +1,358 @@
+# Session 9 — Run Map: Branching Graph + Resume
+**Model:** Opus | **Focus:** Deterministic Slay-the-Spire-style branching map; map screen UI; mid-run auto-save; resume on reload. **Realm 1 fully playable end-to-end after this session.**
+
+## Pre-flight
+
+1. Read spec sections 2.3 (run length & shape), 6.4 (run state).
+2. Read this plan's mapGen section.
+3. Run `/marauder-checklist`.
+
+## Files to create
+
+- `claudes-math-marauder/js/run/mapGen.js` — pure-logic deterministic map generator
+- `claudes-math-marauder/js/run/runtime.js` — run lifecycle (start, advance, save, abandon, resume)
+- `claudes-math-marauder/js/run/mapScreen.js` — DOM/canvas map screen UI
+- `claudes-math-marauder/js/run/events.js` — Mystery event resolver (Realm 1's 5 events)
+- `claudes-math-marauder/js/run/shop.js` — Spell-shop offering generator + UI
+- `claudes-math-marauder/scripts/test-map-gen.js`
+
+## Files to modify
+
+- `claudes-math-marauder/js/game.js` — wire RUN_MAP / FIGHT / RESULTS state transitions; on init, if `save.activeRun` is set, resume into RUN_MAP at that node
+
+## Deliverables
+
+### 1. `run/mapGen.js` — Pure-logic map generation
+
+```js
+(function(global) {
+  'use strict';
+
+  // Build a deterministic branching map from (seed, realm).
+  // Returns { nodes: Map(id -> nodeRecord), startId, bossId, columns: [[ids], [ids], ...] }
+  // Node record: { id, kind, column, row, x, y, edgesOut: [ids], visited, completed }
+  function generateMap(seed, realm) {
+    const rng = _mulberry32(seed);
+
+    // Node-type composition — drawn from realm.nodeCounts
+    const counts = { ...realm.nodeCounts };
+    // Build a multiset of node kinds (excluding boss + start)
+    const pool = [];
+    Object.entries(counts).forEach(([kind, n]) => { for (let i = 0; i < n; i++) pool.push(kind); });
+    // Shuffle pool (Fisher-Yates with seeded rng)
+    for (let i = pool.length - 1; i > 0; i--) { const j = Math.floor(rng() * (i + 1)); [pool[i], pool[j]] = [pool[j], pool[i]]; }
+    const total = pool.length;     // should be 9 (5+1+1+1+1) for Realm 1, leaves 11 with start+boss
+
+    // Lay out columns: 4 columns of 2-3 nodes each + final boss column with 1 node
+    // Constraint: total in middle columns = pool.length
+    // Strategy: 4 columns, sizes [2, 3, 2, 2] = 9 (matches Realm 1); pull from pool in order
+    const layout = _layoutForRealm(realm, pool.length);  // returns array of column sizes
+    const columns = [];
+    columns.push(['start']);                              // col 0
+    let idCounter = 1;
+    layout.forEach((size, ci) => {
+      const col = [];
+      for (let i = 0; i < size; i++) {
+        const kind = pool.shift();
+        col.push(`n${idCounter++}:${kind}`);
+      }
+      columns.push(col);
+    });
+    columns.push(['boss']);
+
+    // Build nodes Map
+    const nodes = new Map();
+    columns.forEach((col, ci) => {
+      col.forEach((id, ri) => {
+        const kind = id === 'start' ? 'start' : id === 'boss' ? 'boss' : id.split(':')[1];
+        nodes.set(id, { id, kind, column: ci, row: ri, x: ci, y: ri, edgesOut: [], visited: false, completed: false });
+      });
+    });
+
+    // Connect each node in column ci to 1-2 nodes in column ci+1
+    // Constraints:
+    //   - Every node in ci has at least 1 outgoing edge
+    //   - Every node in ci+1 has at least 1 incoming edge
+    //   - Edges don't cross (ri sorted: a node at row r in ci can connect to rows in [r-1, r, r+1] of ci+1, clamped)
+    for (let ci = 0; ci < columns.length - 1; ci++) {
+      const fromCol = columns[ci];
+      const toCol = columns[ci + 1];
+      _connectColumns(fromCol, toCol, nodes, rng);
+    }
+
+    return {
+      nodes, startId: 'start', bossId: 'boss',
+      columns: columns.map(c => c.slice())
+    };
+  }
+
+  function _layoutForRealm(realm, poolSize) {
+    // For Realm 1 with poolSize=9, return [2,3,2,2].
+    // For other realms, compute a balanced 4-column layout: split poolSize across 4 columns evenly with remainder spread to middle.
+    const nCols = 4;
+    const base = Math.floor(poolSize / nCols);
+    const extra = poolSize - base * nCols;   // distribute these to col indices [1, 2, 3, ...]
+    const sizes = Array(nCols).fill(base);
+    for (let i = 0; i < extra; i++) sizes[i + 1 < nCols ? i + 1 : i] += 1;
+    return sizes;
+  }
+
+  function _connectColumns(fromCol, toCol, nodes, rng) {
+    // Greedy: each fromNode connects to 1-2 toNodes within row ±1.
+    // Then sweep toCol — any toNode with no incoming, connect from the closest fromNode.
+    fromCol.forEach((fromId, fromRow) => {
+      const candidates = toCol.filter((_, toRow) => Math.abs(toRow - fromRow) <= 1);
+      // Connect to 1 or 2 candidates randomly
+      const nEdges = candidates.length === 1 ? 1 : (rng() < 0.5 ? 1 : 2);
+      const picks = _pickN(candidates, Math.min(nEdges, candidates.length), rng);
+      picks.forEach(toId => {
+        const fn = nodes.get(fromId);
+        if (!fn.edgesOut.includes(toId)) fn.edgesOut.push(toId);
+      });
+    });
+    // Ensure every toNode has incoming
+    toCol.forEach((toId, toRow) => {
+      const hasIncoming = fromCol.some(fromId => nodes.get(fromId).edgesOut.includes(toId));
+      if (!hasIncoming) {
+        // Find closest fromNode by row and link
+        let bestFrom = fromCol[0]; let bestDiff = Infinity;
+        fromCol.forEach((fromId, fromRow) => { const d = Math.abs(toRow - fromRow); if (d < bestDiff) { bestDiff = d; bestFrom = fromId; } });
+        nodes.get(bestFrom).edgesOut.push(toId);
+      }
+    });
+  }
+
+  function _pickN(arr, n, rng) {
+    const copy = arr.slice();
+    for (let i = copy.length - 1; i > 0; i--) { const j = Math.floor(rng() * (i + 1)); [copy[i], copy[j]] = [copy[j], copy[i]]; }
+    return copy.slice(0, n);
+  }
+
+  function _mulberry32(seed) {
+    let s = seed | 0;
+    return () => {
+      s = (s + 0x6D2B79F5) | 0;
+      let t = Math.imul(s ^ (s >>> 15), 1 | s);
+      t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+      return ((t ^ (t >>> 14)) >>> 0) / 0xFFFFFFFF;
+    };
+  }
+
+  // BFS reachability check (used by tests + at runtime to verify no orphan nodes)
+  function bfsReachable(map, fromId) {
+    const seen = new Set([fromId]);
+    const queue = [fromId];
+    while (queue.length) {
+      const id = queue.shift();
+      const n = map.nodes.get(id);
+      if (!n) continue;
+      for (const next of n.edgesOut) if (!seen.has(next)) { seen.add(next); queue.push(next); }
+    }
+    return seen;
+  }
+
+  const exp = { generateMap, bfsReachable };
+  if (typeof module !== 'undefined' && module.exports) module.exports = exp;
+  else global.MapGen = exp;
+})(typeof window !== 'undefined' ? window : globalThis);
+```
+
+### 2. `scripts/test-map-gen.js`
+
+```js
+const MG = require('../js/run/mapGen.js');
+const assert = require('assert');
+let p=0,f=0; function it(n,fn){try{fn();console.log('PASS',n);p++}catch(e){console.error('FAIL',n,e.message);f++}}
+
+const realm1 = { nodeCounts: { combat: 5, elite: 1, spellshop: 1, mystery: 1, rest: 1 } };
+
+it('every map has exactly one start and one boss', () => {
+  for (let s = 1; s <= 50; s++) {
+    const m = MG.generateMap(s, realm1);
+    let starts = 0, bosses = 0;
+    m.nodes.forEach(n => { if (n.kind === 'start') starts++; if (n.kind === 'boss') bosses++; });
+    assert.strictEqual(starts, 1);
+    assert.strictEqual(bosses, 1);
+  }
+});
+
+it('all nodes reachable from start (BFS)', () => {
+  for (let s = 1; s <= 100; s++) {
+    const m = MG.generateMap(s, realm1);
+    const reached = MG.bfsReachable(m, m.startId);
+    assert.strictEqual(reached.size, m.nodes.size, `seed ${s}: reached ${reached.size} / total ${m.nodes.size}`);
+  }
+});
+
+it('boss reachable via every leaf path (no orphan branches)', () => {
+  // Every node must have at least one path to boss.
+  for (let s = 1; s <= 50; s++) {
+    const m = MG.generateMap(s, realm1);
+    m.nodes.forEach((n, id) => {
+      const reached = MG.bfsReachable(m, id);
+      assert.ok(reached.has(m.bossId), `seed ${s}: ${id} cannot reach boss`);
+    });
+  }
+});
+
+it('total node count is 11 for Realm 1 (start + 9 middle + boss)', () => {
+  for (let s = 1; s <= 50; s++) {
+    const m = MG.generateMap(s, realm1);
+    assert.strictEqual(m.nodes.size, 11);
+  }
+});
+
+it('determinism: same (seed, realm) produces identical map', () => {
+  const a = MG.generateMap(42, realm1);
+  const b = MG.generateMap(42, realm1);
+  // Compare adjacency lists
+  const sigA = JSON.stringify([...a.nodes.entries()].sort().map(([id, n]) => [id, n.edgesOut.slice().sort()]));
+  const sigB = JSON.stringify([...b.nodes.entries()].sort().map(([id, n]) => [id, n.edgesOut.slice().sort()]));
+  assert.strictEqual(sigA, sigB);
+});
+
+it('different seeds produce different maps', () => {
+  const a = MG.generateMap(1, realm1);
+  const b = MG.generateMap(2, realm1);
+  const sigA = JSON.stringify([...a.nodes.entries()].sort().map(([id, n]) => [id, n.edgesOut.slice().sort()]));
+  const sigB = JSON.stringify([...b.nodes.entries()].sort().map(([id, n]) => [id, n.edgesOut.slice().sort()]));
+  assert.notStrictEqual(sigA, sigB);
+});
+
+console.log(`\n${p} passed, ${f} failed`);
+process.exit(f>0?1:0);
+```
+
+### 3. `run/runtime.js` — Run lifecycle
+
+```js
+class Runtime {
+  startRun(realm, classData) {
+    const seed = Date.now() & 0x7fffffff;       // simple seed; could be UUID-derived
+    const map = MapGen.generateMap(seed, realm);
+    const data = SaveManager.load();
+    data.activeRun = {
+      runId: _uuid(),
+      realmId: realm.id,
+      classId: classData.id,
+      deck: data.equippedDeck.slice(),
+      seed,
+      mapNodes: _serializeMap(map),
+      currentNodeId: map.startId,
+      wizardHpFlavor: 60,
+      streak: 0,
+      score: 0,
+      retries: 0,
+      ultimateCharge: 0,
+      goldThisRun: 0,
+      spellsAddedThisRun: [],
+      factsThisRun: [],
+      startedAt: Date.now()
+    };
+    data.totalRunsStarted++;
+    SaveManager.save(data);
+    return data.activeRun;
+  }
+
+  advanceTo(nodeId) { /* update activeRun.currentNodeId + mark visited; SaveManager.save() */ }
+  resolveNode(outcome) { /* apply outcome to activeRun (gold delta, spell unlock, etc.); save */ }
+  finishRun({ outcome, stars, score }) { /* write realmStars, increment totalRunsCompleted, clear activeRun, save */ }
+  abandonRun() { /* clear activeRun without star/completed credit; save */ }
+  resume() { /* return SaveManager.load().activeRun (may be null) */ }
+}
+```
+
+### 4. `run/mapScreen.js` — Map screen UI
+
+DOM-based (faster than canvas for static UI; accessible).
+
+- A grid layout of node buttons. Columns positioned via CSS grid. Edges drawn as inline SVG lines beneath the buttons.
+- Each node is a `<button>` with:
+  - Icon emoji (⚔️ 👹 🛒 🔮 💤 👑) + label
+  - `aria-label="Combat node, row 2"` updated dynamically as state changes
+  - Disabled (`<button disabled>`) for nodes not reachable from `currentNodeId` (via BFS using only outgoing edges from currently-visited)
+  - `.locked` class for visual treatment in addition to native `disabled`
+  - `.completed` class for already-cleared nodes
+- The currently selectable nodes (next column from current) get a `.glow` class with subtle pulsing animation
+- Click → `runtime.advanceTo(nodeId)` then transition to FIGHT / SHOP / MYSTERY / REST overlay
+
+**SVG edges:** Generated once per map from `nodes` adjacency list. Edges from completed nodes have a different color to show progress.
+
+### 5. `run/events.js` — Mystery event resolver
+
+Read from `data/events.json`. On entering a Mystery node:
+1. Open a modal dialog (focus trap + Escape + focus return)
+2. Show event prompt + 🔊 button (auto-narrated if setting on)
+3. Show 2-3 choice buttons; on click, apply outcomes
+4. Outcome kinds:
+   - `gold`: `runtime.modifyGold(delta)`
+   - `heal`: not used in B3 (no real HP); flavor only
+   - `damage`: flavor wizard HP only
+   - `spell`: pick a random spell of the given rarity from `data/spells.json` excluding owned; add to `ownedSpellIds` and `spellsAddedThisRun`
+   - `streak_bonus`: extend streak counter
+   - `class_unlock`: unused in events, reserved
+5. Display outcome text (also narrated), then close the modal and continue to next column
+
+### 6. `run/shop.js` — Spell shop offerings
+
+When entering a Spellshop node, generate 3 random offerings:
+- Use the run's `seed` mixed with `nodeId` as a sub-seed for determinism
+- Offerings: 1 random common (~40% odds), 1 random common-or-rare, 1 random rare-or-epic
+- Filter out spells the player already owns
+- Each offering shows: name, rarity badge, cost (rarity-tiered), modifier summary, 🔊 button for narration
+- Two buttons: "Buy" (disabled if `gold < cost`), "Skip" (always enabled)
+- On Buy: `gold -= cost`, `ownedSpellIds.push(spellId)`, save, close modal, advance
+
+### 7. `game.js` integration
+
+- On init: check `save.activeRun`; if non-null, transition to RUN_MAP and restore from `mapNodes` + `currentNodeId`
+- On entering RUN_MAP: build map from `seed + realmId` (deterministic) and overlay `visited`/`completed` from `activeRun.mapNodes`
+- On selecting a node: dispatch to FIGHT (combat/elite/boss) or open the appropriate overlay (shop/mystery/rest)
+- On FIGHT victory: increment `goldThisRun` (random 5–15 gold), call `runtime.advanceTo(nextNode)`, return to RUN_MAP
+- On reaching BOSS node and winning: open RESULTS card → `finishRun()` → return to HUB
+
+### 8. Resume contract
+
+- Auto-save fires after every node advance and every modal-close
+- On reload, the player resumes at exactly the node they left from, with all run-scoped state intact (gold, streak, retries, ultimate charge, deck additions, mastery deltas)
+- "Quit run" button on the map screen calls `abandonRun()` and returns to HUB; the run is irrevocably abandoned (no resume from arbitrary point)
+
+## Tests to run
+
+```bash
+node claudes-math-marauder/scripts/test-map-gen.js
+```
+
+Plus all existing Layer-1 tests must still pass.
+
+Manual playtest of Realm 1 end-to-end:
+
+- [ ] Start a run from HUB
+- [ ] Map renders with 11 nodes, start glowing, all others locked
+- [ ] Click first available node → fight launches, win → return to map, current node moves forward
+- [ ] All node kinds tested: combat, elite, spellshop, mystery, rest
+- [ ] Reaching boss node launches Goblin Warlord boss fight
+- [ ] On boss victory, RESULTS card shown (placeholder OK — Session 12 fleshes it out)
+- [ ] On reload mid-run, the run resumes at the exact same node with all state preserved
+- [ ] On "Quit run", run is abandoned cleanly; HUB reflects no active run
+
+## Acceptance checklist
+
+- [ ] `mapGen.js` is pure (no DOM / canvas / audio imports); UMD-exported for Node tests
+- [ ] All 6 map-gen tests pass
+- [ ] `test-map-gen.js` part of standard Layer-1 test runs
+- [ ] Resume works after browser close
+- [ ] Map nodes use native `<button disabled>` for locked (CLAUDE.md ARIA rule)
+- [ ] Edges drawn via inline SVG (works with screen readers; visual)
+- [ ] No `style.display` in JS; visibility via classes
+- [ ] Mystery / Shop overlays follow modal accessibility contract (focus trap + Escape + focus return)
+- [ ] Run advance / save uses `runtime.advanceTo()` — never direct `SaveManager.save()` from event handlers
+- [ ] Realm 1 fully playable from HUB → run → boss → results → HUB
+
+## Session end
+
+1. Re-run all Layer-1 tests including the new map-gen tests
+2. Manual playtest: complete at least 2 full runs of Realm 1 (one with 0 retries, one with 2+ retries) to verify mastery deltas and run-state persistence
+3. Run `marauder-web-review` agent
+4. Commit `Session 9: run map — branching graph, mid-run save, resume, Realm 1 playable`
+5. Push to `main`

--- a/claudes-math-marauder/sessions/session-10.md
+++ b/claudes-math-marauder/sessions/session-10.md
@@ -1,0 +1,389 @@
+# Session 10 — Hub: Wizard's Tower, Deck Builder, Codex
+**Model:** Sonnet | **Focus:** The persistent home base — class picker, spell deck builder, codex (mastery heatmap with tap-to-drill), star-rating display, story-panel viewer, gold ledger.
+
+By the end, the player has a "home" between runs that shows their progress, lets them tweak their loadout, and surfaces the mastery heatmap as a teaching tool.
+
+## Pre-flight
+
+1. Read spec sections 2.4 (Hub) and 5 (Save Schema).
+2. Re-read CLAUDE.md sections on modal dialogs, focus return, dynamic aria-label, native `<button disabled>`.
+3. Re-read `lizzies-petstore`'s settings panel as a precedent for layered overlays + focus return.
+4. Run `/marauder-checklist`.
+
+## Files to create
+
+- `claudes-math-marauder/js/hub/hub.js` — Hub screen controller (top-level layout, button bindings)
+- `claudes-math-marauder/js/hub/deckBuilder.js` — Deck builder overlay (pick 4 spells from owned)
+- `claudes-math-marauder/js/hub/classPicker.js` — Class picker overlay (pick 1 of N unlocked classes)
+- `claudes-math-marauder/js/hub/codex.js` — Codex overlay (13×13 mastery heatmap + tap-to-drill mini-fights)
+- `claudes-math-marauder/js/hub/story.js` — Story panel viewer overlay (panels unlocked so far + audio narration)
+- `claudes-math-marauder/js/hub/realmPicker.js` — Realm picker (5 realms, locked/unlocked + star rating per realm)
+
+## Files to modify
+
+- `claudes-math-marauder/js/game.js` — wire HUB state, route between hub overlays and run lifecycle
+- `claudes-math-marauder/index.html` — add hub DOM scaffold (screens, overlay roots)
+- `claudes-math-marauder/css/style.css` — hub layout, codex heatmap grid, deck-builder rows
+- `claudes-math-marauder/js/save.js` — confirm `_defaults()` covers everything hub reads (audit pass)
+
+## Deliverables
+
+### 1. `index.html` HUB scaffold
+
+```html
+<!-- HUB screen: visible when game.state === 'HUB' -->
+<section id="hub-screen" class="screen" aria-label="Wizard's Tower">
+  <header class="hub-header">
+    <h1>WIZARD'S TOWER</h1>
+    <div class="hub-stats" role="group" aria-label="Stats">
+      <div class="stat" id="hub-stat-gold"><span class="stat-icon" aria-hidden="true">💰</span><span class="stat-value" aria-label="Gold: 0">0</span></div>
+      <div class="stat" id="hub-stat-class"><span class="stat-icon" aria-hidden="true">🧙</span><span class="stat-value" aria-label="Class: Apprentice">Apprentice</span></div>
+    </div>
+  </header>
+
+  <div class="hub-grid">
+    <button class="hub-tile" id="hub-btn-start-run" aria-label="Start a new run">
+      <span class="tile-icon" aria-hidden="true">⚔️</span>
+      <span class="tile-title">START RUN</span>
+      <span class="tile-sub" id="hub-btn-start-run-sub">Choose a realm</span>
+    </button>
+    <button class="hub-tile" id="hub-btn-deck" aria-label="Build your spell deck">
+      <span class="tile-icon" aria-hidden="true">📜</span>
+      <span class="tile-title">DECK</span>
+      <span class="tile-sub" id="hub-btn-deck-sub">4 spells equipped</span>
+    </button>
+    <button class="hub-tile" id="hub-btn-class" aria-label="Pick your wizard class">
+      <span class="tile-icon" aria-hidden="true">🎓</span>
+      <span class="tile-title">CLASS</span>
+      <span class="tile-sub" id="hub-btn-class-sub">1 unlocked</span>
+    </button>
+    <button class="hub-tile" id="hub-btn-codex" aria-label="View the codex of facts">
+      <span class="tile-icon" aria-hidden="true">📖</span>
+      <span class="tile-title">CODEX</span>
+      <span class="tile-sub" id="hub-btn-codex-sub">0 / 169 mastered</span>
+    </button>
+    <button class="hub-tile" id="hub-btn-story" aria-label="View story panels">
+      <span class="tile-icon" aria-hidden="true">📚</span>
+      <span class="tile-title">STORY</span>
+      <span class="tile-sub" id="hub-btn-story-sub">0 panels</span>
+    </button>
+    <button class="hub-tile" id="hub-btn-settings" aria-label="Open settings">
+      <span class="tile-icon" aria-hidden="true">⚙️</span>
+      <span class="tile-title">SETTINGS</span>
+      <span class="tile-sub">Voice, font, audio</span>
+    </button>
+  </div>
+
+  <!-- Resume run banner (only when active run exists) -->
+  <div id="hub-resume-banner" class="banner" hidden>
+    <span class="banner-text">A run is in progress.</span>
+    <button id="hub-btn-resume" class="primary">Resume</button>
+    <button id="hub-btn-abandon" class="secondary">Abandon</button>
+  </div>
+</section>
+
+<div id="overlay-root"></div>
+```
+
+### 2. `hub/hub.js`
+
+```js
+class HubScreen {
+  constructor({ save, audio, hud, runtime, deckBuilder, classPicker, codex, story, realmPicker, settings }) {
+    this._save = save;
+    this._audio = audio;
+    this._runtime = runtime;
+    this._deckBuilder = deckBuilder;
+    this._classPicker = classPicker;
+    this._codex = codex;
+    this._story = story;
+    this._realmPicker = realmPicker;
+    this._settings = settings;
+    this._root = document.getElementById('hub-screen');
+  }
+
+  show() {
+    this._root.classList.add('active');
+    this._refresh();
+    document.getElementById('hub-btn-start-run').focus();
+    this._bind();
+  }
+
+  hide() {
+    this._root.classList.remove('active');
+    this._unbind();
+  }
+
+  _refresh() {
+    const data = this._save.load();
+    document.querySelector('#hub-stat-gold .stat-value').textContent = String(data.meta.gold);
+    document.querySelector('#hub-stat-gold .stat-value').setAttribute('aria-label', `Gold: ${data.meta.gold}`);
+    const classDef = this._classDefById(data.meta.classId);
+    document.querySelector('#hub-stat-class .stat-value').textContent = classDef.name;
+    document.querySelector('#hub-stat-class .stat-value').setAttribute('aria-label', `Class: ${classDef.name}`);
+    const deckCount = (data.meta.deck || []).length;
+    document.getElementById('hub-btn-deck-sub').textContent = `${deckCount} spells equipped`;
+    const unlockedClasses = data.meta.unlockedClasses || ['apprentice'];
+    document.getElementById('hub-btn-class-sub').textContent = `${unlockedClasses.length} unlocked`;
+    const masteredCount = this._countMastered(data.mastery);
+    document.getElementById('hub-btn-codex-sub').textContent = `${masteredCount} / 169 mastered`;
+    const storyCount = (data.meta.storyUnlocked || []).length;
+    document.getElementById('hub-btn-story-sub').textContent = `${storyCount} panels`;
+    const banner = document.getElementById('hub-resume-banner');
+    if (data.activeRun) banner.removeAttribute('hidden');
+    else banner.setAttribute('hidden', '');
+  }
+
+  _bind() {
+    document.getElementById('hub-btn-start-run').addEventListener('click', this._handlers.startRun);
+    document.getElementById('hub-btn-deck').addEventListener('click', this._handlers.deck);
+    document.getElementById('hub-btn-class').addEventListener('click', this._handlers.cls);
+    document.getElementById('hub-btn-codex').addEventListener('click', this._handlers.codex);
+    document.getElementById('hub-btn-story').addEventListener('click', this._handlers.story);
+    document.getElementById('hub-btn-settings').addEventListener('click', this._handlers.settings);
+    document.getElementById('hub-btn-resume').addEventListener('click', this._handlers.resume);
+    document.getElementById('hub-btn-abandon').addEventListener('click', this._handlers.abandon);
+  }
+
+  _unbind() { /* mirror remove */ }
+}
+```
+
+### 3. `hub/deckBuilder.js`
+
+A modal overlay listing all owned spells (from `save.meta.spells`), with checkboxes for the 4 selected. Constraints:
+
+- Min 3, max 4 spells equipped
+- Each spell row shows: icon, name, factFamilyHint, baseDamage, description
+- Spells the player doesn't own are dimmed and shown with `<button disabled aria-label="Locked: Frost Lance">`
+- Tap a spell to toggle equipped state (with visual checkmark)
+- "Save" button writes `save.meta.deck` and closes
+- "Cancel" reverts unsaved changes
+
+```js
+class DeckBuilder {
+  constructor({ save, spellsData, audio, focusReturnTo }) {
+    this._save = save;
+    this._spells = spellsData;        // loaded from data/spells.json
+    this._audio = audio;
+    this._overlay = null;
+    this._draft = [];                 // working copy
+    this._focusReturnTo = focusReturnTo; // element to refocus on close
+    this._timers = { _resolveTimer: null };
+  }
+
+  open() {
+    this.cancel();                     // re-entry guard
+    const data = this._save.load();
+    this._draft = [...(data.meta.deck || [])];
+    this._build(data.meta.spells || []);
+    this._overlay.classList.add('open');
+    this._overlay.setAttribute('aria-hidden', 'false');
+    this._focusFirstButton();
+    this._bindKeys();
+  }
+
+  cancel() {
+    Object.values(this._timers).forEach(t => { if (t) clearTimeout(t); });
+    Object.keys(this._timers).forEach(k => this._timers[k] = null);
+    this._unbindKeys();
+    if (this._overlay) {
+      this._overlay.classList.remove('open');
+      this._overlay.setAttribute('aria-hidden', 'true');
+    }
+  }
+
+  _build(ownedIds) { /* render dialog DOM with role="dialog" + aria-modal="true" + aria-label="Deck builder" */ }
+
+  _toggle(spellId) {
+    if (this._draft.includes(spellId)) {
+      if (this._draft.length <= 3) { this._toast('Need at least 3 spells'); return; }
+      this._draft = this._draft.filter(id => id !== spellId);
+    } else {
+      if (this._draft.length >= 4) { this._toast('Max 4 spells. Remove one first.'); return; }
+      this._draft.push(spellId);
+    }
+    this._render();
+  }
+
+  _save_() {
+    const data = this._save.load();
+    data.meta.deck = [...this._draft];
+    this._save.save(data);
+    this.cancel();
+    if (this._focusReturnTo) this._focusReturnTo.focus();
+  }
+}
+```
+
+**ARIA contract:**
+- `role="dialog" aria-modal="true" aria-label="Deck builder"`
+- First focusable: ✕ close button
+- Each spell row: native `<button>` (disabled when locked) with `aria-pressed="true"` if currently equipped, `"false"` otherwise
+- Tab/Shift-Tab cycles within the dialog; Escape closes (with `classList.contains('open')` guard)
+- Focus returns to `#hub-btn-deck` on close
+
+### 4. `hub/classPicker.js`
+
+Same modal pattern as deck builder. Lists `data/classes.json` with locked/unlocked state. Picking a class:
+- Sets `save.meta.classId = id`
+- Replaces `save.meta.deck` with the new class's `startingDeck`
+- Saves immediately
+
+Locked classes show their unlock condition: e.g., `"Beat Realm 2 boss"`. Use `<button disabled>` per CLAUDE.md.
+
+### 5. `hub/codex.js` — The Mastery Heatmap
+
+The teaching centerpiece. A 13×13 grid showing every multiplication fact, color-coded by mastery state:
+
+- New (no attempts): cream `#F5F0E8` background, dashed gray border
+- Learning (box 1–2): pale red `#FCE8E8`
+- Practicing (box 3): pale yellow `#FCF4D8`
+- Mastered (box ≥ 4 and `totalCorrect ≥ 6`): pale green `#D8F0D8` with a star `★`
+- Each cell is a native `<button>` (≥ 44px) with `aria-label="3 times 7 equals 21. Mastered."` etc.
+
+Tapping a cell launches a **drill mini-fight** — a 3-problem fight focused only on that fact family + adjacent (e.g., tap 3×7 → 3 problems pulled from `x3` family, weighted heavy on `3×7`). On mini-fight complete: returns to codex; mastery is updated; the cell visually updates.
+
+```js
+class Codex {
+  constructor({ save, problemGen, fight, distractors, mastery, audio, hud, focusReturnTo }) {
+    this._save = save;
+    this._problemGen = problemGen;
+    this._fight = fight;          // FightManager (reused)
+    this._mastery = mastery;
+    this._audio = audio;
+    this._hud = hud;
+    this._overlay = null;
+    this._focusReturnTo = focusReturnTo;
+  }
+
+  open() {
+    this.cancel();
+    this._build();
+    this._overlay.classList.add('open');
+    this._overlay.setAttribute('aria-hidden', 'false');
+    this._focusFirstButton();
+    this._bindKeys();
+  }
+
+  _build() {
+    const data = this._save.load();
+    // Render 13×13 grid (a in 0..12, b in 0..12). Each cell is <button> with aria-label.
+    // Color by box state.
+  }
+
+  _onCellTap(a, b) {
+    const factKey = `${Math.min(a,b)}x${Math.max(a,b)}`;
+    // Build a 3-problem mini-fight focused on this fact
+    // Use the existing FightManager but with a custom problem source:
+    //   _customProblems: 3 problems sampled where one is exactly `a × b` and 2 are family neighbors
+    this._launchMiniFight(factKey, a, b);
+  }
+
+  _launchMiniFight(factKey, a, b) {
+    // Hide codex (stays in DOM, classList.remove('open'))
+    // FightManager.start(monster_drill, customProblems)
+    // On complete: re-open codex, refresh
+  }
+}
+```
+
+**Heatmap as teaching surface:** This is the most important UI element for the parent's mental model — it shows what the player has mastered and what's still red. It's also a fast way for the kid to grind a specific weak fact without starting a full run.
+
+### 6. `hub/story.js`
+
+Lists unlocked story panels (`save.meta.storyUnlocked`). Each panel has:
+- A title
+- A 4–6 panel comic strip (placeholder images for now — real art added in Session 12)
+- A 🔊 read-aloud button per panel that narrates the panel text
+- A "back" button
+
+Each panel is a `<button>` (when unlocked) or a placeholder card (when not yet unlocked, dimmed with "Beat the Goblin Warlord to unlock" hint). Native `<button disabled>` for locked.
+
+### 7. `hub/realmPicker.js`
+
+A list/grid of 5 realms (Forest of Threes, Goblin Mines, Dragon's Spire, Sky Citadel, Void Crucible). Each card shows:
+
+- Realm name + thumbnail (palette-tinted blob)
+- Unlock state (locked = `<button disabled>` with hint `"Beat the previous realm"`)
+- Star rating (0–3) from `save.meta.stars[realmId]`
+- Best score
+- Best run time (optional)
+
+Picking a realm: confirms via a small inline modal ("Start a run in Forest of Threes?"), then calls `runtime.startRun(realmId)`.
+
+### 8. `game.js` HUB wiring
+
+```js
+async _enterHub() {
+  this.state = 'HUB';
+  // Cancel any active fight/managers
+  if (this._fight) this._fight.cancel();
+  if (this._bossFight) this._bossFight.cancel();
+  // Hide all other screens
+  document.getElementById('run-screen')?.classList.remove('active');
+  document.getElementById('fight-screen')?.classList.remove('active');
+  this._hub.show();
+}
+
+_onResumeRun() {
+  const data = this._save.load();
+  if (!data.activeRun) return;
+  this.state = 'RUN';
+  this._hub.hide();
+  this._runtime.resume(data.activeRun);  // throws into RUN_MAP
+}
+
+_onAbandonRun() {
+  // Confirm via inline dialog, then:
+  this._runtime.abandonRun();
+  this._hub._refresh();
+}
+```
+
+## Tests to run
+
+Manual:
+
+- [ ] HUB renders gold, class, deck count, codex count, story count correctly
+- [ ] Tile keyboard nav: Tab moves between tiles in DOM order; Enter/Space activates
+- [ ] Deck builder: open → see 10 spells → toggle 1 → save → reopen → state persists
+- [ ] Deck builder: cannot drop below 3 (toast appears); cannot exceed 4 (toast appears)
+- [ ] Deck builder: locked spells render `<button disabled>`, are not focusable in tab order
+- [ ] Class picker: only Apprentice unlocked; Pyromancer is locked + disabled
+- [ ] Class picker: switching class replaces deck (and toast confirms)
+- [ ] Codex: opens 13×13 grid; mastered cells show star; tap a cell → drill mini-fight launches
+- [ ] Codex: drill mini-fight uses the existing FightManager + custom problem source
+- [ ] Codex: on drill complete, codex re-opens with updated cell color
+- [ ] Story: shows N unlocked panels; locked panels are dimmed; 🔊 read-aloud reads panel text
+- [ ] Realm picker: shows 5 realms; only Realm 1 unlocked; tapping starts a run
+- [ ] Resume banner: only visible when `save.activeRun` is non-null
+- [ ] Resume → returns to map; Abandon → confirm dialog → save.activeRun cleared
+- [ ] Focus returns correctly on every overlay close
+
+Edge cases:
+
+- [ ] Open codex with 0 mastered → all cells red/cream, no crashes
+- [ ] Open story with 0 unlocked → empty state shows "Beat your first boss to start the story"
+- [ ] Switch class while a run is active → blocked or auto-abandon (decide and document; default = blocked with toast "Finish or abandon your run first")
+
+## Acceptance checklist
+
+- [ ] All 6 hub overlay managers follow timer-lifecycle pattern (constructor null, cancel() clears all)
+- [ ] All overlays use `role="dialog" aria-modal="true" aria-label="..."`
+- [ ] All overlays focus a close button first; trap focus; Escape closes (with classList guard)
+- [ ] All overlays return focus to the triggering hub tile on close
+- [ ] All locked items use native `<button disabled>` (or `tabindex="-1" aria-disabled="true"` for divs)
+- [ ] Codex heatmap cells have dynamic `aria-label` reflecting current state ("3 times 7. Mastered.")
+- [ ] No `style.display` in JS; visibility via classes
+- [ ] HUB layout works at 768×1024 (iPad portrait) and 1024×768 (iPad landscape)
+- [ ] All Layer-1 tests still pass
+
+## Session end
+
+1. Run all Layer-1 tests
+2. Manual playtest: HUB → start run → finish run → return to HUB → check star rating + gold updated
+3. Manual playtest: Codex drill → mini-fight → mastery updated → cell color changes
+4. Run `marauder-web-review` agent
+5. Commit `Session 10: hub — wizard's tower, deck builder, codex heatmap, story viewer`
+6. Push to `main`

--- a/claudes-math-marauder/sessions/session-11.md
+++ b/claudes-math-marauder/sessions/session-11.md
@@ -1,0 +1,278 @@
+# Session 11 — Data Authoring Round 2: Fill the World
+**Model:** Sonnet | **Focus:** Author the remaining 4 realms, all monsters, 4 more bosses, full spell roster, all classes, full story arc, full event/shop pool. Make the game feel **big**.
+
+By the end of this session, every realm is playable, every fact family is reachable, and the codex has 169 facts to track.
+
+## Pre-flight
+
+1. Read spec section 5 (Save Schema) and 6 (Data Files).
+2. Review Realm 1 data files from Session 4 as the template.
+3. Re-read the design spec's per-realm fact-family weighting strategy.
+4. Run `/marauder-checklist`.
+5. Run `/validate-marauder-data` on existing files to confirm baseline.
+
+## Files to modify
+
+- `claudes-math-marauder/data/realms.json` — flesh out realms 2–5 fully
+- `claudes-math-marauder/data/monsters.json` — add ~20 more monsters across realms 2–5
+- `claudes-math-marauder/data/bosses.json` — add 4 more bosses (one per realm 2–5)
+- `claudes-math-marauder/data/spells.json` — verify all 10 starter spells, add 6 more shop-only spells
+- `claudes-math-marauder/data/classes.json` — add 3 more classes (Pyromancer already drafted in S4)
+- `claudes-math-marauder/data/story.json` — add chapters 2–5 (one per boss kill)
+- `claudes-math-marauder/data/events.json` — add 8 more events (total 13)
+- `claudes-math-marauder/scripts/validate-data.js` — extend to check the new constraints
+
+## Deliverables
+
+### 1. `realms.json` — 5 realms total
+
+Each realm gets a unique fact-family-weight profile. The progression is designed so the player encounters every fact family by Realm 5. Earlier realms revisit easy families to give the kid wins; later realms front-load harder families.
+
+| Realm | Tier | Theme | Family weights (notable) | Stretch enabled? |
+|---|---|---|---|---|
+| 1: Forest of Threes | 1 | green/cream forest | x2,x3,x5,x10 dominant | yes (mastered only) |
+| 2: Goblin Mines | 2 | dim purple mines | x4,x6,x7 dominant; light x3,x5,x8 | yes |
+| 3: Dragon's Spire | 3 | red/orange volcano | x6,x7,x8,x9 dominant | yes |
+| 4: Sky Citadel | 4 | blue/silver clouds | x7,x8,x9,x11,x12 dominant | yes |
+| 5: Void Crucible | 5 | black/violet void | all families equal weight; division-heavy | yes |
+
+```json
+{
+  "id": "goblin_mines",
+  "tier": 2,
+  "name": "Goblin Mines",
+  "description": "A maze of tunnels lit by greenglow torches.",
+  "palette": {
+    "bg": "#3A2A4A",
+    "accent": "#7A5A8A",
+    "ink": "#1A0A2A",
+    "highlight": "#FCD86A"
+  },
+  "silhouettes": ["pickaxe", "ore", "torch"],
+  "monsterPool": ["goblin_grunt", "kobold_thief", "bat_swarm", "tunnel_spider", "elder_goblin"],
+  "bossId": "shaman_zorgath",
+  "factFamilyWeights": {
+    "x0": 0,
+    "x1": 0,
+    "x2": 0.05,
+    "x3": 0.05,
+    "x4": 0.18,
+    "x5": 0.10,
+    "x6": 0.20,
+    "x7": 0.18,
+    "x8": 0.12,
+    "x9": 0.05,
+    "x10": 0.07,
+    "x11": 0,
+    "x12": 0
+  },
+  "nodeCounts": { "totalNodes": 13, "elites": 2, "shops": 2, "rest": 1, "mystery": 2 },
+  "rewardMultiplier": 1.2,
+  "unlockedBy": "beat_goblin_warlord"
+}
+```
+
+Repeat for realms 3, 4, 5 with appropriate weights and `nodeCounts` scaling slightly upward (15, 17, 19 nodes).
+
+### 2. `monsters.json` — 24+ total monsters
+
+Roster targets per realm:
+- Realm 1: 4 monsters (already done in S4) + 2 elite variants
+- Realm 2: 4 base + 1 elite
+- Realm 3: 5 base + 2 elite (volcano theme — fire imps, lava elementals, dragon whelps)
+- Realm 4: 5 base + 2 elite (cloud theme — wind sylphs, sky knights, storm callers)
+- Realm 5: 5 base + 2 elite (void theme — null wraiths, paradox golems, eldritch eyes)
+
+Each monster has fields per S4 schema:
+- `id`, `name`, `realm`, `tier` (1–3 within realm), `hpHits`, `damageMultiplier`, `palette`, `parts[]`, `idleAnim`, `attackAnim`, `voiceProfile`, `flavorText`
+
+**New for elites:** `isElite: true`, +1 hpHit, ~25% bigger sprite, slightly brighter highlight color, occasional dialog quip.
+
+### 3. `bosses.json` — 5 bosses total
+
+Each realm boss has 3 phases. Phase design follows the template:
+- **Phase 1**: orb cast on a fact family the realm emphasized
+- **Phase 2**: orb cast on a *harder* family the realm introduced
+- **Phase 3**: typed ultimate (or stretch-fact ultimate) using a stretched fact
+
+| Boss | Realm | Phase 1 | Phase 2 | Phase 3 |
+|---|---|---|---|---|
+| Goblin Warlord | 1 | x5 div | x10 mul | stretch (if any mastered) or x10 ultimate |
+| Shaman Zorgath | 2 | x4 mul | x7 div | x6 ultimate |
+| Spire Dragon Vrak'tor | 3 | x8 mul | x9 div | x7 stretch ultimate |
+| Sky Lord Aerion | 4 | x11 div | x12 mul | x9 stretch ultimate |
+| Void King Null | 5 | random hard mul | random hard div | full-keyboard ultimate (any answer 1–144) |
+
+Each boss includes `introSpeech`, `phaseHints[]`, `defeatSpeech`, `voiceProfile`, `palette`, `parts` (bigger / more elaborate than monsters), and `koCinematicNotes`.
+
+### 4. `spells.json` — 16 total spells
+
+**Starter (free, in starter decks):**
+1. Ember Bolt (Apprentice starter, fire, 1 hit, x3 hint)
+2. Frost Lance (ice, 1 hit, x4 hint)
+3. Stone Hammer (earth, 1 hit, x6 hint)
+4. Wind Slash (air, 1 hit, x5 hint)
+5. Spark Dart (lightning, 1 hit, x2 hint)
+
+**Shop-only (cost 80–150 gold):**
+6. Inferno (fire, 2 hits, x7 hint)
+7. Glacial Spike (ice, 2 hits, x8 hint)
+8. Earthen Ward (earth, 1 hit + heal 15, x6 hint)
+9. Storm Lash (lightning, 2 hits, x9 hint)
+10. Mind Pierce (psychic, 1 hit ignoring armor, x11 hint)
+11. Solar Flare (light, 2 hits, x12 hint)
+12. Spectral Bolt (shadow, 1 hit + lifesteal 10, x10 hint)
+13. Time Stop (utility, 1 hit + +50% answer time on next problem, x4 hint)
+14. Twin Comet (fire, 1.5 hits avg, x6 hint, "rolls" damage)
+15. Voidbeam (void, 2 hits, x12 hint, only available in Realm 5 shops)
+16. Truth's Hammer (light, 3 hits, stretch x5 hint, very rare)
+
+Each spell entry:
+```json
+{
+  "id": "ember_bolt",
+  "name": "Ember Bolt",
+  "icon": "🔥",
+  "element": "fire",
+  "factFamilyHint": "x3",
+  "baseDamage": 1.0,
+  "description": "A bolt of red flame.",
+  "cost": null,
+  "rarity": "common",
+  "starterFor": ["apprentice"],
+  "effects": []
+}
+```
+
+### 5. `classes.json` — 4 classes total
+
+```
+1. Apprentice — starter — bonus: +1 starting HP, balanced
+2. Pyromancer — unlocked after beating Realm 2 — bonus: +20% damage on x3, x6, x7 (fire-aligned)
+3. Stormcaller — unlocked after Realm 3 — bonus: +10% ultimate charge gain (faster ultimate)
+4. Voidweaver — unlocked after Realm 5 (NG+) — bonus: stretch facts available even without mastery (with a small score penalty)
+```
+
+Each class has `id`, `name`, `description`, `unlockCondition`, `startingDeck` (4 spell IDs), `passiveBonus`, `iconColor`.
+
+### 6. `story.json` — 5 chapters
+
+```
+Chapter 1: "The Wizard Awakens" — 4 panels — unlocks at game start
+Chapter 2: "Goblin Warlord Falls" — 5 panels — unlocks after Realm 1 boss
+Chapter 3: "Whispers in the Mines" — 6 panels — unlocks after Realm 2 boss
+Chapter 4: "The Spire of Dragons" — 6 panels — unlocks after Realm 3 boss
+Chapter 5: "Sky Citadel" — 6 panels — unlocks after Realm 4 boss
+Chapter 6 (epilogue): "The Void Within" — 8 panels — unlocks after Realm 5 boss
+```
+
+Each panel:
+```json
+{
+  "id": "ch2_p1",
+  "imageDescriptor": "<JSON describing canvas-rendered panel>",
+  "narration": "The Goblin Warlord falls. His warhammer shatters into stardust.",
+  "voiceProfile": { "rate": 0.95, "pitch": 1.0 }
+}
+```
+
+`imageDescriptor` is a small JSON DSL the renderer reads to draw a procedural panel: e.g., `{ scene: "interior_tower", figures: [{ id: "wizard", pose: "stand_left" }, { id: "fallen_goblin", pose: "lie_right" }], caption: "Victory!" }`. Implementation in Session 12.
+
+### 7. `events.json` — 13 events
+
+Categories: 🧙 Boon (3), 🪦 Curse (3), 🎁 Loot (3), 🤝 Encounter (3), 🌀 Chaos (1).
+
+Each event has 2–4 choices. Each choice has an outcome formatted as:
+```json
+{
+  "id": "wandering_merchant",
+  "title": "Wandering Merchant",
+  "description": "An old merchant offers you a strange deal.",
+  "choices": [
+    { "label": "Buy a random spell (60 gold)", "outcome": { "kind": "buy_random_spell", "cost": 60 } },
+    { "label": "Politely decline", "outcome": { "kind": "noop" } }
+  ]
+}
+```
+
+Outcome kinds (handled in `run/events.js` — built in S9):
+- `buy_random_spell` — adds random unowned spell, deducts gold
+- `gain_gold` — adds N gold
+- `lose_gold` — deducts N gold
+- `gain_max_hp` — increases base wizard HP for this run
+- `boon_streak_start` — start the next fight at streak 3
+- `curse_orb_fewer` — next 2 fights show only 3 orbs (fewer answer options) [stretch]
+- `noop`
+
+### 8. `scripts/validate-data.js` extensions
+
+Add validators for:
+- Realm `factFamilyWeights` sum to 1.0 (±0.01 tolerance)
+- Boss phases reference valid `factFamilyHint` values
+- Boss `phases.length === 3` (spec contract)
+- Spell `starterFor[]` IDs all exist in `classes.json`
+- Class `startingDeck` IDs all exist in `spells.json`
+- Story chapter IDs unique; `imageDescriptor.figures[].id` present in a known figure registry (figure registry built in S12 — for now, validator just checks JSON parses)
+- Event outcome `kind` is one of the known set
+- Monster IDs unique; `realm` references existing realm
+- All palette colors are valid 7-char hex (`/^#[0-9A-Fa-f]{6}$/`)
+
+### 9. Data scale check
+
+After this session, the totals should be approximately:
+- 5 realms
+- ~24 monsters
+- 5 bosses
+- 16 spells
+- 4 classes
+- 6 story chapters
+- 13 events
+
+### 10. Run-time integration sanity test
+
+Manual: do a full run of each realm. Each run should:
+- Pull problems with the realm's `factFamilyWeights` distribution
+- Display monsters from the realm's `monsterPool`
+- Open a shop with realm-tier spells
+- Reach a boss that uses the realm-appropriate phases
+- On boss kill: unlock the next realm + the next class (if applicable) + the next story chapter
+
+## Tests to run
+
+Automated:
+- [ ] Run `/validate-marauder-data` — passes for all data files
+- [ ] Run `node scripts/validate-data.js` — exit 0
+- [ ] Existing Layer-1 tests still pass
+
+Manual playtest:
+- [ ] Realm 1 → Realm 2 → ... → Realm 5: each realm has unique palette, monster set, boss
+- [ ] Beating Realm 2 boss unlocks Pyromancer class + advances story to chapter 3
+- [ ] Pyromancer's +20% damage on x3,x6,x7 fires correctly (verified via score check)
+- [ ] Codex heatmap shows ALL 169 facts (no missing cells)
+- [ ] All 13 events trigger correctly when their node is opened
+- [ ] All 16 spells castable when equipped (no missing assets / strings)
+
+Edge cases:
+- [ ] Voidweaver class: unlocked only after Realm 5; stretch facts work without mastery (with score penalty applied)
+- [ ] Shop in Realm 5 can sell Voidbeam (only place it appears)
+- [ ] Realm 5 boss "Void King Null" full-keyboard ultimate accepts any 2-digit answer
+
+## Acceptance checklist
+
+- [ ] All 5 realms playable end-to-end
+- [ ] Every fact family appears in at least one realm with weight > 0
+- [ ] Every realm's `factFamilyWeights` sums to 1.0
+- [ ] Every boss has 3 phases with correct hint/mode shape
+- [ ] Class unlock chain works (Apprentice → Pyromancer → Stormcaller → Voidweaver)
+- [ ] Story panel chain works (Ch1 default → Ch6 epilogue)
+- [ ] All data files pass validators
+- [ ] No `Math.random()` calls in any of the new pure logic — only seeded `_rng`
+
+## Session end
+
+1. Run `/validate-marauder-data` and `/marauder-checklist`
+2. Run all Layer-1 tests
+3. Manual playtest: complete a full Realm 5 run end-to-end
+4. Run `marauder-web-review` agent
+5. Commit `Session 11: data — 5 realms, 24 monsters, 5 bosses, 16 spells, 4 classes, 6 story chapters`
+6. Push to `main`

--- a/claudes-math-marauder/sessions/session-12.md
+++ b/claudes-math-marauder/sessions/session-12.md
@@ -1,0 +1,333 @@
+# Session 12 — Cutscenes, Results Cards, Transitions
+**Model:** Sonnet | **Focus:** Story-panel renderer (procedural canvas comic panels), results card with star rating + loot reveal, screen transitions (page-flip / panel-wipe), boss intro polish.
+
+By the end, the game has the **graphic-novel feel** the player wanted — story panels render procedurally on canvas, the results card rolls out with stars and loot, and screen transitions feel like flipping a comic page.
+
+## Pre-flight
+
+1. Read spec section 4 (Renderer + Comic FX) and 7 (Story).
+2. Re-read Session 3 (`fx/comicfx.js` primitives) and Session 7 (boss KO cinematic).
+3. Run `/marauder-checklist`.
+
+## Files to create
+
+- `claudes-math-marauder/js/fx/storyPanel.js` — Procedural panel renderer (reads `imageDescriptor` from story.json)
+- `claudes-math-marauder/js/ui/resultsCard.js` — Post-fight results overlay (stars, score, loot reveal)
+- `claudes-math-marauder/js/fx/transitions.js` — Screen transitions (page-flip, panel-wipe, ink-splatter)
+- `claudes-math-marauder/js/fx/figureRegistry.js` — Pose/figure descriptor → canvas drawing map
+
+## Files to modify
+
+- `claudes-math-marauder/js/hub/story.js` — replace placeholder panels with `storyPanel.draw()`
+- `claudes-math-marauder/js/run/runtime.js` — show results card on fight victory + boss KO
+- `claudes-math-marauder/js/game.js` — call `transitions.play()` on screen change
+
+## Deliverables
+
+### 1. `fx/storyPanel.js` — Procedural Comic Panels
+
+`imageDescriptor` JSON DSL (defined in story.json):
+
+```json
+{
+  "scene": "interior_tower",         // background type from a known set
+  "framing": "wide",                 // "wide" | "close" | "extreme"
+  "lighting": "moonlight",           // tints palette
+  "figures": [
+    { "id": "wizard", "pose": "stand_left", "expression": "determined" },
+    { "id": "fallen_goblin", "pose": "lie_right", "expression": "defeated" }
+  ],
+  "fx": ["ink_splatter_left"],
+  "caption": "Victory!",             // burst-text overlay
+  "speech": [                        // optional speech bubbles
+    { "from": "wizard", "text": "And so the warlord falls..." }
+  ]
+}
+```
+
+Renderer signature:
+
+```js
+class StoryPanelRenderer {
+  constructor({ figureRegistry, comicfx }) { /* ... */ }
+
+  // Draw a story panel into a target canvas at a given size
+  draw(ctx, w, h, descriptor, palette) {
+    this._drawScene(ctx, w, h, descriptor.scene, palette, descriptor.lighting);
+    this._drawFigures(ctx, w, h, descriptor.figures, palette, descriptor.framing);
+    this._drawFx(ctx, w, h, descriptor.fx, palette);
+    if (descriptor.caption) this._comicfx.burstText(ctx, w/2, h*0.85, descriptor.caption, palette);
+    if (descriptor.speech) this._drawSpeechBubbles(ctx, w, h, descriptor.speech, descriptor.figures);
+  }
+
+  _drawScene(ctx, w, h, sceneId, palette, lighting) {
+    // Known scenes: 'interior_tower', 'forest_glade', 'mine_shaft', 'spire_lava',
+    //              'cloud_pinnacle', 'void_chasm', 'wizard_workshop', 'starfield'
+    // Each is a procedural drawing with halftone fills + ink-line silhouettes
+  }
+
+  _drawFigures(ctx, w, h, figures, palette, framing) {
+    figures.forEach(f => {
+      const drawer = this._figureRegistry.get(f.id);
+      if (!drawer) return;
+      const pos = this._posForPose(f.pose, w, h, framing);
+      drawer(ctx, pos.x, pos.y, pos.scale, f.expression, palette);
+    });
+  }
+
+  _drawSpeechBubbles(ctx, w, h, bubbles, figures) {
+    // Word-balloon: rounded rectangle with tail pointing to figure
+    // Text inside is drawn with comic-block font (OpenDyslexic available; canvas falls back to Comic Sans)
+    // Word-wrap if text > 28 chars
+  }
+}
+```
+
+### 2. `fx/figureRegistry.js`
+
+A registry keyed by figure ID. Each entry is a function `(ctx, x, y, scale, expression, palette) => void` that draws the figure procedurally using `fx/shapes.js` primitives.
+
+```js
+const figureRegistry = {
+  wizard: (ctx, x, y, scale, expr, palette) => {
+    // Same wizard shape as in fx/wizardRenderer.js but with pose variations
+    // expr drives mouth shape: 'determined' = grim line, 'shocked' = O, 'happy' = smile, 'defeated' = downturn
+  },
+  fallen_goblin: (ctx, x, y, scale, expr, palette) => { /* lying-down silhouette */ },
+  goblin_warlord: (ctx, x, y, scale, expr, palette) => { /* uses parts from monsters.json */ },
+  shaman_zorgath: ...,
+  spire_dragon: ...,
+  sky_lord: ...,
+  void_king: ...,
+  fallen_<each-boss>: ...,
+  // Background figures
+  goblin_grunt: ...,
+  bat: ...,
+  glow_orb: ...
+};
+```
+
+Pose names (`pose` field): `stand_left`, `stand_right`, `stand_center`, `lie_left`, `lie_right`, `kneel_left`, `kneel_right`, `fly_left`, `fly_right`, `loom_above`.
+
+### 3. `ui/resultsCard.js`
+
+Shown on every fight victory. Comic-panel-style card overlay with:
+- Big "VICTORY!" or "BOSS DOWN!" header (burst text)
+- Stars: 0–3 stars rendered in big style with stagger animation (1st star pops at 200ms, 2nd at 400ms, 3rd at 600ms)
+- Score breakdown: base + speed bonus + streak multiplier + retries penalty
+- Loot reveal: gold, +1 spell (if shop reward), story panel unlock (if applicable, with thumbnail)
+- "CONTINUE" button
+- 🔊 Read-aloud button that narrates "Three stars! Excellent work, wizard!"
+
+Star rating formula:
+```
+let stars = 0;
+if (retries === 0) stars++;
+if (avgAnswerTimeMs < 4000 && correctRate >= 0.9) stars++;
+if (streakMax >= 5 && correctRate === 1.0) stars++;
+```
+
+Draft tuning numbers — finalized via playtest in Session 14.
+
+```js
+class ResultsCard {
+  constructor({ audio, speech, save, focusReturnTo }) { /* ... */ }
+
+  show(result, opts = {}) {
+    this.cancel();
+    this._result = result;
+    this._build();
+    this._overlay.classList.add('open');
+    this._overlay.setAttribute('aria-hidden', 'false');
+    this._focusFirstButton();
+    this._bindKeys();
+    this._animateStars();           // staggered timers
+    this._narrateSummary();
+  }
+
+  cancel() {
+    Object.values(this._timers).forEach(t => { if (t) clearTimeout(t); });
+    Object.keys(this._timers).forEach(k => this._timers[k] = null);
+    this._unbindKeys();
+    if (this._overlay) {
+      this._overlay.classList.remove('open');
+      this._overlay.setAttribute('aria-hidden', 'true');
+    }
+    this._speech.cancel();
+    this.onContinue = null;
+  }
+
+  _animateStars() {
+    [200, 400, 600].forEach((delay, i) => {
+      this._timers[`_star${i}`] = setTimeout(() => {
+        if (i < this._result.stars) {
+          this._overlay.querySelector(`#result-star-${i}`).classList.add('lit');
+          this._audio.play('starGain');
+        }
+      }, delay);
+    });
+  }
+
+  _narrateSummary() {
+    const messages = ['Three stars! Excellent work, wizard!', 'Two stars! Well fought!', 'One star! Keep practicing!', 'Try again, wizard.'];
+    this._speech.speak(messages[3 - this._result.stars]);
+  }
+}
+```
+
+**ARIA:**
+- `role="dialog" aria-modal="true" aria-label="Results"`
+- Stars are decorative (`aria-hidden="true"`) — the dialog's accessible name explains the rating
+- Score breakdown rows have `<div role="group" aria-labelledby="score-label-X">`
+- Continue button is the focused element
+
+### 4. `fx/transitions.js`
+
+Screen-to-screen transitions. Each transition is a 600–900ms full-screen overlay animation.
+
+```js
+const transitions = {
+  pageFlip: ({ from, to, ctx, w, h, audio }) => Promise<void>,
+  panelWipe: ({ from, to, ctx, w, h, audio }) => Promise<void>,
+  inkSplatter: ({ from, to, ctx, w, h, audio }) => Promise<void>,
+};
+```
+
+Where the transitions are used:
+- `pageFlip`: HUB → RUN_MAP, and back
+- `panelWipe`: between map nodes (subtle, ~400ms)
+- `inkSplatter`: pre-boss-fight (dramatic, ~900ms)
+
+Each transition draws to a top-layer canvas (`#transition-canvas`) that overlays everything:
+
+```js
+async function pageFlip({ ctx, w, h, audio }) {
+  audio.play('pageFlip');
+  const start = performance.now();
+  const duration = 700;
+  return new Promise(resolve => {
+    function frame() {
+      const t = (performance.now() - start) / duration;
+      if (t >= 1) { ctx.clearRect(0, 0, w, h); resolve(); return; }
+      ctx.clearRect(0, 0, w, h);
+      const angle = t * Math.PI * 0.5;       // 0 → 90°
+      const slideX = Math.sin(angle) * w;
+      // Draw a "page" rectangle that sweeps across the screen with a slight rotation
+      ctx.save();
+      ctx.translate(slideX - w, 0);
+      ctx.fillStyle = '#F5F0E8';
+      ctx.fillRect(0, 0, w, h);
+      // Ink-line edge
+      ctx.strokeStyle = '#1A1208';
+      ctx.lineWidth = 4;
+      ctx.strokeRect(0, 0, w, h);
+      ctx.restore();
+      requestAnimationFrame(frame);
+    }
+    requestAnimationFrame(frame);
+  });
+}
+```
+
+Honor `prefers-reduced-motion`: when set, all transitions immediately resolve (instant cut).
+
+### 5. Boss intro polish
+
+In Session 7 the boss intro was a slide-in + title card. Polish in this session:
+
+- Slide-in animation eased with a small overshoot (cubic-bezier-style ease-out-back)
+- Title card uses `comicfx.burstText` with 96px stroked title
+- Three "danger speed lines" sweep in from corners during the title
+- The "tap to skip" hint pulses at 1Hz after 1.5s
+- Boss voice narration applies pitch/rate from `boss.voiceProfile`
+- After narration ends, transition to phase 1 with a `panelWipe` (200ms)
+
+### 6. `runtime.js` integration
+
+```js
+async _onFightComplete(result) {
+  await this._transitions.panelWipe({ ... });
+  this._resultsCard.onContinue = () => this._afterResults(result);
+  this._resultsCard.show(result);
+}
+
+_afterResults(result) {
+  this._resultsCard.cancel();
+  // Apply rewards
+  this._save.applyFightRewards(result);
+  // Advance map
+  if (result.outcome === 'boss_victory') this._afterBossVictory(result);
+  else this._returnToMap();
+}
+
+_afterBossVictory(result) {
+  this._save.applyBossRewards(result);
+  // Save unlocks (next realm, next class, next story chapter)
+  // Fire story-unlock notification
+  this._showStoryUnlockToast(result.bossId);
+  // After a short delay, return to HUB
+  setTimeout(() => this._enterHub(), 2500);
+}
+```
+
+### 7. `hub/story.js` integration
+
+Replace placeholder rendering in `story.js` with calls to `storyPanel.draw()`. Each panel renders into its own offscreen canvas (cached — same LRU as monsters), then drawn into the panel viewer.
+
+When the player taps 🔊 on a panel: `speech.speak(panel.narration)` with `panel.voiceProfile`.
+
+### 8. CSS
+
+```css
+#transition-canvas {
+  position: fixed; inset: 0; pointer-events: none; z-index: 1000;
+  display: block;
+}
+#results-card { /* full-screen panel-bordered overlay */ }
+#results-card .stars { display: flex; gap: 12px; justify-content: center; margin: 24px 0; }
+#results-card .star { font-size: 80px; color: #2C2416; opacity: 0.3; transition: opacity 200ms, transform 200ms; }
+#results-card .star.lit { opacity: 1; transform: scale(1.1); color: #F0D840; }
+@media (prefers-reduced-motion: reduce) {
+  #results-card .star, #transition-canvas { transition: none; }
+}
+```
+
+## Tests to run
+
+Manual playtest:
+
+- [ ] Beat a Realm 1 fight — results card appears, stars animate (staggered), narration plays
+- [ ] All 4 star scenarios: 0 stars (defeat-retry x3), 1 star (no streak), 2 stars (good streak), 3 stars (perfect)
+- [ ] Beat a boss — results card shows, story unlock toast appears, 2.5s later return to HUB
+- [ ] Open story → Chapter 2 panels render procedurally (no missing assets / blank panels)
+- [ ] Speech bubbles render with proper word-wrap; 🔊 read-aloud per panel works
+- [ ] HUB → start run: page-flip transition plays
+- [ ] Map → pre-boss: ink-splatter transition plays
+- [ ] `prefers-reduced-motion: reduce` set → all transitions instant
+- [ ] No memory leak from results card / story panel openings (test 50× rapid open/close)
+
+Edge cases:
+
+- [ ] Story panel with 0 figures (background-only) renders without crash
+- [ ] Speech bubble with 50+ characters word-wraps correctly
+- [ ] Two figures at the same `pose` slot — second one offsets to avoid overlap
+- [ ] Caption with apostrophe: `"It's over!"` — escaped properly in canvas text
+- [ ] Continue button on results card returns focus to map node (or HUB tile if boss-victory path)
+
+## Acceptance checklist
+
+- [ ] All transitions respect `prefers-reduced-motion`
+- [ ] Results card follows timer-lifecycle pattern (constructor null, cancel clears all, save cb before cancel)
+- [ ] Story panels cache in LRU (same cache as monsters)
+- [ ] No `style.display` in JS
+- [ ] No `aria-live` on elements that toggle `aria-hidden`
+- [ ] Speech bubbles are decorative on canvas (text alternative is the panel narration via 🔊 button)
+- [ ] All Layer-1 tests still pass
+
+## Session end
+
+1. Re-run all Layer-1 tests
+2. Manual playtest: full run with story panels viewed, results card stars verified, transitions smooth
+3. Run `marauder-web-review` agent
+4. Commit `Session 12: cutscenes — story panels, results cards, transitions, boss intro polish`
+5. Push to `main`

--- a/claudes-math-marauder/sessions/session-13.md
+++ b/claudes-math-marauder/sessions/session-13.md
@@ -1,0 +1,356 @@
+# Session 13 — Replay Harness, Dev Menu, Fuzzer
+**Model:** Sonnet | **Focus:** Tools that let us verify the game holds up under load — record/replay seeded runs, a dev menu to jump anywhere, and a fuzzer that hammers combat for hours.
+
+By the end of this session, we can prove no `Math.random()` slipped in (replays are bit-identical), and we have a fuzzer that catches edge cases before kid playtest.
+
+## Pre-flight
+
+1. Read spec section 8 (Testing & QA) and 9.13 (Session 13 in the breakdown).
+2. Review `combat/problemGen.js` and `combat/distractors.js` — confirm both take `rng` as injected dependency (no module-level random).
+3. Run `/marauder-checklist`.
+
+## Files to create
+
+- `claudes-math-marauder/js/util/recorder.js` — Run recorder (logs every input event with timestamps)
+- `claudes-math-marauder/js/util/replayer.js` — Run replayer (replays a recorded run from a seed + input log)
+- `claudes-math-marauder/js/dev/devMenu.js` — In-game dev menu (toggle with `?dev=1` URL param)
+- `claudes-math-marauder/scripts/fuzz-combat.js` — Headless fuzzer (Node-only; runs 10k fights with random inputs, asserts no crashes)
+- `claudes-math-marauder/scripts/fuzz-mapgen.js` — Map-gen fuzzer (1000 seeds, all reachable, no crashes)
+- `claudes-math-marauder/scripts/replay-determinism.js` — Replay determinism test (record run → replay → compare every state)
+
+## Files to modify
+
+- `claudes-math-marauder/js/game.js` — wire dev menu, expose `_recorder` and `_replayer` to `window` when `?dev=1`
+- `claudes-math-marauder/js/save.js` — add export/import save methods (for dev menu "load save from JSON")
+
+## Deliverables
+
+### 1. `util/recorder.js` — Deterministic Recording
+
+```js
+class Recorder {
+  constructor() {
+    this._events = [];
+    this._startedAt = null;
+    this._seed = null;
+    this._meta = null;
+    this._active = false;
+  }
+
+  start({ seed, meta }) {
+    this._events = [];
+    this._startedAt = performance.now();
+    this._seed = seed;
+    this._meta = meta;
+    this._active = true;
+  }
+
+  log(kind, payload) {
+    if (!this._active) return;
+    this._events.push({
+      t: Math.round(performance.now() - this._startedAt),
+      kind,                              // 'orb_tap', 'numpad_digit', 'numpad_commit', 'pause', 'resume', 'map_node_select'
+      payload                            // serializable
+    });
+  }
+
+  stop() { this._active = false; }
+
+  export() {
+    return {
+      version: 1,
+      seed: this._seed,
+      meta: this._meta,
+      events: [...this._events],
+      duration: performance.now() - this._startedAt
+    };
+  }
+
+  exportAsJson() { return JSON.stringify(this.export()); }
+}
+```
+
+What to log:
+- Every orb tap: `{ kind: 'orb_tap', payload: { value: 12, position: 'top_left' } }`
+- Every numpad digit / commit / cancel
+- Every map node selection
+- Every pause / resume
+- Every settings change (font size, voice rate)
+- Every "abandon run"
+
+What NOT to log:
+- Frame-by-frame anim state (too much; replay reconstructs it)
+- Mouse-move events (irrelevant)
+- Scroll events (game has none)
+
+### 2. `util/replayer.js` — Replay from Recording
+
+```js
+class Replayer {
+  constructor({ game, recorder }) {
+    this._game = game;
+    this._recorder = recorder;
+    this._currentLog = null;
+    this._eventIdx = 0;
+    this._timer = null;
+  }
+
+  replay(log) {
+    this._currentLog = log;
+    this._eventIdx = 0;
+    // Re-seed the game's RNG
+    this._game._rng = mulberry32(log.seed);
+    // Reset save to log.meta state
+    this._game._save.import(log.meta);
+    // Start playback: each event scheduled at log.events[i].t
+    this._tick();
+  }
+
+  _tick() {
+    if (this._eventIdx >= this._currentLog.events.length) {
+      this._game.dispatchEvent(new CustomEvent('replay-complete'));
+      return;
+    }
+    const ev = this._currentLog.events[this._eventIdx];
+    const now = performance.now() - this._startedAt;
+    const wait = Math.max(0, ev.t - now);
+    this._timer = setTimeout(() => {
+      this._dispatchEvent(ev);
+      this._eventIdx++;
+      this._tick();
+    }, wait);
+  }
+
+  _dispatchEvent(ev) {
+    switch (ev.kind) {
+      case 'orb_tap': this._game._fight.selectOrb(ev.payload.value); break;
+      case 'numpad_digit': this._game._ultimate._onDigit(ev.payload.digit); break;
+      // ... all event kinds
+    }
+  }
+
+  cancel() {
+    if (this._timer) { clearTimeout(this._timer); this._timer = null; }
+    this._currentLog = null;
+  }
+}
+```
+
+### 3. `dev/devMenu.js` — In-Game Dev Menu
+
+Toggled by `?dev=1` URL param. Adds a fixed-position button bottom-right of the screen; tapping opens a modal with:
+
+- **Seed override**: input field; "Apply" button creates a new run with that seed
+- **Jump to**: dropdowns to jump to (1) any realm, (2) any boss, (3) any story chapter, (4) shop test, (5) ultimate test, (6) drill mini-fight test
+- **Mastery override**: "Set all facts mastered" / "Reset mastery" / "Set 50% mastered (random)"
+- **Gold/spell override**: "+1000 gold" / "Unlock all spells" / "Equip random deck"
+- **Replay controls**:
+  - "Start recording" → enables `Recorder`
+  - "Stop & download" → exports the recording as a `.json` file
+  - "Upload replay" → file picker that accepts a `.json` log → calls `replayer.replay(log)`
+- **Save controls**:
+  - "Export save (clipboard)" → copies `JSON.stringify(save.load())` to clipboard
+  - "Import save (paste)" → modal with textarea → parses and imports
+  - "Reset save" → confirms, then clears save and reloads
+- **Toggles**:
+  - "Force reduced motion" (toggles `body[data-reduced-motion]`)
+  - "Force big-font" (forces 24px root font-size)
+  - "Show hitboxes" (renders orb hitboxes in red overlay)
+  - "Verbose logging" (enables `console.log` traces in combat)
+
+Implementation: pure DOM modal. `role="dialog" aria-modal="true" aria-label="Dev menu"`. Native `<button>` and `<select>` elements. Standard timer-lifecycle pattern.
+
+Dev menu is **never accessible without the `?dev=1` query param** — there's no UI surface to it from normal play. Don't even create the DOM elements unless the param is present.
+
+### 4. `scripts/fuzz-combat.js` — Headless Combat Fuzzer
+
+Node-only script. Reuses the UMD-exported combat modules.
+
+```js
+const { selectProblem } = require('../js/combat/problemGen.js');
+const { generateDistractors } = require('../js/combat/distractors.js');
+const { recordResolve, isMastered } = require('../js/combat/mastery.js');
+const { mulberry32 } = require('../js/util/rng.js');
+
+function fuzzOneFight(seed) {
+  const rng = mulberry32(seed);
+  const masteryMap = {};
+  const realm = require('../data/realms.json').realms[0];
+  const recentKeys = [];
+  const fakeAnswers = [true, false, true, true, false, true, true]; // simulated
+
+  for (let problemIdx = 0; problemIdx < 50; problemIdx++) {
+    const problem = selectProblem({ realm, masteryMap, recentKeys, rng, mulRatio: 0.7, allowStretch: true, realmTier: 1 });
+    if (!problem) throw new Error(`Seed ${seed}, problem ${problemIdx}: selectProblem returned null`);
+    if (typeof problem.answer !== 'number') throw new Error(`Bad answer type at seed ${seed}, problem ${problemIdx}`);
+    if (problem.answer < 0 || problem.answer > 144) throw new Error(`Answer out of bounds at seed ${seed}, problem ${problemIdx}: ${problem.answer}`);
+
+    const orbs = generateDistractors(problem, rng);
+    if (orbs.length !== 4) throw new Error(`Expected 4 orbs, got ${orbs.length}`);
+    if (!orbs.includes(problem.answer)) throw new Error(`Correct answer not among orbs`);
+    if (new Set(orbs).size !== orbs.length) throw new Error(`Duplicate orbs`);
+
+    const correct = fakeAnswers[problemIdx % fakeAnswers.length];
+    recordResolve(masteryMap, problem.factKey, { correct, timeMs: 2000, now: Date.now(), masteredAvgMs: 2500 });
+    recentKeys.push(problem.factKey);
+    if (recentKeys.length > 5) recentKeys.shift();
+  }
+}
+
+const FUZZ_RUNS = 10000;
+let failures = 0;
+for (let seed = 1; seed <= FUZZ_RUNS; seed++) {
+  try { fuzzOneFight(seed); }
+  catch (err) { failures++; console.error(`SEED ${seed}: ${err.message}`); }
+}
+console.log(`${FUZZ_RUNS} fights run; ${failures} failures.`);
+process.exit(failures === 0 ? 0 : 1);
+```
+
+Run with: `node claudes-math-marauder/scripts/fuzz-combat.js`. CI-eligible (exits non-zero on failure).
+
+### 5. `scripts/fuzz-mapgen.js` — Map-Gen Fuzzer
+
+```js
+const { generateMap } = require('../js/run/mapGen.js');
+const realms = require('../data/realms.json').realms;
+
+const FUZZ_RUNS = 1000;
+let failures = 0;
+for (const realm of realms) {
+  for (let seed = 1; seed <= FUZZ_RUNS; seed++) {
+    try {
+      const map = generateMap({ realm, seed });
+      // Assert exactly one start node
+      const starts = map.nodes.filter(n => n.kind === 'start');
+      if (starts.length !== 1) throw new Error(`Realm ${realm.id} seed ${seed}: ${starts.length} start nodes`);
+      // Assert exactly one boss node
+      const bosses = map.nodes.filter(n => n.kind === 'boss');
+      if (bosses.length !== 1) throw new Error(`Realm ${realm.id} seed ${seed}: ${bosses.length} boss nodes`);
+      // BFS from start
+      const visited = bfsReachable(map);
+      if (visited.size !== map.nodes.length) throw new Error(`Realm ${realm.id} seed ${seed}: ${map.nodes.length - visited.size} unreachable nodes`);
+      // Boss reachable from every node (forward graph)
+      for (const node of map.nodes) {
+        if (!canReachBoss(map, node.id)) throw new Error(`Realm ${realm.id} seed ${seed}: ${node.id} cannot reach boss`);
+      }
+    } catch (err) { failures++; console.error(err.message); }
+  }
+}
+console.log(`${realms.length * FUZZ_RUNS} maps run; ${failures} failures.`);
+process.exit(failures === 0 ? 0 : 1);
+```
+
+### 6. `scripts/replay-determinism.js` — Determinism Test
+
+This is the canary that proves we have no hidden non-determinism (no rogue `Math.random()`, no `Date.now()` in pure code, no DOM-state-dependent logic).
+
+```js
+// 1. Record a 50-problem fight with a fixed seed and a fixed input sequence
+// 2. Re-run the same fight: same seed, same input sequence
+// 3. Assert every problem's factKey, displayText, and answer are identical
+// 4. Assert every distractor set is identical
+// 5. Assert mastery state at the end is bit-identical
+
+const { selectProblem } = require('../js/combat/problemGen.js');
+const { generateDistractors } = require('../js/combat/distractors.js');
+const { mulberry32 } = require('../js/util/rng.js');
+const realms = require('../data/realms.json').realms;
+const realm = realms[0];
+
+function runWithSeed(seed) {
+  const rng = mulberry32(seed);
+  const masteryMap = {};
+  const recentKeys = [];
+  const trace = [];
+  const inputs = ['correct', 'wrong', 'correct', 'correct', 'wrong']; // fixed input sequence
+
+  for (let i = 0; i < 50; i++) {
+    const problem = selectProblem({ realm, masteryMap, recentKeys, rng, mulRatio: 0.7, allowStretch: true, realmTier: 1 });
+    const orbs = generateDistractors(problem, rng);
+    trace.push({ key: problem.factKey, ans: problem.answer, orbs: [...orbs] });
+    const correct = inputs[i % inputs.length] === 'correct';
+    require('../js/combat/mastery.js').recordResolve(masteryMap, problem.factKey, { correct, timeMs: 2000, now: 1000000 + i, masteredAvgMs: 2500 });
+    recentKeys.push(problem.factKey);
+    if (recentKeys.length > 5) recentKeys.shift();
+  }
+  return { trace, masteryMap };
+}
+
+const a = runWithSeed(42);
+const b = runWithSeed(42);
+if (JSON.stringify(a) !== JSON.stringify(b)) { console.error('NON-DETERMINISTIC'); process.exit(1); }
+console.log('DETERMINISTIC ✓');
+```
+
+### 7. `save.js` extensions
+
+```js
+class SaveManager {
+  // ... existing methods ...
+  export() { return { ...this._cache }; }
+  import(snapshot) { this._cache = JSON.parse(JSON.stringify(snapshot)); this.save(this._cache); }
+}
+```
+
+### 8. CI integration
+
+Add the fuzz scripts to a top-level test runner script:
+
+```bash
+# claudes-math-marauder/scripts/test-all.sh
+#!/usr/bin/env bash
+set -e
+node scripts/test-fact-keys.js
+node scripts/test-mastery.js
+node scripts/test-problem-gen.js
+node scripts/test-distractors.js
+node scripts/test-save-migration.js
+node scripts/test-map-gen.js
+node scripts/replay-determinism.js
+node scripts/fuzz-combat.js
+node scripts/fuzz-mapgen.js
+node scripts/validate-data.js
+echo "All tests passed."
+```
+
+The `/validate-marauder-data` skill runs this entire script.
+
+## Tests to run
+
+Automated:
+- [ ] `node scripts/fuzz-combat.js` → 10000 fights, 0 failures
+- [ ] `node scripts/fuzz-mapgen.js` → 5000 maps (5 realms × 1000 seeds), 0 failures
+- [ ] `node scripts/replay-determinism.js` → "DETERMINISTIC ✓"
+- [ ] `bash scripts/test-all.sh` → exit 0
+
+Manual:
+- [ ] `?dev=1` → dev menu button appears bottom-right
+- [ ] Dev menu: "Jump to Realm 3 boss" → boss fight launches
+- [ ] Dev menu: "Set all facts mastered" → codex shows all green
+- [ ] Dev menu: "Start recording" → play 1 fight → "Stop & download" → JSON file downloads
+- [ ] Dev menu: "Upload replay" → pick the downloaded file → replay plays back accurately
+- [ ] Dev menu: "Export save (clipboard)" → paste into "Import save" → save round-trips identically
+- [ ] Dev menu: "Force reduced motion" → all transitions instant
+- [ ] Dev menu invisible without `?dev=1` (DOM not even created)
+
+Edge cases:
+- [ ] Replay a recorded run after migrating save schema (recorder logs `meta.version`; if mismatch, replay refuses with clear error)
+- [ ] Fuzzer with empty mastery map (start-of-game) — never crashes
+- [ ] Fuzzer with all-mastered map — stretch facts kick in correctly
+
+## Acceptance checklist
+
+- [ ] All fuzz scripts exit 0 in CI
+- [ ] Replay-determinism test passes (no `Math.random()`, no `Date.now()` in pure code)
+- [ ] Dev menu DOM only created with `?dev=1` (no leakage to normal players)
+- [ ] Recorder/replayer are pure (no DOM dependencies in core logic — only event dispatch touches DOM)
+- [ ] All Layer-1 tests still pass
+
+## Session end
+
+1. Run `bash scripts/test-all.sh`
+2. Manual: record a full Realm 1 run, replay it, confirm deterministic
+3. Run `marauder-web-review` agent
+4. Commit `Session 13: dev tools — recorder, replayer, dev menu, combat & map-gen fuzzers`
+5. Push to `main`

--- a/claudes-math-marauder/sessions/session-14.md
+++ b/claudes-math-marauder/sessions/session-14.md
@@ -1,0 +1,242 @@
+# Session 14 — Accessibility, iPad QA, Final Polish
+**Model:** Opus | **Focus:** Real-device testing on iPad with Bluetooth keyboard, full accessibility audit, performance tuning, kid playtest. Ship-ready by end of session.
+
+By the end, the game runs at 60fps on a real iPad in Safari, passes a full a11y audit, and has been playtested by the actual 10-year-old target audience.
+
+## Pre-flight
+
+1. Read CLAUDE.md sections on Accessibility Requirements and HTML/JS Coding Standards (full pass).
+2. Read spec section 7 (Accessibility & Comfort) and 11 (Open Questions).
+3. Run `/marauder-checklist`.
+4. Get an iPad (any model, iOS 14+) + Bluetooth keyboard ready.
+5. Charge a kid for the playtest session :).
+
+## Goals
+
+By session end:
+- 60 fps minimum on iPad Safari (target: iPad 9th gen or newer, 1024×768 viewport)
+- Full WCAG AA pass (axe-core or manual contrast / keyboard / screen-reader audit)
+- ≥ 4.5:1 contrast on every text element on every screen
+- All interactive elements ≥ 44px
+- VoiceOver flow: full game playable with VoiceOver only (where reasonable)
+- Keyboard-only flow: full game playable with Tab/Enter/Esc/Arrows
+- Reduced-motion: all animations skip / instant-cut
+- Kid playtest: 30-minute session with the actual player; iterate on top 3 pain points
+
+## Files to modify (most files lightly)
+
+- `claudes-math-marauder/css/style.css` — final pass on contrast, font sizing, focus rings
+- `claudes-math-marauder/js/*.js` — fix any a11y regressions found
+- `claudes-math-marauder/js/ui/settings.js` — verify font scale, voice rate, audio volume sliders
+- `claudes-math-marauder/index.html` — verify viewport meta, lang attr, document title
+- `claudes-math-marauder/CLAUDE.md` — game-specific quirks discovered during QA
+
+## Deliverables
+
+### 1. Performance pass
+
+**Target: 60 fps minimum on iPad 9.**
+
+Profiling steps:
+1. Open game on iPad Safari, connect Web Inspector from Mac
+2. Record a 60-second timeline during a Realm 5 boss fight (the most complex scene)
+3. Identify any frames > 16.7ms
+
+Likely hot spots and their fixes:
+
+| Hot spot | Fix |
+|---|---|
+| Per-frame `drawCreature` redraw | Confirm cached offscreen canvas hit (check LRU stats); evict only on resize |
+| Particle burst (>50 particles) | Cap pool size to 80; recycle aggressively |
+| Speech `cancel()` triggering layout | Already debounced via 50ms setTimeout — verify still in place |
+| Halftone dot pattern | Pre-bake into a tile canvas; `ctx.drawImage` instead of per-dot calls |
+| Inline SVG map node count > 19 | Already capped at 19; ensure `<g>` nodes reused on resize, not recreated |
+| Boss intro speech blocking RAF | Already async; verify no blocking work in `_narrate()` |
+| Resize handler thrash on rotate | Debounce to 100ms; also make sure the cache is invalidated only when DPR changes |
+
+**Memory budget:** under 80 MB heap on iPad 9 (older devices have ~256 MB usable for Safari tabs).
+
+### 2. Accessibility audit
+
+Run through this checklist on every screen + overlay:
+
+#### Color & Contrast
+- [ ] Body text: ≥ 4.5:1 (#2C2416 on #F5F0E8 = 13.5:1 ✓)
+- [ ] Secondary text uses #595143 or darker — never #666/#888/#999
+- [ ] Focus rings visible on all interactive elements: 3px solid #2C2416, offset 2px
+- [ ] Locked / disabled state still ≥ 3:1 contrast (so it's visible but distinguishable)
+
+#### Touch & Pointer
+- [ ] Every interactive element ≥ 44×44px (orbs are 96px ✓, numpad ≥ 72px ✓)
+- [ ] No element relies on hover-only state
+- [ ] `touch-action: none` set on canvas containers (prevents iOS double-tap zoom interference)
+
+#### Keyboard
+- [ ] Tab moves through every interactive element in DOM order
+- [ ] Shift-Tab reverses
+- [ ] Enter/Space activates buttons
+- [ ] Escape closes any open overlay
+- [ ] Arrow keys navigate map nodes (extra: keyboard-only players can use arrows to move between nodes on the map)
+- [ ] No keyboard trap outside of intentional focus-trap modals
+- [ ] Focus visible on every focusable element (`:focus-visible` styles applied)
+
+#### Screen Reader (VoiceOver / TalkBack)
+- [ ] Every screen has a useful `aria-label` (or `<h1>`)
+- [ ] Every modal: `role="dialog" aria-modal="true" aria-label="..."`
+- [ ] Every button has discernible text or `aria-label`
+- [ ] Live-update regions use `role="status"` (problem, score, streak)
+- [ ] No `aria-live` + `aria-hidden` collisions
+- [ ] No `aria-live` + `aria-label` collisions
+- [ ] Dynamic `aria-label` updates whenever `textContent` changes on labelled elements
+- [ ] Locked items: native `<button disabled>` — never a `.locked` div
+
+#### Motion
+- [ ] `prefers-reduced-motion: reduce` honored:
+  - Boss intro: no slide; just appears
+  - Phase break: no shake; just label change
+  - Page-flip / panel-wipe / ink-splatter: instant cut
+  - Particle bursts: 1 frame, then despawn
+  - Star animations on results card: pop instantly without transform/opacity transition
+
+#### Speech & Audio
+- [ ] All voiced text has a visible 🔊 button — none auto-plays without user gesture (except mid-fight where audio is the player's choice)
+- [ ] Settings panel exposes voice picker, voice rate (0.5–1.5), master volume (0–1), SFX volume (0–1), speech volume (0–1)
+- [ ] Audio mute toggle persists across sessions
+
+### 3. Final CSS pass
+
+```css
+/* Focus ring — visible on all focusable elements */
+*:focus-visible {
+  outline: 3px solid var(--ink-dark);
+  outline-offset: 2px;
+}
+
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+/* Cream background variants for AA-safe muted text */
+:root {
+  --bg: #F5F0E8;
+  --ink-dark: #2C2416;
+  --ink-muted: #595143;     /* AA-safe on cream */
+  --accent-comic-yellow: #F0D840;
+  --accent-comic-red: #D04030;
+  --accent-comic-blue: #2A60B0;
+  --error-red: #B83020;
+}
+
+/* Touch target floor — global */
+button, [role="button"], input[type="button"] {
+  min-width: 44px;
+  min-height: 44px;
+}
+```
+
+### 4. iPad-specific QA
+
+- [ ] Run on iPad 9 (oldest target) and iPad Pro (current target)
+- [ ] Both portrait (768×1024) and landscape (1024×768)
+- [ ] iOS Safari 16, 17, 18
+- [ ] Verify no double-tap zoom on canvas
+- [ ] Verify Bluetooth keyboard works (numpad ultimate, Tab nav, Esc close)
+- [ ] Verify `safe-area-inset-*` respected (notch, home indicator)
+- [ ] Audio survives backgrounding the tab + resume
+- [ ] Save survives Safari clearing the tab cache (verify localStorage retained)
+
+### 5. Kid playtest protocol
+
+30-minute session, player journals after:
+
+**Phase 1 (10 min): Onboarding**
+- Hand them the iPad. No instructions. Watch.
+- Note where they pause, look confused, try to tap something that's not interactive.
+- Ask: "What did you think was going to happen?"
+
+**Phase 2 (15 min): Free play**
+- "Play however you want for 15 minutes."
+- Watch for: boredom (does the kid wander away?), frustration (does the kid say "this is stupid"?), excitement (do they laugh / lean in?).
+- Time how long until they hit their first ultimate, first phase break, first boss kill.
+
+**Phase 3 (5 min): Debrief**
+- "What did you like the most?"
+- "What was annoying?"
+- "What was hard? Was it the math hard or the game hard?"
+- "Would you play again?"
+
+Take notes on every "annoying" or "confusing" — those become the polish backlog.
+
+### 6. Top 3 polish pass (post-playtest)
+
+Whatever the kid said is annoying — fix it before commit. Likely candidates from common kid-playtest patterns:
+
+- Speech rate too slow → adjust default to 1.05
+- Numpad commit button too small / hard to find → make ✓ button green and 1.5× width
+- Phase break delay too long → tighten from 1300ms to 900ms
+- Boss intro too long → shrink "tap to skip" wait from 1.5s to 1.0s
+- Story panels too text-heavy → confirm narration is accurate; offer "skip narration" toggle
+- Mastery delta after each fight isn't visible → add a small "mastery +1" toast on streak-end
+- Wrong-answer penalty narration says the answer too loud / too long → adjust voice rate to 1.1
+
+### 7. Final regression test pass
+
+- [ ] All Layer-1 tests pass
+- [ ] All fuzz scripts (10k combat, 5k mapgen) pass
+- [ ] Replay-determinism test passes
+- [ ] Manual: full Realm 1 run from new save → boss kill → results → HUB → save reload → resume → finish run
+- [ ] Manual: full Realm 5 run with all classes/spells unlocked
+- [ ] Manual: 30-minute mixed session — check for memory leak (DOM node count steady, listener count steady)
+
+### 8. Hosting / deployment
+
+- [ ] `claudes-math-marauder/index.html` is the entry; pushing to `main` triggers `update-index.yml`
+- [ ] Game card on the index page registered in `.github/scripts/update-index.js` (icon `🤖⚔️📐`, category `learning`)
+- [ ] After push, verify GitHub Pages serves the game at `https://<user>.github.io/games-for-my-kids/claudes-math-marauder/`
+
+### 9. Update game-specific CLAUDE.md / rules
+
+`/Users/aaronfleckenstein/development/github/games-for-my-kids/.claude/rules/marauder.md` should already exist (created in Session 1). Add discovered quirks:
+- Per-fight mastery save batching (prevents localStorage thrash)
+- Speech delay quirk on iPad
+- LRU cache stats target (≤30 canvases, ~6MB)
+- Replay/dev menu opt-in via `?dev=1`
+
+## Tests to run
+
+- [ ] **Layer-1**: `bash scripts/test-all.sh` → all green
+- [ ] **Performance**: 60s recording on iPad 9, no frame > 16.7ms
+- [ ] **Memory**: 30-min play session, heap stable < 80 MB, DOM nodes stable, listener count stable
+- [ ] **A11y axe-core scan**: 0 violations
+- [ ] **VoiceOver flow**: Full Realm 1 run completable with VoiceOver only (verify orb tap announces problem + answer)
+- [ ] **Keyboard-only flow**: Full Realm 1 run completable with Tab/Enter/Esc/Arrows only
+- [ ] **Reduced motion**: Game playable with `prefers-reduced-motion: reduce`; no jarring animations
+- [ ] **Kid playtest**: Player completes Realm 1 in 5–15 min; reports ≥ "fun" rating
+
+## Acceptance checklist
+
+- [ ] 60 fps on iPad 9 in Realm 5 boss
+- [ ] WCAG AA: contrast, touch targets, keyboard, screen reader all pass
+- [ ] `prefers-reduced-motion` fully honored
+- [ ] Speech mute and voice picker work on iOS Safari
+- [ ] Save survives tab close, browser restart, Safari cache eviction (localStorage)
+- [ ] Resume works mid-run after closing the tab
+- [ ] Kid playtest done; top-3 issues fixed
+- [ ] Game registered on the games-for-my-kids index
+- [ ] CLAUDE.md per-game rules updated with discovered quirks
+
+## Session end
+
+1. Run all automated tests one final time
+2. Run `marauder-web-review` agent across the entire `claudes-math-marauder/` tree
+3. Push final fixes
+4. Commit `Session 14: a11y, iPad QA, kid playtest, ship`
+5. Push to `main`
+6. Verify GitHub Pages deploys cleanly; open the game on a fresh device and play one full run end-to-end
+7. Celebrate with the player. They earned it. 🎉

--- a/docs/superpowers/plans/2026-05-01-claudes-math-marauder.md
+++ b/docs/superpowers/plans/2026-05-01-claudes-math-marauder.md
@@ -1,0 +1,54 @@
+# Plan: Claude's Math Marauder
+
+**Date:** 2026-05-01
+**Status:** Ready for execution
+**Spec:** `docs/superpowers/specs/2026-05-01-claudes-math-marauder-design.md`
+**Plan canonical location:** `claudes-math-marauder/plan.md` (per repo convention; this file is a pointer)
+**Per-session implementation specs:** `claudes-math-marauder/sessions/session-NN.md` (14 sessions)
+
+## Why this plan lives outside `docs/superpowers/plans/`
+
+Repo convention (set by `lizzies-petstore`, `phonics-game`) is to keep each game's plan and per-session specs colocated with the game directory: `<game>/plan.md` + `<game>/sessions/session-NN.md`. The writing-plans skill's default path is `docs/superpowers/plans/` — but skill defaults yield to repo conventions / user instructions. This file exists only as a discoverable pointer for anyone searching the canonical plans directory.
+
+## Quick summary
+
+Slay-the-Spire-style branching-map roguelike teaching multiplication and division 0–12 (with stretch facts in 5s/10s/2s families) to a 10-year-old with ADHD + dyslexia. Hybrid combat: tappable answer orbs (default), typed-answer ultimate (~1 in 10 problems), multi-phase boss glyph combos. Comic-book art style rendered procedurally on Canvas 2D — no image assets. Adaptive Leitner spaced-repetition mastery engine. 5 realms, 5 bosses, 16 spells, 4 classes, 6 story chapters. ~5–15 minute sessions. Retry-on-defeat (no run-loss); stakes via 1–2–3⭐ rating. Vanilla JS, no bundler, GitHub Pages deploy.
+
+## Sessions (14 total)
+
+| # | Title | Model |
+|---|---|---|
+| 1 | Scaffold: Repo Layout, Save Schema, Tooling | Sonnet |
+| 2 | Pure-Logic Combat: Mastery, Problem Gen, Distractors | Sonnet |
+| 3 | Comic Renderer: Procedural Sprites, FX Library | Opus |
+| 4 | Data Authoring Round 1: Realm 1 Playable | Sonnet |
+| 5 | Combat: Orb Cast Loop | Sonnet |
+| 6 | Combat: Typed Ultimate Spell | Sonnet |
+| 7 | Boss Fight: Glyph Combo | Opus |
+| 8 | Audio: Web Speech + Synthesized SFX + Settings | Sonnet |
+| 9 | Run Map: Branching Graph + Resume | Sonnet |
+| 10 | Hub: Wizard's Tower, Deck Builder, Codex | Sonnet |
+| 11 | Data Authoring Round 2: Fill the World | Sonnet |
+| 12 | Cutscenes, Results Cards, Transitions | Sonnet |
+| 13 | Replay Harness, Dev Menu, Fuzzer | Sonnet |
+| 14 | Accessibility, iPad QA, Final Polish | Opus |
+
+Read each session's spec before executing it. Each session has its own pre-flight, file list, deliverables, tests, acceptance checklist, and end-of-session ritual.
+
+## Execution
+
+Two execution options:
+
+### 1. Subagent-Driven (recommended)
+
+Run each session in a fresh subagent with the session spec as the prompt. The main agent stays in the user's conversation context; subagents do the heavy lifting. After each subagent completes:
+- Review the diff
+- Run the listed tests
+- Run `marauder-web-review` agent
+- Commit + push
+
+### 2. Inline Execution
+
+Work through the sessions sequentially in this conversation. Higher context cost but tighter feedback.
+
+Both approaches respect the per-session test gates listed at the bottom of each `sessions/session-NN.md`.

--- a/docs/superpowers/specs/2026-05-01-claudes-math-marauder-design.md
+++ b/docs/superpowers/specs/2026-05-01-claudes-math-marauder-design.md
@@ -188,7 +188,7 @@ Single RAF chain owned by `game.js`; all draw passes are passive `update(dt)` / 
 
 1. **Panel background** — solid zone color + halftone gradient (cached offscreen)
 2. **Parallax silhouettes** — 2 layers of zone-specific landmarks (cached offscreen)
-3. **Monster sprite** — procedural, drawn fresh each frame for animation
+3. **Monster sprite** — base shape cached to one offscreen canvas per part (head/body/limbs); composited per frame via `drawImage` with animation transforms (translate/rotate/scale). Re-cache only when palette/scale changes (Petstore-precedent paper-doll model).
 4. **Spell projectile** — only during RESOLVE; trail of ink dots
 5. **Wizard portrait** — bottom-left frame, animates on hit/cast
 6. **Comic-effects layer** — burst text, speed lines, screen-flash, panel flashes
@@ -458,11 +458,15 @@ Class roster:
 2. Compute pull weight per fact:
    ```
    weight = boxWeight[box] × shakyMultiplier × recencyDamping
-   boxWeight = [_, 5, 4, 3, 2, 1]   // lower box = higher weight
+   boxWeight = { 1: 5, 2: 4, 3: 3, 4: 2, 5: 1 }   // lower box = higher weight
    shakyMultiplier = 2.5 if shaky else 1.0
    recencyDamping = 0.3 if seen in last 5 problems else 1.0
    ```
-3. With probability `0.10 + 0.02 × realmTier` (0.12 in realm 1 → 0.20 in realm 5), instead pull a **stretch fact** from a mastered family (`5×N`, `10×N`, `2×N` where N ∈ {13..30}, plus their division inverses)
+3. With probability `0.10 + 0.02 × realmTier` (0.12 in realm 1 → 0.20 in realm 5), instead pull a **stretch fact** from a mastered family (and only when that family is mastered):
+   - **5s:** `5 × N` for `N ∈ [13, 30]` (max product 150) + division inverses
+   - **10s:** `10 × N` for `N ∈ [13, 30]` (max product 300) + division inverses
+   - **2s:** `2 × N` for `N ∈ [13, 50]` (max product 100; covers `2 × 25`, `2 × 50` etc.) + division inverses
+   - All stretch facts are tagged so combat fires the bonus "chrono blast" celebration on correct answer
 4. Pick weighted-random from the resulting distribution
 5. 70% multiplication / 30% division by default; realm config can override
 

--- a/docs/superpowers/specs/2026-05-01-claudes-math-marauder-design.md
+++ b/docs/superpowers/specs/2026-05-01-claudes-math-marauder-design.md
@@ -1,0 +1,794 @@
+# Claude's Math Marauder — Design Spec
+
+**Date:** 2026-05-01
+**Author:** Claude (in collaboration with Aaron)
+**Folder:** `claudes-math-marauder/`
+**Status:** Approved design, pending implementation plan
+**Index card:** `🤖⚔️📐` "Claude's Math Marauder" — *"Claude built this fantasy roguelike where you cast multiplication and division spells to defeat goblins, dragons, and liches."*
+
+---
+
+## 1. Goal & Player
+
+A browser-based fantasy roguelike that drills multiplication and division (factors 0–12, results 0–144, plus stretch facts in the 5s/10s/2s families up to ~30) for one specific 10-year-old player.
+
+**Player profile:**
+- Age 10, strong at math, bores easily, ADHD + dyslexia
+- Loves fantasy: monsters, wizards, dragons, space battles, magic, graphic novels
+- Struggles with reading — every dialogue/text block must be available as audio
+- Plays in 5–15 minute sessions
+
+**Design constraints derived from the player:**
+- Anti-boredom: high novelty per fight, real player choice each run, never grind-locked
+- Anti-frustration: no run-loss state (B3 retry-on-defeat), no countdown timers visible by default, no harsh audio
+- Reading-light: all text narrated via Web Speech, large dyslexia-friendly font, sentence-per-panel max
+- Difficulty calibration: adaptive (Leitner) so the kid is always at the edge of his ability
+
+**Tech stack** (matches repo conventions): vanilla JavaScript, HTML5 Canvas 2D, Web Audio, Web Speech, LocalStorage. No frameworks, no build step, no npm. Deployed to GitHub Pages from `main`.
+
+---
+
+## 2. High-Level Game Loop
+
+### 2.1 The fantasy
+
+Player is a young apprentice wizard in the Tower of Numbers. Each run is a march through one of five **realms** (Goblin Forest → Crystal Cave → Dragon Peak → Astral Void → Lich Citadel) to defeat its boss, learn a chapter of the story, and bring back gold + spell scrolls.
+
+### 2.2 Top-level state machine
+
+```
+TITLE
+  ↓
+HUB (Wizard's Tower)
+  • Cast pool / deck builder (up to 5 equipped spells)
+  • Class picker (unlocked wizards)
+  • Codex (story panels, mastery heatmap, drill-this-fact)
+  • Realm picker (start a run)
+  ↓
+RUN  ─ branching node map (10–12 nodes) ─
+  Node types:
+    ⚔️  Combat       (standard monsters, orb combat)
+    👹  Elite        (tougher monster, guaranteed spell drop)
+    🛒  Spellshop    (run-scoped buffs for gold)
+    🔮  Mystery      (narrated event card with choices)
+    💤  Rest         (heal flavor HP OR upgrade one spell)
+    👑  Boss         (multi-phase glyph-combo combat — required to clear realm)
+  ↓
+RESULTS (graphic-novel card: gold earned, mastery deltas, story panel if first clear)
+  ↓
+HUB
+```
+
+### 2.3 Run length & shape
+
+- **Map shape:** Slay-the-Spire branching graph (A1 in brainstorm).
+- **Length:** 10–12 nodes per run, ~1 minute per node = 10–15 min per run target.
+- **Generation:** deterministic from `(runSeed, realmId)`; same inputs produce identical map (enables resume + replay).
+
+### 2.4 Failure model (B3 — retry-on-defeat, no run-loss)
+
+- Wizard HP exists for *flavor and feedback*, not run-failure. Hitting 0 doesn't end the run.
+- On defeat: the fight enters **second wind** — re-fight the same monster with an apology beat ("the Lich laughs — try again!"), streak resets to 0, retries++.
+- Stakes come from three live meters tracked per run:
+  1. **Streak counter** — fights cleared with no retries (multiplies score/gold)
+  2. **Score** — base + speed crits + streak multiplier (logged to per-realm leaderboard-of-self)
+  3. **Star rating** at run end:
+     - 1⭐ cleared
+     - 2⭐ cleared with ≤2 retries
+     - 3⭐ cleared with 0 retries (perfect)
+- Star unlocks gate next class / next realm (any star count clears the realm; higher stars accelerate meta-progression).
+
+### 2.5 Meta-progression (D4 — all three tracks)
+
+- **Gold** — earned per run, spent in hub on permanent spell unlocks
+- **Class unlocks** — beat each realm boss (any star) to unlock its associated wizard class:
+  - Apprentice (start) → Pyromancer → Necromancer → Astromancer → Chronomancer
+  - Each class has a unique combat feel (see §6.3)
+- **Story panels** — each first-time boss clear unlocks a graphic-novel cutscene panel (audio-narrated, big 🔊 button, sentence-by-sentence highlighting, skippable). 5 realms = 5 chapters.
+
+### 2.6 Session-friendliness
+
+- Auto-save after every node (resume mid-run if browser closes / tab crashes).
+- "Quit run" returns to hub; current run is *abandoned* (not resumable from arbitrary point) — accepted gracefully, no guilt UI.
+- Hub shows total runs, total problems solved, mastery heatmap, story progress.
+
+---
+
+## 3. Combat Architecture
+
+### 3.1 Per-fight state machine
+
+```
+INTRO         → monster slides in, name banner, taunt narrated
+PROBLEM       → comic panel reveals "7 × 8 = ?", four orbs float up
+ANSWERING     → player taps orb / types ultimate / boss glyph
+RESOLVE       → spell flies, ink-burst impact, damage numbers pop
+                if monster HP ≤ 0 → VICTORY
+                else → PROBLEM (next problem for next swing)
+MONSTER_TURN  → woven into RESOLVE on wrong/slow answers (not a separate phase)
+VICTORY       → reward card + node completion
+DEFEAT        → second-wind retry (B3); streak reset; restart at INTRO
+```
+
+Every state is driven by `game.js` RAF — no manager has its own loop (KC4/Petstore single-RAF rule). All managers expose passive `update(dt)` / `draw(ctx, w, h)` methods.
+
+### 3.2 Three combat modes (D in brainstorm)
+
+#### 3.2.1 Orb cast (default, ~85% of problems)
+
+- Problem panel renders top-center: `"7 × 8 = ?"` in OpenDyslexic, ~96px numerals
+- 4 floating orbs at bottom — one correct, three close-miss distractors
+- Tap or click an orb → wizard casts that spell → impact panel
+- Speed scoring (no visible countdown):
+  ```
+  score = base + max(0, (5000 - answerTimeMs) / 50)
+  ```
+  Faster = bigger crit (felt via crit damage and screen flash, not ticking timer)
+- Wrong orb: monster takes no damage, wizard takes a flavorful hit (portrait shake), the correct answer is briefly highlighted as a learning moment ("the answer was 56!") and narrated, then a new problem rolls.
+
+#### 3.2.2 Ultimate cast (typed, ~10% of problems)
+
+- Charge meter fills with each correct orb-cast (roughly 3 streak fills it once; modifiable by spells)
+- Next problem after meter full = **ULTIMATE**: bigger panel, dramatic narration ("Speak the truth!"), on-screen numpad (and physical keyboard if connected) — type the answer, press Enter
+- Correct → massive damage (often one-shot kill on standard mobs), comic "KO!" page-flash
+- Wrong → meter drains, problem reverts to a normal orb cast at 0.5× damage
+- Numpad: 0–9 + ⌫ + ✓; ≥72px keys; entered digits show in a glowing sigil at 96px **before** commit (catches digit-flips)
+
+#### 3.2.3 Boss glyph combo (multi-step, bosses only)
+
+- Bosses have HP equal to their **phase count** (3–5 phases) — KC4-proven pattern.
+- Each phase is its own labeled attack with a unique problem flavor:
+  - Shield phase: division
+  - Curse phase: bigger-number multiplication
+  - Final phase: a stretch fact (e.g., `5 × 20`) for the killing blow
+- Phase 1–2 typically orb-cast; later phases force ultimate (typed). Final boss of a realm always ends with a typed killing-blow problem for cinematic punch.
+- Between phases: short narrated taunt + glyph-shatter animation.
+
+### 3.3 Distractor generation (critical for fairness)
+
+For each problem `a × b = c` (or `c ÷ a = b`), the orbs include the correct answer plus three "plausible-misread" distractors drawn from:
+
+- `a × (b±1)` and `(a±1) × b` (off-by-one factor)
+- `c ± 1` (off-by-one product) — catches sloppy mental math
+- For division: include `c - a`, `b ± 1`, factor-swap confusions
+- Filter so all 4 orbs have unique values, all in plausible "kid would write this" range
+- Always exactly one correct; shuffle position via Fisher-Yates (never `sort(() => Math.random()-0.5)` — Petstore rule)
+
+### 3.4 Per-correct juice
+
+- Comic burst-text ("ZAP!" / "BAM!" / "CRIT!") at impact point, font-size scales with damage
+- Halftone screen-flash pulse (single frame, max 80% opacity — never strobe)
+- Damage number fountains up and fades
+- Streak counter ticks; at 3/5/10 streak, a sparkle border lights the panel
+- Audio: synthesized hit thump + sparkle (Web Audio, lazy-init in user gesture)
+
+### 3.5 Per-wrong feedback
+
+- Wizard portrait shakes (CSS animation, no canvas hijack)
+- Correct answer revealed for 800ms with audio narration ("the answer was 56")
+- Streak resets to 0 (visible counter zeroes, soft "shink" sound)
+- Mastery model bumps that fact toward "shaky" → next 1–2 problems more likely to drill it
+
+---
+
+## 4. Visual Renderer & Comic Style
+
+### 4.1 Canvas setup
+
+```js
+canvas.width  = canvas.clientWidth  * devicePixelRatio;
+canvas.height = canvas.clientHeight * devicePixelRatio;
+ctx.scale(devicePixelRatio, devicePixelRatio);
+ctx.imageSmoothingEnabled = false;  // crisp ink lines
+```
+
+Single RAF chain owned by `game.js`; all draw passes are passive `update(dt)` / `draw(ctx, w, h)` methods on managers (KC4 + Petstore rule). Delta-time capped at 50ms.
+
+### 4.2 Layered draw order per frame (back to front)
+
+1. **Panel background** — solid zone color + halftone gradient (cached offscreen)
+2. **Parallax silhouettes** — 2 layers of zone-specific landmarks (cached offscreen)
+3. **Monster sprite** — procedural, drawn fresh each frame for animation
+4. **Spell projectile** — only during RESOLVE; trail of ink dots
+5. **Wizard portrait** — bottom-left frame, animates on hit/cast
+6. **Comic-effects layer** — burst text, speed lines, screen-flash, panel flashes
+7. **HUD overlay (DOM)** — HP bars, streak, score, ultimate meter, settings
+
+HUD lives as DOM over the canvas (faster, accessible).
+
+### 4.3 Comic-effects library (`fx/comicfx.js`)
+
+| Primitive | What it does | When it fires |
+|---|---|---|
+| `inkOutline(path, weight)` | Thick black line w/ slight wobble | Around every monster shape, panel borders |
+| `halftoneFill(rect, color, density)` | Cached dot pattern at scale-aware density | Backgrounds, monster shading, impact panels |
+| `speedLines(origin, direction, n)` | Radiating ink streaks | Spell cast, monster charge, dash anim |
+| `burstText(x, y, word, size, color)` | Comic "POW!" with stroke + jitter | Hit/crit/KO impacts |
+| `panelFlash(color, alphaCurve)` | Single-frame screen tint | Crit, KO, level-up |
+| `inkBurst(x, y, radius, color)` | Splatter of ink dots radiating out | Spell impact |
+| `wobbleStroke(path, seed)` | Hand-drawn jitter to any stroke | Borders, speech bubbles |
+| `panelBorder(rect, style)` | Black inset comic-panel frame | Boss intro cards, story cutscenes |
+| `screenShake(intensity, ms)` | Translates whole canvas | Boss attacks, KO |
+
+All effects are **seeded per-instance** (Petstore rule on cached procedural textures) so re-cached halftones render identically across LRU evictions.
+
+### 4.4 Monster rendering — parametric "creature schema"
+
+Each monster is data, not art:
+
+```jsonc
+{
+  "id": "goblin_grunt",
+  "name": "Goblin Grunt",
+  "tier": 1,
+  "hp": 1,
+  "size": [180, 220],
+  "palette": ["#3a6b2c", "#1b3618", "#f0d840"],
+  "shape": {
+    "body":  { "kind": "blob",      "rx": 70, "ry": 80, "wobble": 0.12 },
+    "head":  { "kind": "egg",       "scale": 1.1, "tilt": -0.05 },
+    "eyes":  { "kind": "comic_pair","size": 18, "expr": "angry" },
+    "mouth": { "kind": "fang_grin" },
+    "limbs": [ { "kind": "stub_arm", "side": "L" }, { "kind": "stub_arm", "side": "R" } ],
+    "horns": null,
+    "tail":  null
+  },
+  "anim": { "idle": "bob", "attack": "lunge", "hit": "squash" },
+  "voiceTaunts": ["Tiny wizard! Easy lunch!", "Numbers won't save you!"],
+  "spawnSfx": "goblinGrunt"
+}
+```
+
+A `MonsterRenderer` walks the shape tree, draws each part procedurally (`inkOutline` + `halftoneFill`), applies palette, applies animation. ~25–30 standard monsters via parameter tweaks. 5 bosses authored more carefully (one per realm).
+
+### 4.5 Animation system
+
+- Idle: per-monster `update(dt)` advances a phase clock; positions limbs/head via sine-wave offsets
+- Attack: short curve (translate forward → squash → return) over 350ms; drives `monster.x` offset
+- Hit reaction: flash white 60ms, squash 80% scale 100ms, return; `screenShake`
+- Death: ink-burst + halftone fade-out + comic "KO!" burst-text, 600ms total, monster removed at end
+- All animations delta-time based, capped at 50ms (Petstore RAF-throttling rule)
+
+### 4.6 Realm visual themes
+
+| Realm | Palette | Halftone color | Silhouettes | Sky/panel BG |
+|---|---|---|---|---|
+| Goblin Forest | greens + browns | green dots | gnarled trees, mushrooms | dawn green-yellow |
+| Crystal Cave | violets + cyan | violet dots | stalactites, gem clusters | dark blue gradient |
+| Dragon Peak | reds + oranges | red dots | jagged peaks, lava | sunset crimson |
+| Astral Void | indigo + magenta | white dots on dark | floating debris, planets | starfield |
+| Lich Citadel | grayscale + sickly green | green dots on slate | skeletal towers, gravestones | overcast gray-green |
+
+Each realm has 4–5 monsters from the parametric schema + 1 hand-tuned boss + a unique parallax background.
+
+### 4.7 Wizard portrait
+
+- Bottom-left frame, 220×260px, panel-bordered
+- Class-specific look: same base wizard schema, different palette/staff/hat per class
+- Animates on cast (staff thrust + speed-lines), on hit (face flash + portrait shake), on ultimate-charge-full (sparkle aura)
+
+### 4.8 Performance targets
+
+- 60fps on iPad Safari
+- ≤ 50ms dt cap
+- ≤ 30 active offscreen canvases (Petstore LRU pattern; warn + LRU evict if exceeded)
+- No per-frame `SaveManager.load()` — cache run/creature state on state entry, invalidate on save
+
+---
+
+## 5. Audio System
+
+Two paths, both lazy-init in a user gesture (CLAUDE.md iOS Safari rule).
+
+### 5.1 Web Speech API — narration & dialogue
+
+- All on-screen text > ~3 words gets a 🔊 button to read aloud
+- "Auto-narrate" toggle (default ON; tap-to-replay always available)
+- Voice picker: lists `speechSynthesis.getVoices()`, prefers known-good iPad voices ("Daniel (United Kingdom)", "Karen", "Samantha", "Moira")
+- Speech-rate slider: 0.7×–1.3×, default 1.0×
+- Playback rule:
+  ```js
+  if (!('speechSynthesis' in window)) return;
+  speechSynthesis.cancel();
+  setTimeout(() => speechSynthesis.speak(utterance), 50);
+  ```
+- `voiceschanged` event listener loads voice list async (iOS delays it)
+- Per-character voice flavor: small pitch/rate offsets via `monster.voiceProfile`
+
+**Narration sources:**
+- Title screen welcome
+- Hub navigation announcements
+- Monster intro taunts (drawn from `voiceTaunts`)
+- Boss intro speech
+- Wrong-answer correction ("the answer was 56")
+- Story cutscene panels (sentence-by-sentence with auto-advance)
+- Mystery node event text
+- Settings/menu announcements
+
+### 5.2 Web Audio — synthesized SFX
+
+Single `AudioContext` lazily created on first user interaction; `ctx.resume().then(() => schedule())` for oscillators (CLAUDE.md). All SFX synthesized — no audio files (consistent with KC4).
+
+| Sound | Synth recipe |
+|---|---|
+| Orb hover | sine 600Hz, 80ms, low-pass 1500Hz |
+| Orb tap (correct) | square 220→880Hz sweep, 120ms, fast attack, soft release |
+| Spell cast | triangle + filtered noise burst, 200ms |
+| Hit (normal) | low square 110Hz + filtered noise thump, 150ms |
+| Crit hit | hit + bright sparkle (sine 1760Hz arpeggio) |
+| Wrong answer | low triangle 80Hz, 200ms, soft (cute-end, never harsh — Petstore rule) |
+| Streak chime (3/5/10) | bell-like 3-note arpeggio, sine + harmonic |
+| Ultimate charge full | rising sine 220→880Hz, 600ms |
+| Ultimate fire | layered sweep + screen-flash sync |
+| Boss spawn | low rumble (filtered noise) + dramatic chord |
+| KO | triumphant 4-note motif |
+| Page-flip (transitions) | paper rustle (filtered noise burst) |
+| UI button tap | soft click, 40ms |
+
+Master volume slider + mute toggle in settings; persists in save.
+
+### 5.3 ARIA + audio together
+
+- `aria-live="polite"` regions for score / streak / "answer was X" correction
+- Never combine `aria-live` with `aria-hidden` toggling (CLAUDE.md)
+- Never put `aria-label` on aria-live regions
+- 🔊 button is real `<button>` with `aria-label="Read aloud"`; updates to `"Replay"` after first use; uses `disabled` attribute when speech unavailable
+
+### 5.4 Reduced-motion
+
+- `prefers-reduced-motion` media query auto-disables screen shake + panel flashes (effects fall back to static highlight)
+- Manual override toggle in settings
+
+---
+
+## 6. Data Model & Authored Content
+
+### 6.1 Authored data files (ship in `data/`)
+
+- **`data/realms.json`** — 5 realm definitions (palette, halftone, silhouettes, music key, fact-family weights, monster pool, boss id, story chapter id)
+- **`data/monsters.json`** — ~30 standard monsters (parametric schemas)
+- **`data/bosses.json`** — 5 boss schemas (one per realm) with phase arrays
+- **`data/spells.json`** — ~25 spells
+- **`data/classes.json`** — 5 wizard classes
+- **`data/story.json`** — 5 chapters (~6–10 short narrated lines each) + run-flavor lines (taunts, victory blurbs)
+- **`data/events.json`** — ~20 mystery-node events (narrated prompt + 2–3 choices + outcomes)
+
+### 6.2 Spell schema
+
+```jsonc
+{
+  "id": "ember_bolt",
+  "name": "Ember Bolt",
+  "rarity": "common",
+  "tier": 1,
+  "classRestrict": null,
+  "fxColor": "#ff7733",
+  "fxKind": "spark",
+  "modifiers": {
+    "baseDamageBonus": 0,
+    "speedCritBonus": 0.1,
+    "streakBonusBonus": 0,
+    "ultimateChargeBonus": 0.2
+  },
+  "unlock": { "kind": "shop", "cost": 30 }
+}
+```
+
+A run carries a "deck" of up to 5 equipped spells. Effects stack additively. `fxColor`/`fxKind` make each spell visually distinct in combat.
+
+### 6.3 Class schema
+
+```jsonc
+{
+  "id": "pyromancer",
+  "name": "Pyromancer",
+  "passive": {
+    "type": "crit_chain",
+    "description": "Each consecutive correct answer increases crit damage by 5% (caps at 50%)."
+  },
+  "starterDeck": ["ember_bolt", "kindle_step", "ash_shield"],
+  "unlock": { "kind": "boss_clear", "realm": "goblin_forest", "minStars": 1 },
+  "wizardSchema": { /* portrait params */ }
+}
+```
+
+Class roster:
+- **Apprentice** (start) — vanilla
+- **Pyromancer** — chains crits
+- **Necromancer** — steals flavor-HP on correct
+- **Astromancer** — slows monster attack timing
+- **Chronomancer** — reveals one wrong distractor for free, once per fight
+
+### 6.4 Run state (in-memory; auto-saved per node for resume)
+
+```jsonc
+{
+  "runId": "uuid",
+  "realmId": "goblin_forest",
+  "classId": "apprentice",
+  "deck": ["ember_bolt", "...", "..."],
+  "seed": 1209384,
+  "mapNodes": [/* generated branching graph */],
+  "currentNodeId": "n3",
+  "wizardHpFlavor": 60,
+  "streak": 5,
+  "score": 1240,
+  "retries": 1,
+  "ultimateCharge": 0.7,
+  "goldThisRun": 24,
+  "spellsAddedThisRun": [],
+  "factsThisRun": [/* {factKey, correct, ms} */],
+  "startedAt": 1714400000000
+}
+```
+
+### 6.5 Mastery engine — Leitner spaced repetition
+
+#### Fact keys (canonical, dedupe commutative pairs)
+
+- `"mul:7x8"` — always smaller × larger
+- `"div:56/7"` — always larger ÷ smaller form
+
+#### Per-fact stats
+
+```jsonc
+"mastery": {
+  "mul:7x8": {
+    "box": 3,
+    "lastSeenAt": 1714400000000,
+    "totalAsked": 14,
+    "totalCorrect": 12,
+    "avgMs": 2100,
+    "streak": 4,
+    "shaky": false
+  }
+}
+```
+
+#### Box update rule on resolve
+
+- Correct + fast (`< 2 × avgMs of mastered facts`) → `box = min(5, box + 1)`
+- Correct + slow → `box` unchanged
+- Wrong → `box = max(1, box - 2)`, `shaky = true`
+- **Mastered = `box ≥ 4 && totalCorrect ≥ 6`**
+
+#### Problem selection (per problem)
+
+1. Build eligible-fact set from realm's `factFamilyWeights`
+2. Compute pull weight per fact:
+   ```
+   weight = boxWeight[box] × shakyMultiplier × recencyDamping
+   boxWeight = [_, 5, 4, 3, 2, 1]   // lower box = higher weight
+   shakyMultiplier = 2.5 if shaky else 1.0
+   recencyDamping = 0.3 if seen in last 5 problems else 1.0
+   ```
+3. With probability `0.10 + 0.02 × realmTier` (0.12 in realm 1 → 0.20 in realm 5), instead pull a **stretch fact** from a mastered family (`5×N`, `10×N`, `2×N` where N ∈ {13..30}, plus their division inverses)
+4. Pick weighted-random from the resulting distribution
+5. 70% multiplication / 30% division by default; realm config can override
+
+Mastery is recomputed/saved at end of every fight (batch write, not per problem).
+
+### 6.6 Save schema (key: `claudes-math-marauder-save`)
+
+```jsonc
+{
+  "schemaVersion": 1,
+  "createdAt": 1714400000000,
+  "lastPlayedAt": 1714400000000,
+  "playerName": null,
+  "totalRunsStarted": 7,
+  "totalRunsCompleted": 5,
+  "totalProblemsAnswered": 412,
+  "totalCorrect": 380,
+  "gold": 142,
+  "ownedSpellIds": ["ember_bolt", "kindle_step", "ash_shield", "frost_orb"],
+  "equippedDeck": ["ember_bolt", "frost_orb", "kindle_step", "ash_shield", null],
+  "unlockedClassIds": ["apprentice", "pyromancer"],
+  "selectedClassId": "pyromancer",
+  "realmStars": {
+    "goblin_forest": 3,
+    "crystal_cave": 2,
+    "dragon_peak": 0,
+    "astral_void": 0,
+    "lich_citadel": 0
+  },
+  "storyChaptersUnlocked": ["chapter_1", "chapter_2"],
+  "mastery": { /* per-fact stats */ },
+  "activeRun": { /* run state above; null when no run in progress */ },
+  "settings": { /* §6.7 */ }
+}
+```
+
+**SaveManager contract:**
+- Single key, schema-versioned (Petstore pattern)
+- Backup key: `claudes-math-marauder-save-backup`, updated every 5 saves
+- All save reads/writes through SaveManager — never direct `localStorage`
+- `_defaults()` includes every field game.js reads (CLAUDE.md completeness rule)
+- `try/catch` quota errors → user-visible toast
+- Migration step on load: `schemaVersion < current` → run versioned migrators
+
+### 6.7 Settings sub-object
+
+```jsonc
+"settings": {
+  "speechVoiceURI": "com.apple.speech.synthesis.voice.daniel",
+  "speechRate": 1.0,
+  "autoNarrate": true,
+  "sfxVolume": 0.7,
+  "muteAll": false,
+  "reducedMotion": false,
+  "fontScale": 1.0,
+  "showSpeedTimer": false,
+  "allowStretchFacts": true
+}
+```
+
+### 6.8 Per-fact analytics in-game (Codex)
+
+- Codex screen in hub shows a 13×13 grid (0–12 × 0–12) of multiplication facts
+- Each cell colored by box: red (1) → orange → yellow → green (4+) → gold (mastered)
+- Tap a cell → fact, current stats, "drill this one" button (queues 5-problem mini-fight on that fact, small reward, no run consumed)
+- Same for division (separate grid view)
+- Makes mastery progress legible to the kid and gives him agency over what to drill
+
+---
+
+## 7. Accessibility, Dyslexia & ADHD Specifics
+
+### 7.1 Hard-required (from project CLAUDE.md)
+
+- **Font:** OpenDyslexic via `<link rel="stylesheet">` (CDN), Comic Sans MS fallback. Never `@import` in CSS. Canvas text uses `ctx.font = '20px OpenDyslexic, "Comic Sans MS", cursive'` and waits on `document.fonts.ready` before first canvas text render.
+- **Min font size 16pt.** Default game-text 20px. Problem panel numerals 64–96px.
+- **Line height 1.5–2×** everywhere.
+- **Cream background** (`#F5F0E8`), **dark text** (`#2C2416`), secondary `#595143`. WCAG AA contrast 4.5:1 verified across all text/UI pairs by `scripts/check-contrast.js`.
+- **Touch targets ≥ 44×44px.** Combat orbs 96px, numpad keys 72px, settings switches 48px.
+- **No `user-scalable=no`** in viewport meta — pinch-zoom must work.
+- **No flashing/strobing.** Panel-flash peaks at 80% opacity for ≤ 1 frame, never repeats within 500ms. `prefers-reduced-motion` strips flashes + screen-shake; manual override toggle.
+- **No countdown timers visible by default.** Speed scoring is invisible (only the bonus damage appears). Settings flag "show speed timer" off by default.
+
+### 7.2 Dyslexia-specific
+
+- **Numeral clarity:** problem-panel numerals use OpenDyslexic; for `6/9/0` distinction, render with extra letter-spacing and a tiny serif foot baked into the canvas drawing
+- **Typed-input echo:** ultimate numpad shows entered digits at 96px in glowing sigil **before** commit; ⌫ corrects without penalty
+- **Wrong-answer narration always speaks the correct answer.** ("the answer was fifty-six")
+- **Story / dialogue text size 22px+, narrated by default.** Sentence-by-sentence highlighting (current sentence has yellow `#fef0a0` background tint)
+- **Single sentence per panel max.** Story chapters break long passages into short panels.
+- **No required reading.** Every interactive element has icon + tooltip + audio narration; text labels never carry sole meaning.
+
+### 7.3 ADHD-specific
+
+- **No anxiety mechanics.** No countdown timers in combat. No HP-based run-failure (B3). No "you're doing badly" copy ever — wrong-answer text is neutral.
+- **High novelty per fight.** Random monsters, random map paths, random spell-shop offerings, random mystery events. Every fight has visual variation (palette, monster shape, taunt).
+- **Short clear loops.** ~60 sec per fight, ~10–15 min per run. Auto-save after every node so quitting mid-run isn't a loss.
+- **Big visible reward per correct answer.** Burst-text + sound + damage number + streak meter tick.
+- **Pause is real.** Pause overlay anywhere → all timers/animations halt; `update(dt)` short-circuits when state is `PAUSED`. Resume returns to exactly the same problem. Timer callbacks tolerate PAUSED state (KC4 rule).
+- **Skip / fast-forward respected.** Cutscenes, monster intros, results cards have a skip button (focus-on-open, Escape closes). Boss intros skippable after 1.5s minimum.
+- **No grinding gates.** Every realm unlocks via *clearing* the previous realm at any star count — never "earn 200 gold first."
+- **Choice everywhere.** Branching map nodes, mystery options, spell-shop picks, class selection, deck slot choice — every run has 8–12 small player decisions.
+
+### 7.4 State-machine accessibility hooks
+
+- Screen visibility uses **CSS classes only** (CLAUDE.md): `.active` (screens), `.open` (overlays), `.hidden` (internal). No `style.display` assignments in JS.
+- Modals: `<div role="dialog" aria-modal="true" aria-label="...">` (never `<aside>`). Close button first focusable. Tab/Shift-Tab focus trap + Escape to close. `aria-hidden` always explicit `'true'`/`'false'`. Focus returns to trigger button on close.
+- Focus-trap Escape handler guards `if (overlay.classList.contains('open'))` (CLAUDE.md stale-handler rule).
+- `aria-pressed` only on toggle buttons with persistent state (deck slot, equipped class). `role="option"` inside `role="listbox"` uses `aria-selected`. Use `role="group"` for the spell-deck grid (not `role="list"` with `<button>` children).
+- All dynamic `textContent` updates on labelled elements also update `setAttribute('aria-label', ...)`.
+- `aria-live="polite"` regions for streak/score/correction. Never combined with `aria-hidden` toggling. No `aria-label` on aria-live regions.
+- Native `<button disabled>` for locked spells/realms. `.locked` class is supplementary visual only.
+- Filtered list items toggle `aria-hidden` on hidden cards so AT counts stay accurate. Overlays always use explicit `'true'`/`'false'` — never `removeAttribute`.
+
+### 7.5 Settings panel
+
+| Setting | Default | Notes |
+|---|---|---|
+| Master mute | off | persists |
+| SFX volume | 0.7 | slider |
+| Speech rate | 1.0× | 0.7–1.3 |
+| Speech voice | system best | dropdown |
+| Auto-narrate | on | first run |
+| Reduced motion | follows OS | manual override |
+| Font scale | 1.0× | 0.9 / 1.0 / 1.1 / 1.25 / 1.5 — applied via `document.documentElement.style.fontSize`, not by re-declaring CSS vars |
+| Show speed timer | off | adult-debug-style toggle |
+| Allow stretch facts | on | parental opt-out |
+| Reset progress | button | confirmation dialog |
+
+---
+
+## 8. Testing Strategy
+
+The repo has no unit-test framework and no build step, so testing is **layered**: pure-logic Node scripts for deterministic systems, validation scripts for data files, manual playtest checklists per session, and a code-review agent per session.
+
+### 8.1 Layer 1 — Node-runnable logic tests (`claudes-math-marauder/scripts/test-*.js`)
+
+Combat engine's deterministic layers are pure modules (no DOM, no canvas) so Node can `require()` them. Each test asserts and prints `PASS`/`FAIL`.
+
+**`scripts/test-problem-gen.js`**
+- All `mul:AxB` keys for `0 ≤ A ≤ B ≤ 12` produce correct answers
+- Division generator never produces non-integer result
+- Distractor pool: every set of 4 orbs contains exactly one correct, all unique, all in plausible range
+- Distractors never include the correct answer twice
+- Stretch-fact gate: a fact family below mastery threshold never produces stretch problems
+- Determinism: same `(seed, masteryState, realmId)` → same problem sequence
+
+**`scripts/test-mastery.js`**
+- Correct + fast → box increments (capped at 5)
+- Wrong → box decrements by 2 (floored at 1) and `shaky=true`
+- Mastered flag only when `box ≥ 4 && totalCorrect ≥ 6`
+- `recencyDamping` and `shakyMultiplier` produce expected weight distribution
+- Simulated 200-problem run from blank converges most fact-keys into box 3+ when answered correctly
+- Save/load round-trip preserves all mastery fields
+
+**`scripts/test-distractors.js`**
+- For 1000 random `(a, b)` pairs in 0..12: distractors always unique, in plausible range, never negative, never identical to correct
+- For 200 division problems: factor-swap confusion included when distinct from other distractors
+
+**`scripts/test-map-gen.js`**
+- Every map: exactly one START, one BOSS
+- All nodes reachable from START (BFS)
+- BOSS reachable via every leaf path
+- Total node count ∈ [10, 12]
+- Node-type distribution within configured ranges per realm
+- Same `(seed, realmId)` → identical map (determinism for resume)
+
+**`scripts/test-save-migration.js`**
+- v1 ↔ v1 round-trip preserves all fields
+- Synthetic `v0` (missing `mastery`, missing `unlockedClassIds`) migrates cleanly with defaults
+- Corrupt JSON triggers backup-key recovery + user-visible toast (mock; asserts code-path taken)
+- `_defaults()` includes every key game.js reads (asserted via grep across `js/**`)
+
+### 8.2 Layer 2 — Data validation skill `/validate-marauder-data`
+
+A skill (and matching `scripts/validate-data.js`) runs after any edit to `data/*.json` (auto via PostToolUse hook, like petstore). Checks:
+
+- All monster `id` values unique; referenced from realm pools without typos
+- All boss `id` values unique; phases array length === hp; every phase shortcutId references a valid problem-kind
+- All spell `id` values unique; `unlock.kind ∈ {"shop","boss_clear","starter"}`; `classRestrict` either null or refers to existing class
+- All class `starterDeck` IDs reference real spells; `unlock.realm` references real realm
+- All story chapter IDs match realm IDs; chapter line count between 4 and 12
+- All event choices have ≥1 outcome; outcomes reference valid keys
+- All palette colors valid hex; meet WCAG AA against cream where used as text/UI color
+- Realm `factFamilyWeights` sum to within `[0.95, 1.05]`
+- No unreferenced data files
+
+### 8.3 Layer 3 — Pre-implementation checklist `/marauder-checklist`
+
+Mirrors `petstore-checklist`/`kc4-checklist`: prints rules most likely to cause bugs, run **before** writing any session code. Includes:
+
+- Single RAF chain rule (only `game.js`)
+- Timer lifecycle pattern (every manager: null timers, `cancel()`, `complete()` save-cb-before-cancel, `start()` defensive reset)
+- Web Audio iOS quirks
+- Web Speech iOS quirks
+- `aria-hidden` explicit, `aria-pressed` rules, `role="list"`/`role="button"` rule
+- `try/catch` async overlay timing
+- `SaveManager._defaults()` completeness
+- Re-entry guards on shared callbacks
+- Visibility classes only — no `style.display`
+- Dynamic `aria-label` updates with `textContent`
+- `setInterval`/`setTimeout` PAUSED-state tolerance
+
+### 8.4 Layer 4 — Per-session manual playtest checklist (in each `sessions/session-NN.md`)
+
+Each session ends with a hand-run iPad Safari playtest checklist tailored to that session's deliverables. This caught most of the bugs in petstore and KC4.
+
+### 8.5 Layer 5 — Code-review agent `marauder-web-review`
+
+A new Claude agent definition in `.claude/agents/marauder-web-review.md` (mirroring petstore-web-review / kc4-web-review). Run after each session before commit. Reviews:
+
+- Diff against the session's spec
+- KC4/Petstore architecture rules (RAF, timers, audio init, Save, ARIA)
+- Performance hot-paths (no per-frame allocs, no per-frame `SaveManager.load()`)
+- Accessibility (focus management, Escape guards, aria-live conflicts)
+- The `marauder-checklist` rules
+
+### 8.6 Layer 6 — Determinism harness for combat replays
+
+Combat is fully deterministic given `(runSeed, masteryState, inputSequence)`.
+
+- `scripts/replay.js <run.json>` runs a saved input sequence headlessly through the combat engine and asserts the same final state
+- Debug menu in dev mode can save a replay file from a live run; replay reproduces exact problem set / orb arrangement / mastery deltas
+- Bonus fuzzer: `scripts/fuzz-runs.js` runs 10k random runs per realm, asserts no exceptions, no NaN damage, no infinite loops, all mastery keys remain valid
+
+### 8.7 Layer 7 — In-browser dev menu
+
+Hidden behind a settings checkbox `dev mode`. Adds:
+
+- "Skip to boss" button on map screen
+- "Set mastery state" panel — bulk-set boxes for testing problem generation
+- "Force monster" picker
+- "Replay last run" button
+- "Speech voice debug" — list all voices with sample-play
+
+Dev mode never auto-enables and is invisible to normal play.
+
+### 8.8 Verification matrix
+
+| Bug class | Caught by |
+|---|---|
+| Wrong math answers | Layer 1 (test-problem-gen) |
+| Bad orb distractors | Layer 1 (test-distractors) |
+| Mastery drift | Layer 1 (test-mastery) + Layer 6 (fuzz) |
+| Unreachable map nodes | Layer 1 (test-map-gen) |
+| Save schema corruption | Layer 1 (test-save-migration) + Layer 5 (review) |
+| Bad data file | Layer 2 (`/validate-marauder-data` + hook) |
+| RAF/timer/Web Audio init bugs | Layer 3 (checklist) + Layer 5 (review) |
+| Performance regressions | Layer 5 (review) + Layer 4 (playtest) |
+| Accessibility regressions | Layer 5 (review) + Session 14 a11y pass |
+| Unfair fight feel | Layer 6 (replay) |
+
+---
+
+## 9. Implementation Plan — Session Breakdown
+
+This is the *shape*; the full per-session detailed plan is produced by the writing-plans skill after this design is approved. Each session is sized for one Claude work block ending with: tests pass → `marauder-web-review` agent → commit.
+
+| # | Session | Focus | Key Deliverables |
+|---|---|---|---|
+| **1** | Skeleton + Save + Tests scaffolding | Foundations | Repo structure, `index.html` registered in `update-index.js`, CSS design system (cream + comic palette), state-machine shell (TITLE/HUB/RUN/FIGHT/RESULTS/PAUSED), SaveManager schema v1 + backup, `scripts/test-save-migration.js`, `scripts/validate-data.js`, `/marauder-checklist` skill, `/validate-marauder-data` skill, post-tool-use hook, `marauder-web-review` agent definition, `.claude/rules/marauder.md` rules file. |
+| **2** | Problem generation + mastery engine | Pure logic, no UI | `combat/problemGen.js`, `combat/mastery.js` (Leitner boxes, recency, shaky), `combat/distractors.js`, `combat/factKeys.js`, stretch-fact gate, `scripts/test-problem-gen.js`, `scripts/test-mastery.js`, `scripts/test-distractors.js`. All Layer-1 tests passing. |
+| **3** | Comic renderer + monster schema | Visual identity | Canvas + DPR, single RAF in `game.js`, `fx/comicfx.js` library, `MonsterRenderer` walks parametric schema, idle/attack/hit/death animations, offscreen caching for backgrounds + monster bases. Demo screen renders one of each shape primitive. |
+| **4** | Data authoring round 1 | Realm + monsters | `data/realms.json` (5 realms), `data/monsters.json` (5–6 monsters across realms — covers Realm 1 fully + one of each for later), `data/spells.json` (~10 starters), `data/classes.json` (Apprentice + Pyromancer), `data/story.json` (chapter 1), `data/events.json` (5 events). All validated. |
+| **5** | Combat — orb cast loop | Standard fight | `combat/fight.js` state machine, problem panel rendering, 4 floating orbs with hover/tap, correct/wrong resolve, damage numbers, streak counter, ultimate-meter accumulation, mastery save on resolve, retry-on-defeat (B3), wizard portrait reactions. iPad pointer-events tested. |
+| **6** | Combat — ultimate cast (typed) | Numpad spell | Ultimate trigger when meter full, on-screen numpad (≥72px keys), digit echo sigil, ⌫ + ✓, physical-keyboard support, big-damage payoff, fail-down-to-orb path. |
+| **7** | Combat — boss glyph combo | Multi-phase boss | Boss state machine extension, phase array drives problem kinds, glyph-shatter transition between phases, dramatic narration + screen flash on phase break, KO cinematic. Implement Realm 1's Goblin Warlord boss end-to-end. |
+| **8** | Audio: Web Speech + Web Audio | Voice + SFX | Lazy-init audio context, full SFX bank, every text block has 🔊 button, auto-narrate setting, voice picker + speech-rate slider, monster taunt narration, wrong-answer narration ("the answer was 56"), `prefers-reduced-motion` integration. |
+| **9** | Run map + node graph | Branching shape | `run/mapGen.js` deterministic branching map (10–12 nodes/realm), `scripts/test-map-gen.js`, map screen renders connected nodes with inline panels per type, node selection + path-tracking, mid-run auto-save, resume-on-reload. **Realm 1 fully playable end-to-end here.** |
+| **10** | Hub + meta-progression | Outside the run | Hub screen (Wizard's Tower) with realm picker, deck builder (drag/tap to slot up to 5 spells), class picker, gold display, spell-shop in-run flow, codex screen with mastery heatmap (13×13 grid + tap-to-drill mini-fights), star-rating system on run completion, story-panel viewer. |
+| **11** | Data authoring round 2 | Fill the world | Remaining ~25 monsters across realms 2–5, 4 more boss schemas, ~15 more spells, 3 more classes (Necromancer, Astromancer, Chronomancer), chapters 2–5 of story, 15 more mystery events. Validate. Fuzz-run all 5 realms. |
+| **12** | Cutscenes + results cards + transitions | Polish layer | Story-panel viewer with sentence-by-sentence highlighting, narration auto-advance, results card after each run (gold, stars, mastery delta, story unlock if first clear), comic page-turn screen transitions, KO cinematic for last boss of each realm. |
+| **13** | Replay harness + dev menu + fuzzer | QA tools | `scripts/replay.js` deterministic replay, dev menu (skip-to-boss, force-monster, set-mastery, voice debug), `scripts/fuzz-runs.js` (10k runs/realm assert no exceptions/NaN/dead loops). |
+| **14** | Accessibility + iPad QA + final polish | Ship | Full a11y audit (VoiceOver pass, contrast script, focus-trap audit, font-loading guards), iPad Safari 60fps verification (devtools profiler), font-scale slider, settings panel finalized, error toasts, edge cases (corrupt save, 0 mastery, 100% mastery, rapid-tap), final QA checklist, MEMORY.md update, push live. |
+
+**Why this ordering:**
+
+- Tests + scaffolding first (Sessions 1–2) so every later session lands on a green base
+- Combat (5–7) gated on data (4) gated on renderer (3) gated on logic (2) — no fake placeholders that get rewritten
+- One realm playable end-to-end at Session 9 — the kid can playtest a real-but-narrow version mid-build
+- Authoring round 2 (11) deliberately late so we've validated the data shape against working code first
+- Polish (12, 14) at the end where it lands hardest
+
+**Session size budget:** roughly mirrors petstore's 13-session cadence. Each session ends with `marauder-web-review` + manual playtest before commit.
+
+---
+
+## 10. Open Questions for Implementation Plan
+
+Things to nail down when writing the per-session implementation plan (not blockers for the spec):
+
+- Exact orb layout: 2×2 grid vs single arc? (orb count fixed at 4)
+- Map node visual: lines vs dotted paths? Animated reveal as you advance?
+- Class portraits: are all 5 wizards visually distinct enough via palette swap, or do they need different schemas? (Lean toward palette swap for v1.)
+- Spell shop UX: 3 random offerings vs full owned-deck swap-in? (Lean toward 3 random.)
+- Mystery events: how dialog-heavy can they get without breaking the reading-light goal? (Cap at 2 short narrated sentences per event prompt.)
+- Boss intro cinematic length: aim for ≤ 8 seconds, skippable after 1.5s.
+
+---
+
+## 11. Out of Scope (v1)
+
+- Online multiplayer
+- Real-time leaderboards across users (per-self-best is in scope)
+- Cloud save (LocalStorage only)
+- Custom monster/spell editor for the player
+- Localization (English only)
+- Touch-drag deck reordering with animation (tap-to-swap is fine for v1)
+- Pre-recorded voice acting (Web Speech only — confirmed)
+- Music tracks (synthesized SFX only — KC4 precedent)
+
+---
+
+## 12. Acceptance Criteria
+
+The game is "done" when:
+
+1. All 14 sessions complete, each with `marauder-web-review` clean
+2. All Layer-1 logic tests pass (`node scripts/test-*.js`)
+3. `/validate-marauder-data` reports zero errors
+4. `scripts/check-contrast.js` reports zero WCAG AA violations
+5. `scripts/fuzz-runs.js` completes 10k runs/realm with zero exceptions
+6. Manual iPad Safari playtest: 60fps verified, VoiceOver navigates all screens, all 5 realms clearable
+7. The kid plays a 10-minute session without expressing boredom, frustration, or asking for help reading
+8. Game is registered in `.github/scripts/update-index.js` and deployed via the existing GitHub Pages workflow
+
+---
+
+*End of design.*

--- a/index.html
+++ b/index.html
@@ -307,6 +307,16 @@
                 <span class="game-tag">✨ Play Now!</span>
             </a>
 
+            <!-- Claude's Math Marauder -->
+            <a href="claudes-math-marauder/" class="game-card active">
+                <span class="game-icon">🤖⚔️📐</span>
+                <div class="game-title">Claude's Math Marauder</div>
+                <div class="game-description">
+                    Claude built this fantasy roguelike where you cast multiplication and division spells to defeat goblins, dragons, and liches.
+                </div>
+                <span class="game-tag">✨ Play Now!</span>
+            </a>
+
             <!-- Keyboard Quest Round 3 -->
             <a href="keyboard-quest-3/" class="game-card active">
                 <span class="game-icon">🎮</span>


### PR DESCRIPTION
## Summary

- **Session 1**: Full project scaffold — `index.html`, `css/style.css`, `js/save.js` (with migration + backup), `js/game.js` (state machine + RAF loop), and utilities (`rng.js`, `shuffle.js`, `escape.js`, `toast.js`). Registered game in `update-index.js`.
- **Session 2**: Pure math engine (Node-testable, no DOM) — `factKeys.js`, `mastery.js` (Leitner spaced-repetition, boxes 1–5), `problemGen.js` (weighted problem selection, stretch facts), `distractors.js` (4-orb generation). 43 unit tests, all passing.
- **Review fixes**: mastery null-baseline threshold raised to 12 s; `equippedDeck` corrected to 4 slots; `var` → `const`/`let` in combat modules; combat scripts wired into `index.html`; two additional tests (avgMs convergence, null-weights guard).

## Test plan

- [ ] `node scripts/test-fact-keys.js` → 8 passed, 0 failed
- [ ] `node scripts/test-mastery.js` → 20 passed, 0 failed
- [ ] `node scripts/test-problem-gen.js` → 15 passed, 0 failed
- [ ] `node scripts/test-distractors.js` → 8 passed, 0 failed
- [ ] Open `claudes-math-marauder/index.html` in browser — title screen renders, no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)