### PR TITLE
Claude's Math Marauder — Sessions 1–3 (scaffold, math engine, comic renderer)

### DIFF
--- a/claudes-math-marauder/css/style.css
+++ b/claudes-math-marauder/css/style.css
@@ -76,6 +76,7 @@ html, body {
 #paused-screen.active {
   display: flex;
 }
+/* #demo-screen.active display is set in the Demo screen section below */
 
 /* ===== Overlays ===== */
 .overlay {
@@ -181,6 +182,42 @@ button.danger {
   border: 2px solid var(--accent-ink);
   max-width: 80vw;
   text-align: center;
+}
+
+/* ===== Demo screen ===== */
+#demo-screen.active {
+  display: block;
+  background: transparent;
+  pointer-events: none;
+}
+#demo-controls {
+  position: fixed;
+  bottom: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: center;
+  pointer-events: auto;
+  z-index: 20;
+}
+#demo-controls button {
+  font-size: 14px;
+  padding: 6px 14px;
+  min-height: 44px;
+}
+
+/* ===== FPS counter ===== */
+#fps-counter {
+  position: fixed;
+  top: 6px;
+  right: 10px;
+  font-size: 13px;
+  color: var(--text-secondary);
+  font-family: monospace;
+  z-index: 200;
+  pointer-events: none;
 }
 
 /* ===== Title screen ===== */

--- a/claudes-math-marauder/index.html
+++ b/claudes-math-marauder/index.html
@@ -15,6 +15,7 @@
   <div id="overlay-root"></div>
   <div id="toast-root" role="status"></div>
   <div id="transition-canvas-wrap"><canvas id="transition-canvas"></canvas></div>
+  <div id="fps-counter" aria-hidden="true"></div>
 
   <!-- TITLE screen -->
   <section id="title-screen" class="screen active" aria-label="Title screen">
@@ -41,11 +42,23 @@
     <button id="resume-button" class="primary" aria-label="Resume game">Resume</button>
   </section>
 
+  <!-- DEMO screen — visible at ?demo=1; canvas renders all content; buttons are DOM overlays -->
+  <section id="demo-screen" class="screen" aria-label="Render demo">
+    <div id="demo-controls" aria-label="Demo controls">
+      <button id="demo-flash-toggle" class="secondary" aria-pressed="false" aria-label="Toggle panel flash">Flash</button>
+      <button id="demo-shake-toggle" class="secondary" aria-label="Trigger screen shake">Shake</button>
+      <button id="demo-hit-0" class="secondary" aria-label="Hit goblin">Hit Goblin</button>
+      <button id="demo-hit-1" class="secondary" aria-label="Hit dragon">Hit Dragon</button>
+      <button id="demo-hit-2" class="secondary" aria-label="Hit lich">Hit Lich</button>
+    </div>
+  </section>
+
   <!--
     Script load order (all defer, UMD globals — no bundler required):
       1. Utilities: save, rng, shuffle, escape, toast
       2. Combat logic (pure, no DOM): factKeys → mastery → problemGen → distractors
-      3. Game orchestration: game.js last (reads all globals)
+      3. FX system: cache → comicfx → shapes → animation → particles → renderers
+      4. Game orchestration: game.js last (reads all globals)
   -->
   <script src="js/save.js" defer></script>
   <script src="js/util/rng.js" defer></script>
@@ -57,7 +70,15 @@
   <script src="js/combat/mastery.js" defer></script>
   <script src="js/combat/problemGen.js" defer></script>
   <script src="js/combat/distractors.js" defer></script>
-  <!-- Future sessions will add: fight.js, bossFight.js, mapGen.js, hub.js, etc. -->
+  <!-- FX system (Session 3) -->
+  <script src="js/fx/cache.js" defer></script>
+  <script src="js/fx/comicfx.js" defer></script>
+  <script src="js/fx/shapes.js" defer></script>
+  <script src="js/fx/animation.js" defer></script>
+  <script src="js/fx/particles.js" defer></script>
+  <script src="js/fx/monsterRenderer.js" defer></script>
+  <script src="js/fx/wizardRenderer.js" defer></script>
+  <!-- Game orchestration -->
   <script src="js/game.js" defer></script>
 </body>
 </html>

--- a/claudes-math-marauder/js/fx/animation.js
+++ b/claudes-math-marauder/js/fx/animation.js
@@ -1,0 +1,80 @@
+(function(global) {
+  'use strict';
+
+  // Idle breath is computed analytically from `now` — no per-monster timers.
+  // One-shot anims (hit, attack, death, charge) are tracked per-target in _states.
+  class AnimationManager {
+    constructor() {
+      this._states = new Map(); // targetId → { kind, startedAt, duration }
+    }
+
+    // Begin a one-shot animation on a target.
+    // kind: 'attack' | 'hit' | 'death' | 'charge'
+    begin(targetId, anim) {
+      this._states.set(targetId, {
+        kind: anim.kind,
+        startedAt: anim.startedAt,
+        duration: anim.duration,
+      });
+    }
+
+    // Advance all animations; prune completed one-shots.
+    update(dt, now) {
+      for (const [id, anim] of this._states) {
+        if (anim.kind === 'idle') continue;
+        if (now - anim.startedAt >= anim.duration) {
+          this._states.delete(id);
+        }
+      }
+    }
+
+    // Returns a snapshot of animation state used by renderers.
+    // now is passed in so the caller (game.js) controls timing.
+    stateFor(targetId, now) {
+      // Analytical idle breath — 1.2s cycle, ±2.5% scale
+      const idleBreath = Math.sin((now / 1200) * Math.PI * 2) * 0.025;
+
+      const base = {
+        idleBreath,
+        hitFlash: 0,
+        attackProgress: 0,
+        deathFade: 1,
+        chargeGlow: 0,
+        shakeUntilMs: 0,
+      };
+
+      const anim = this._states.get(targetId);
+      if (!anim || anim.kind === 'idle') return base;
+
+      const elapsed = now - anim.startedAt;
+      const t = Math.min(1, elapsed / anim.duration);
+
+      if (anim.kind === 'hit') {
+        base.hitFlash = Math.max(0, 1 - t * 2.5);
+        base.shakeUntilMs = anim.startedAt + Math.min(200, anim.duration * 0.6);
+      } else if (anim.kind === 'attack') {
+        base.attackProgress = t;
+      } else if (anim.kind === 'death') {
+        base.deathFade = 1 - t;
+      } else if (anim.kind === 'charge') {
+        base.chargeGlow = t;
+      }
+
+      return base;
+    }
+
+    cancel(targetId) {
+      this._states.delete(targetId);
+    }
+
+    cancelAll() {
+      this._states.clear();
+    }
+  }
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { AnimationManager };
+  } else {
+    global.AnimationManager = AnimationManager;
+  }
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/claudes-math-marauder/js/fx/cache.js
+++ b/claudes-math-marauder/js/fx/cache.js
@@ -1,0 +1,56 @@
+(function(global) {
+  'use strict';
+
+  class FxCache {
+    constructor(maxCanvases) {
+      this.max = maxCanvases === undefined ? 30 : maxCanvases;
+      this._map = new Map();
+      this._lru = []; // head = LRU, tail = MRU
+    }
+
+    get(key) {
+      if (!this._map.has(key)) return null;
+      this._bumpLru(key);
+      return this._map.get(key);
+    }
+
+    build(key, w, h, drawFn) {
+      const canvas = document.createElement('canvas');
+      canvas.width = w;
+      canvas.height = h;
+      drawFn(canvas.getContext('2d'), w, h);
+      this._map.set(key, canvas);
+      this._bumpLru(key);
+      this._evictIfNeeded();
+      return canvas;
+    }
+
+    invalidate(key) {
+      if (!this._map.has(key)) return;
+      this._map.delete(key);
+      const idx = this._lru.indexOf(key);
+      if (idx !== -1) this._lru.splice(idx, 1);
+    }
+
+    size() { return this._map.size; }
+
+    _bumpLru(key) {
+      const idx = this._lru.indexOf(key);
+      if (idx !== -1) this._lru.splice(idx, 1);
+      this._lru.push(key);
+    }
+
+    _evictIfNeeded() {
+      while (this._map.size > this.max) {
+        const oldest = this._lru.shift();
+        this._map.delete(oldest);
+      }
+    }
+  }
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { FxCache };
+  } else {
+    global.FxCache = FxCache;
+  }
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/claudes-math-marauder/js/fx/comicfx.js
+++ b/claudes-math-marauder/js/fx/comicfx.js
@@ -1,0 +1,206 @@
+(function(global) {
+  'use strict';
+
+  // Module-level cache for halftone pattern canvases (keyed by color:density:seed).
+  const _halftoneCache = new Map();
+
+  function _getHalftoneCanvas(color, density, seed) {
+    const key = color + ':' + density + ':' + seed;
+    if (_halftoneCache.has(key)) return _halftoneCache.get(key);
+    const canvas = document.createElement('canvas');
+    canvas.width = 64;
+    canvas.height = 64;
+    _drawHalftonePattern(canvas.getContext('2d'), 64, 64, color, density, seed);
+    _halftoneCache.set(key, canvas);
+    return canvas;
+  }
+
+  function _drawHalftonePattern(ctx, pw, ph, color, density, seed) {
+    const rng = mulberry32(hashString('ht:' + color + ':' + density + ':' + seed));
+    const count = Math.floor(pw * ph * density);
+    ctx.clearRect(0, 0, pw, ph);
+    ctx.fillStyle = color;
+    for (let i = 0; i < count; i++) {
+      const cx = rng() * pw;
+      const cy = rng() * ph;
+      const r = 1.5 + rng() * 2.5;
+      ctx.beginPath();
+      ctx.arc(cx, cy, r, 0, Math.PI * 2);
+      ctx.fill();
+    }
+  }
+
+  // Thick ink-outline stroke around a path defined by pathFn(ctx).
+  // wobbleSeed > 0 adds a second slightly-offset pass for a hand-drawn feel.
+  function inkOutline(ctx, pathFn, weight, color, wobbleSeed) {
+    weight = weight === undefined ? 4 : weight;
+    color = color || '#1a1a1a';
+    wobbleSeed = wobbleSeed || 0;
+    ctx.save();
+    ctx.lineWidth = weight;
+    ctx.strokeStyle = color;
+    ctx.lineCap = 'round';
+    ctx.lineJoin = 'round';
+    if (wobbleSeed) {
+      const rng = mulberry32(hashString('io:' + wobbleSeed));
+      ctx.save();
+      ctx.translate((rng() - 0.5) * 1.5, (rng() - 0.5) * 1.5);
+      ctx.globalAlpha = 0.4;
+      pathFn(ctx);
+      ctx.stroke();
+      ctx.restore();
+      ctx.globalAlpha = 1;
+    }
+    pathFn(ctx);
+    ctx.stroke();
+    ctx.restore();
+  }
+
+  // Halftone dot-pattern fill in (x, y, w, h). Cached by (color, density, seed).
+  function halftoneFill(ctx, x, y, w, h, color, density, seed) {
+    density = density === undefined ? 0.04 : density;
+    seed = seed === undefined ? 0 : seed;
+    const patternCanvas = _getHalftoneCanvas(color, density, seed);
+    const pattern = ctx.createPattern(patternCanvas, 'repeat');
+    ctx.save();
+    ctx.fillStyle = pattern;
+    ctx.fillRect(x, y, w, h);
+    ctx.restore();
+  }
+
+  // Radiating speed lines from (ox, oy) in direction dirRad ± spread.
+  function speedLines(ctx, ox, oy, dirRad, n, len, color) {
+    n = n === undefined ? 8 : n;
+    len = len === undefined ? 80 : len;
+    color = color || '#1a1a1a';
+    ctx.save();
+    ctx.strokeStyle = color;
+    ctx.lineCap = 'round';
+    const spread = Math.PI * 0.4;
+    for (let i = 0; i < n; i++) {
+      const t = n === 1 ? 0.5 : i / (n - 1);
+      const angle = dirRad - spread / 2 + t * spread;
+      const lineLen = len * (0.5 + (i % 3) * 0.25);
+      ctx.lineWidth = 0.8 + (i % 2) * 0.8;
+      ctx.beginPath();
+      ctx.moveTo(ox, oy);
+      ctx.lineTo(ox + Math.cos(angle) * lineLen, oy + Math.sin(angle) * lineLen);
+      ctx.stroke();
+    }
+    ctx.restore();
+  }
+
+  // Comic POW!/ZAP! text with fat stroke + fill and slight seeded rotation.
+  function burstText(ctx, x, y, text, size, color, strokeColor, seed) {
+    size = size === undefined ? 48 : size;
+    color = color || '#f0d840';
+    strokeColor = strokeColor || '#1a1a1a';
+    seed = seed === undefined ? 0 : seed;
+    const rng = mulberry32(hashString('bt:' + text + ':' + seed));
+    const rot = (rng() * 0.2) - 0.1;
+    ctx.save();
+    ctx.translate(x, y);
+    ctx.rotate(rot);
+    ctx.font = 'bold ' + size + 'px "OpenDyslexic", "Comic Sans MS", cursive';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.lineWidth = Math.max(4, size * 0.18);
+    ctx.strokeStyle = strokeColor;
+    ctx.lineJoin = 'round';
+    ctx.strokeText(text, 0, 0);
+    ctx.fillStyle = color;
+    ctx.fillText(text, 0, 0);
+    ctx.restore();
+  }
+
+  // Single-frame screen tint. alpha is provided by an external animation curve.
+  function panelFlash(ctx, w, h, color, alpha) {
+    if (alpha <= 0) return;
+    ctx.save();
+    ctx.globalAlpha = alpha;
+    ctx.fillStyle = color;
+    ctx.fillRect(0, 0, w, h);
+    ctx.restore();
+  }
+
+  // Splatter of ink dots radiating from (x, y).
+  function inkBurst(ctx, x, y, radius, color, n, seed) {
+    n = n === undefined ? 20 : n;
+    seed = seed === undefined ? 0 : seed;
+    const rng = mulberry32(hashString('ib:' + x + ':' + y + ':' + seed));
+    ctx.save();
+    ctx.fillStyle = color;
+    for (let i = 0; i < n; i++) {
+      const angle = rng() * Math.PI * 2;
+      const dist = rng() * radius;
+      const r = 1 + rng() * 4;
+      ctx.beginPath();
+      ctx.arc(x + Math.cos(angle) * dist, y + Math.sin(angle) * dist, r, 0, Math.PI * 2);
+      ctx.fill();
+    }
+    ctx.restore();
+  }
+
+  // Comic-style thick inset border.
+  function panelBorder(ctx, x, y, w, h, weight, color) {
+    weight = weight === undefined ? 6 : weight;
+    color = color || '#1a1a1a';
+    ctx.save();
+    ctx.lineWidth = weight;
+    ctx.strokeStyle = color;
+    ctx.lineJoin = 'miter';
+    ctx.strokeRect(x + weight / 2, y + weight / 2, w - weight, h - weight);
+    ctx.restore();
+  }
+
+  // Returns {dx, dy} offset for the caller to translate the canvas by.
+  // Returns {dx:0, dy:0} when untilMs has passed or reduced-motion is active.
+  function screenShake(now, intensity, untilMs) {
+    if (now >= untilMs) return { dx: 0, dy: 0 };
+    if (document.body.hasAttribute('data-reduced-motion')) return { dx: 0, dy: 0 };
+    const remaining = untilMs - now;
+    const fade = Math.min(1, remaining / 150);
+    const rng = mulberry32((now * 100) | 0);
+    return {
+      dx: (rng() - 0.5) * intensity * 2 * fade,
+      dy: (rng() - 0.5) * intensity * 2 * fade,
+    };
+  }
+
+  // Helper used by shapes.js: perturb an array of {x,y} points and draw as a closed path.
+  function wobbleStroke(ctx, points, wobbleSeed, jitterAmount) {
+    jitterAmount = jitterAmount === undefined ? 2 : jitterAmount;
+    const rng = mulberry32(hashString('ws:' + wobbleSeed));
+    if (points.length < 2) return;
+    ctx.beginPath();
+    ctx.moveTo(
+      points[0].x + (rng() - 0.5) * jitterAmount,
+      points[0].y + (rng() - 0.5) * jitterAmount
+    );
+    for (let i = 1; i < points.length; i++) {
+      ctx.lineTo(
+        points[i].x + (rng() - 0.5) * jitterAmount,
+        points[i].y + (rng() - 0.5) * jitterAmount
+      );
+    }
+    ctx.closePath();
+  }
+
+  const comicfx = {
+    inkOutline,
+    halftoneFill,
+    speedLines,
+    burstText,
+    panelFlash,
+    inkBurst,
+    panelBorder,
+    screenShake,
+    wobbleStroke,
+  };
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = comicfx;
+  } else {
+    global.comicfx = comicfx;
+  }
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/claudes-math-marauder/js/fx/monsterRenderer.js
+++ b/claudes-math-marauder/js/fx/monsterRenderer.js
@@ -1,0 +1,270 @@
+(function(global) {
+  'use strict';
+
+  const Z_ORDER = ['tail', 'wings', 'limbs', 'body', 'head', 'eyes', 'mouth', 'horns'];
+
+  // Padding around each part canvas so outlines don't clip.
+  const PAD = 12;
+
+  // Expression config for comicEyesPair pupils.
+  const EXPR_CONFIG = {
+    angry:     { pupilFrac: 0.38, browTilt: 0.55 },
+    surprised: { pupilFrac: 0.48, browTilt: 0 },
+    happy:     { pupilFrac: 0.40, browTilt: -0.3 },
+    neutral:   { pupilFrac: 0.42, browTilt: 0 },
+    dead:      { pupilFrac: 0, browTilt: 0 },
+  };
+
+  class MonsterRenderer {
+    constructor(fxCache) {
+      this._cache = fxCache;
+    }
+
+    // Build per-part offscreen canvases for a monster. Returns a compiled object.
+    // monster: { id, palette, shape:{body,head,eyes,mouth,limbs,tail,wings,horns}, layout }
+    buildCreature(monster) {
+      const parts = {};
+      const id = monster.id;
+
+      for (const slot of Z_ORDER) {
+        const shapeDef = monster.shape[slot];
+        if (!shapeDef && slot !== 'limbs') continue;
+
+        if (slot === 'limbs') {
+          const limbDefs = monster.shape.limbs;
+          if (!limbDefs || !limbDefs.length) continue;
+          parts.limbs = limbDefs.map((def, idx) => {
+            return this._buildPart(id, 'limb' + idx, def, monster.palette, monster.layout['limb' + idx] || { ox: 0, oy: 0 });
+          });
+          continue;
+        }
+
+        const layout = (monster.layout && monster.layout[slot]) || { ox: 0, oy: 0 };
+        parts[slot] = this._buildPart(id, slot, shapeDef, monster.palette, layout);
+      }
+
+      const bbox = this._computeBbox(monster);
+      return { parts, bbox };
+    }
+
+    _buildPart(monsterId, slot, shapeDef, palette, layout) {
+      const cacheKey = monsterId + ':' + slot + ':' + shapeDef.seed;
+      let canvas = this._cache.get(cacheKey);
+
+      if (!canvas) {
+        const { w, h } = this._partSize(slot, shapeDef);
+        canvas = this._cache.build(cacheKey, w, h, (ctx) => {
+          this._drawPart(ctx, slot, shapeDef, palette, w, h);
+        });
+      }
+
+      return { canvas, cx: layout.ox, cy: layout.oy };
+    }
+
+    _partSize(slot, def) {
+      let w, h;
+      if (slot === 'body')  { w = (def.rx || 40) * 2 + PAD * 2; h = (def.ry || 40) * 2 + PAD * 2; }
+      else if (slot === 'head')  { w = (def.rx || 25) * 2 + PAD * 2; h = (def.ry || 32) * 2 + PAD * 2; }
+      else if (slot === 'eyes')  { w = (def.size || 12) * 4 + PAD * 2; h = (def.size || 12) * 2 + PAD * 2; }
+      else if (slot === 'mouth') { w = (def.width || 20) + PAD * 2; h = (def.height || 12) + PAD * 2; }
+      else if (slot === 'tail')  { w = (def.length || 50) + PAD * 2; h = (def.length || 50) + PAD * 2; }
+      else if (slot === 'horns') { w = (def.size || 18) * 3 + PAD * 2; h = (def.size || 18) * 2 + PAD * 2; }
+      else if (slot === 'wings') { w = (def.size || 40) * 3 + PAD * 2; h = (def.size || 40) + PAD * 2; }
+      else if (slot.startsWith('limb')) { w = (def.length || 30) + PAD * 2; h = (def.length || 30) + PAD * 2; }
+      else { w = 80; h = 80; }
+      return { w: Math.ceil(w), h: Math.ceil(h) };
+    }
+
+    _drawPart(ctx, slot, def, palette, w, h) {
+      const cx = w / 2, cy = h / 2;
+      ctx.translate(cx, cy);
+
+      if (slot === 'body') {
+        const pathFn = shapes.blob(def);
+        ctx.fillStyle = palette.body || '#888';
+        pathFn(ctx); ctx.fill();
+        comicfx.inkOutline(ctx, pathFn, 4, '#1a1a1a', def.seed);
+      } else if (slot === 'head') {
+        const pathFn = shapes.egg(def);
+        ctx.fillStyle = palette.head || palette.body || '#888';
+        pathFn(ctx); ctx.fill();
+        comicfx.inkOutline(ctx, pathFn, 3, '#1a1a1a', def.seed);
+      } else if (slot === 'eyes') {
+        this._drawEyes(ctx, def, palette);
+      } else if (slot === 'mouth') {
+        const pathFn = shapes.fangGrin(def);
+        ctx.fillStyle = palette.mouth || '#1a1a1a';
+        pathFn(ctx); ctx.fill();
+        comicfx.inkOutline(ctx, pathFn, 2, '#1a1a1a', def.seed);
+      } else if (slot === 'tail') {
+        const pathFn = shapes.tail(def);
+        ctx.fillStyle = palette.body || '#888';
+        pathFn(ctx); ctx.fill();
+        comicfx.inkOutline(ctx, pathFn, 3, '#1a1a1a', def.seed);
+      } else if (slot === 'horns') {
+        const pathFn = shapes.hornsPair(def);
+        ctx.fillStyle = palette.horns || '#c8a040';
+        pathFn(ctx); ctx.fill();
+        comicfx.inkOutline(ctx, pathFn, 3, '#1a1a1a', def.seed);
+      } else if (slot === 'wings') {
+        const pathFn = shapes.wingsPair(def);
+        ctx.globalAlpha = 0.85;
+        ctx.fillStyle = palette.wings || '#444';
+        pathFn(ctx); ctx.fill();
+        ctx.globalAlpha = 1;
+        comicfx.inkOutline(ctx, pathFn, 2, '#1a1a1a', def.seed);
+      } else if (slot.startsWith('limb')) {
+        const kindFn = def.kind === 'bony_arm' ? shapes.bonyArm : shapes.stubArm;
+        const pathFn = kindFn(def);
+        ctx.fillStyle = palette.limbs || palette.body || '#888';
+        pathFn(ctx); ctx.fill();
+        comicfx.inkOutline(ctx, pathFn, 3, '#1a1a1a', def.seed);
+      }
+    }
+
+    _drawEyes(ctx, def, palette) {
+      const size = def.size || 12;
+      const expr = def.expr || 'neutral';
+      const gap = size * 0.75;
+      const r = size * 0.55;
+      const cfg = EXPR_CONFIG[expr] || EXPR_CONFIG.neutral;
+
+      for (const side of [-1, 1]) {
+        const ex = side * gap;
+        // Sclera
+        ctx.beginPath();
+        ctx.arc(ex, 0, r, 0, Math.PI * 2);
+        ctx.fillStyle = palette.eyes || '#fff';
+        ctx.fill();
+        ctx.lineWidth = 2;
+        ctx.strokeStyle = '#1a1a1a';
+        ctx.stroke();
+
+        if (expr === 'dead') {
+          // X pupils for dead expression
+          ctx.strokeStyle = '#1a1a1a';
+          ctx.lineWidth = 2;
+          const s = r * 0.55;
+          ctx.beginPath();
+          ctx.moveTo(ex - s, -s); ctx.lineTo(ex + s, s);
+          ctx.moveTo(ex + s, -s); ctx.lineTo(ex - s, s);
+          ctx.stroke();
+        } else {
+          // Round pupil
+          const pr = r * cfg.pupilFrac;
+          ctx.beginPath();
+          ctx.arc(ex, 0, pr, 0, Math.PI * 2);
+          ctx.fillStyle = palette.pupils || '#1a1a1a';
+          ctx.fill();
+        }
+
+        // Eyebrow for angry/happy
+        if (cfg.browTilt !== 0) {
+          const bx = ex, by = -r * 1.15;
+          const bw = r * 0.9;
+          ctx.save();
+          ctx.translate(bx, by);
+          ctx.rotate(side * cfg.browTilt);
+          ctx.fillStyle = palette.pupils || '#1a1a1a';
+          ctx.fillRect(-bw / 2, -3, bw, 4);
+          ctx.restore();
+        }
+      }
+    }
+
+    // Composite all cached parts onto ctx with animation transforms.
+    drawCreature(ctx, x, y, compiled, animState, now) {
+      if (!compiled) return;
+      const { parts, bbox } = compiled;
+
+      ctx.save();
+
+      // Death fade
+      if (animState && animState.deathFade < 1) {
+        ctx.globalAlpha = Math.max(0, animState.deathFade);
+      }
+
+      // Screen shake for hit — uses caller's RAF now so it matches animState timing
+      if (animState && now !== undefined && animState.shakeUntilMs > now) {
+        const shake = comicfx.screenShake(now, 4, animState.shakeUntilMs);
+        ctx.translate(shake.dx, shake.dy);
+      }
+
+      // Attack lunge: translate the whole creature toward the player
+      if (animState && animState.attackProgress > 0) {
+        const lunge = Math.sin(animState.attackProgress * Math.PI) * 14;
+        ctx.translate(-lunge, 0);
+      }
+
+      // Draw all parts in Z_ORDER
+      for (const slot of Z_ORDER) {
+        if (slot === 'limbs') {
+          if (!parts.limbs) continue;
+          for (const lp of parts.limbs) {
+            this._drawPartCanvas(ctx, x, y, lp, animState, slot);
+          }
+        } else {
+          if (!parts[slot]) continue;
+          this._drawPartCanvas(ctx, x, y, parts[slot], animState, slot);
+        }
+      }
+
+      // Hit flash overlay on top of all parts
+      if (animState && animState.hitFlash > 0) {
+        ctx.save();
+        if (bbox) {
+          ctx.globalAlpha = animState.hitFlash * 0.7;
+          ctx.fillStyle = '#ffffff';
+          ctx.fillRect(x + bbox.x, y + bbox.y, bbox.w, bbox.h);
+        }
+        ctx.restore();
+      }
+
+      ctx.restore();
+    }
+
+    _drawPartCanvas(ctx, anchorX, anchorY, part, animState, slot) {
+      const { canvas, cx, cy } = part;
+      const hw = canvas.width / 2;
+      const hh = canvas.height / 2;
+
+      ctx.save();
+
+      // Idle breath scale on body and head
+      if (animState && (slot === 'body' || slot === 'head')) {
+        const s = 1 + animState.idleBreath;
+        ctx.translate(anchorX + cx, anchorY + cy);
+        ctx.scale(s, s);
+        ctx.drawImage(canvas, -hw, -hh);
+      } else {
+        ctx.drawImage(canvas, anchorX + cx - hw, anchorY + cy - hh);
+      }
+
+      ctx.restore();
+    }
+
+    _computeBbox(monster) {
+      const shape = monster.shape;
+      const rx = (shape.body && shape.body.rx) || 40;
+      const ry = (shape.body && shape.body.ry) || 40;
+      const headRy = (shape.head && shape.head.ry) || 30;
+      const headOy = (monster.layout && monster.layout.head) ? monster.layout.head.oy : -ry - headRy;
+      return {
+        x: -(rx + PAD),
+        y: headOy - headRy - PAD,
+        w: (rx + PAD) * 2,
+        h: ry * 2 + Math.abs(headOy) + headRy + PAD * 2,
+      };
+    }
+
+    invalidatePart(creatureId, slot) {
+      this._cache.invalidate(creatureId + ':' + slot);
+    }
+  }
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { MonsterRenderer };
+  } else {
+    global.MonsterRenderer = MonsterRenderer;
+  }
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/claudes-math-marauder/js/fx/particles.js
+++ b/claudes-math-marauder/js/fx/particles.js
@@ -1,0 +1,83 @@
+(function(global) {
+  'use strict';
+
+  const GRAVITY = 220; // px/s²
+
+  class ParticlePool {
+    constructor(size) {
+      size = size === undefined ? 128 : size;
+      this._size = size;
+      this._pool = [];
+      this._next = 0; // round-robin eviction index
+      for (let i = 0; i < size; i++) {
+        this._pool.push({ live: false, kind: 'sparkle', x: 0, y: 0, vx: 0, vy: 0, life: 0, maxLife: 1, color: '#fff' });
+      }
+    }
+
+    // Claim a slot (round-robin on full pool — oldest particle evicted).
+    spawn(kind, x, y, vx, vy, ttl, color) {
+      let slot = -1;
+      for (let i = 0; i < this._size; i++) {
+        if (!this._pool[i].live) { slot = i; break; }
+      }
+      if (slot === -1) {
+        slot = this._next;
+        this._next = (this._next + 1) % this._size;
+      }
+      const p = this._pool[slot];
+      p.live = true; p.kind = kind;
+      p.x = x; p.y = y; p.vx = vx; p.vy = vy;
+      p.life = ttl; p.maxLife = ttl; p.color = color;
+    }
+
+    // Advance all live particles. No allocations.
+    update(dt) {
+      const dtSec = dt / 1000;
+      for (let i = 0; i < this._size; i++) {
+        const p = this._pool[i];
+        if (!p.live) continue;
+        p.x += p.vx * dtSec;
+        p.y += p.vy * dtSec;
+        p.vy += GRAVITY * dtSec;
+        p.life -= dt;
+        if (p.life <= 0) p.live = false;
+      }
+    }
+
+    // Draw all live particles — batched globalAlpha, no save/restore per particle.
+    draw(ctx) {
+      // Draw each kind in a group to minimize state changes.
+      this._drawKind(ctx, 'sparkle');
+      this._drawKind(ctx, 'ember');
+      this._drawKind(ctx, 'inkdot');
+      ctx.globalAlpha = 1;
+    }
+
+    _drawKind(ctx, kind) {
+      for (let i = 0; i < this._size; i++) {
+        const p = this._pool[i];
+        if (!p.live || p.kind !== kind) continue;
+        ctx.globalAlpha = Math.max(0, p.life / p.maxLife);
+        ctx.fillStyle = p.color;
+        if (kind === 'sparkle') {
+          const s = 3;
+          ctx.fillRect(p.x - s / 2, p.y - s / 2, s, s);
+        } else if (kind === 'ember') {
+          ctx.beginPath();
+          ctx.arc(p.x, p.y, 3, 0, Math.PI * 2);
+          ctx.fill();
+        } else {
+          ctx.beginPath();
+          ctx.arc(p.x, p.y, 2, 0, Math.PI * 2);
+          ctx.fill();
+        }
+      }
+    }
+  }
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { ParticlePool };
+  } else {
+    global.ParticlePool = ParticlePool;
+  }
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/claudes-math-marauder/js/fx/shapes.js
+++ b/claudes-math-marauder/js/fx/shapes.js
@@ -1,0 +1,254 @@
+(function(global) {
+  'use strict';
+
+  // All shape generators return a pathFn(ctx) that defines a closed path centered at origin.
+  // Callers fill/stroke the path; shapes never call fill() or stroke() internally.
+  // Wobble uses seeded PRNG so identical seeds produce identical paths.
+
+  function _rng(seed) {
+    return mulberry32(hashString(String(seed)));
+  }
+
+  // Irregular oval with seeded wobble on each radial sample.
+  function blob({ rx, ry, wobble, seed }) {
+    rx = rx || 40; ry = ry || 40; wobble = wobble || 0; seed = seed || 0;
+    const n = 20;
+    const rng = _rng('blob:' + seed);
+    const pts = [];
+    for (let i = 0; i < n; i++) {
+      const angle = (i / n) * Math.PI * 2;
+      const jitter = 1 + (rng() - 0.5) * wobble * 0.04;
+      pts.push({ x: Math.cos(angle) * rx * jitter, y: Math.sin(angle) * ry * jitter });
+    }
+    return function(ctx) {
+      ctx.beginPath();
+      ctx.moveTo(pts[0].x, pts[0].y);
+      for (let i = 1; i < pts.length; i++) ctx.lineTo(pts[i].x, pts[i].y);
+      ctx.closePath();
+    };
+  }
+
+  // Egg/pear shape: narrower at top, wider at bottom. tilt in radians.
+  function egg({ rx, ry, scale, tilt, seed }) {
+    rx = rx || 25; ry = ry || 32; scale = scale || 1; tilt = tilt || 0; seed = seed || 0;
+    const n = 24;
+    const rng = _rng('egg:' + seed);
+    const cosT = Math.cos(tilt), sinT = Math.sin(tilt);
+    const pts = [];
+    for (let i = 0; i < n; i++) {
+      const angle = (i / n) * Math.PI * 2;
+      const widthFactor = 1 + 0.28 * Math.cos(angle + Math.PI); // narrower top
+      const jitter = 1 + (rng() - 0.5) * 0.06;
+      const lx = Math.cos(angle) * rx * scale * widthFactor * jitter;
+      const ly = Math.sin(angle) * ry * scale * jitter;
+      pts.push({ x: lx * cosT - ly * sinT, y: lx * sinT + ly * cosT });
+    }
+    return function(ctx) {
+      ctx.beginPath();
+      ctx.moveTo(pts[0].x, pts[0].y);
+      for (let i = 1; i < pts.length; i++) ctx.lineTo(pts[i].x, pts[i].y);
+      ctx.closePath();
+    };
+  }
+
+  // Two white sclera circles. Pupils/expression drawn by the caller (monsterRenderer).
+  function comicEyesPair({ size, expr, seed }) {
+    size = size || 12; seed = seed || 0;
+    const gap = size * 0.75;
+    const r = size * 0.55;
+    return function(ctx) {
+      // Left sclera
+      ctx.beginPath();
+      ctx.moveTo(-gap + r, 0);
+      ctx.arc(-gap, 0, r, 0, Math.PI * 2);
+      // Right sclera
+      ctx.moveTo(gap + r, 0);
+      ctx.arc(gap, 0, r, 0, Math.PI * 2);
+      ctx.closePath();
+    };
+  }
+
+  // Toothy comic grin with two visible fangs.
+  function fangGrin({ width, height, seed }) {
+    width = width || 20; height = height || 12; seed = seed || 0;
+    const hw = width / 2, hh = height / 2;
+    return function(ctx) {
+      ctx.beginPath();
+      ctx.moveTo(-hw, -hh);
+      ctx.lineTo(hw, -hh);
+      ctx.lineTo(hw, hh * 0.3);
+      // Right fang
+      ctx.lineTo(hw * 0.5, hh * 0.3);
+      ctx.lineTo(hw * 0.35, hh);
+      ctx.lineTo(hw * 0.2, hh * 0.3);
+      // Middle gap
+      ctx.lineTo(-hw * 0.2, hh * 0.3);
+      // Left fang
+      ctx.lineTo(-hw * 0.35, hh);
+      ctx.lineTo(-hw * 0.5, hh * 0.3);
+      ctx.lineTo(-hw, hh * 0.3);
+      ctx.closePath();
+    };
+  }
+
+  // Short rounded arm stump. side: 'left' (-1) or 'right' (1).
+  function stubArm({ length, width, side, seed }) {
+    length = length || 25; width = width || 8; side = side || 'right'; seed = seed || 0;
+    const dir = side === 'left' ? -1 : 1;
+    const rng = _rng('stub:' + seed);
+    const angle = dir * (Math.PI * 0.45 + (rng() - 0.5) * 0.2);
+    const cosA = Math.cos(angle), sinA = Math.sin(angle);
+    const hw = width / 2;
+    return function(ctx) {
+      ctx.beginPath();
+      ctx.moveTo(-hw * sinA, hw * cosA);
+      ctx.lineTo(-hw * sinA + cosA * length, hw * cosA + sinA * length);
+      ctx.arc(cosA * length, sinA * length, hw, angle - Math.PI / 2 + Math.PI, angle + Math.PI / 2 + Math.PI);
+      ctx.lineTo(hw * sinA, -hw * cosA);
+      ctx.closePath();
+    };
+  }
+
+  // Segmented arm with visible elbow joint.
+  function bonyArm({ length, width, side, seed }) {
+    length = length || 30; width = width || 7; side = side || 'right'; seed = seed || 0;
+    const dir = side === 'left' ? -1 : 1;
+    const rng = _rng('bony:' + seed);
+    const upperAngle = dir * (Math.PI * 0.38 + (rng() - 0.5) * 0.15);
+    const lowerAngle = dir * (Math.PI * 0.65 + (rng() - 0.5) * 0.2);
+    const half = length / 2;
+    const jx = Math.cos(upperAngle) * half;
+    const jy = Math.sin(upperAngle) * half;
+    const ex = jx + Math.cos(lowerAngle) * half;
+    const ey = jy + Math.sin(lowerAngle) * half;
+    const hw = width / 2;
+    return function(ctx) {
+      ctx.beginPath();
+      ctx.moveTo(-hw, 0);
+      ctx.lineTo(jx - hw, jy);
+      ctx.lineTo(ex - hw, ey);
+      ctx.lineTo(ex + hw, ey);
+      ctx.lineTo(jx + hw, jy);
+      ctx.lineTo(hw, 0);
+      ctx.closePath();
+    };
+  }
+
+  // S-curve tail with seeded segments.
+  function tail({ length, segments, seed }) {
+    length = length || 50; segments = segments || 6; seed = seed || 0;
+    const rng = _rng('tail:' + seed);
+    const pts = [{ x: 0, y: 0 }];
+    let angle = Math.PI * 0.15;
+    const segLen = length / segments;
+    for (let i = 0; i < segments; i++) {
+      angle += (rng() - 0.5) * 0.6 - 0.05 * i;
+      pts.push({
+        x: pts[pts.length - 1].x + Math.cos(angle) * segLen,
+        y: pts[pts.length - 1].y + Math.sin(angle) * segLen,
+      });
+    }
+    const tipR = 4;
+    return function(ctx) {
+      ctx.beginPath();
+      ctx.moveTo(pts[0].x, pts[0].y);
+      for (let i = 1; i < pts.length; i++) ctx.lineTo(pts[i].x, pts[i].y);
+      const last = pts[pts.length - 1];
+      ctx.arc(last.x, last.y, tipR, 0, Math.PI * 2);
+      ctx.closePath();
+    };
+  }
+
+  // Pair of horns. kind: 'ram' | 'demon' | 'antler'
+  function hornsPair({ size, kind, seed }) {
+    size = size || 18; kind = kind || 'demon'; seed = seed || 0;
+    const rng = _rng('horns:' + kind + ':' + seed);
+    const gap = size * 0.7;
+    // Pre-compute jitter so pathFn is pure (called twice: once for fill, once for stroke).
+    const leftJitter  = (rng() - 0.5) * 4;
+    const rightJitter = (rng() - 0.5) * 4;
+
+    function _hornPath(ctx, side) {
+      const d = side === 'left' ? -1 : 1;
+      const jitter = side === 'left' ? leftJitter : rightJitter;
+      if (kind === 'ram') {
+        // moveTo arc start so we don't accidentally connect from previous subpath
+        const startAngle = side === 'left' ? Math.PI * 0.5 : 0;
+        const endAngle   = side === 'left' ? Math.PI * 1.5 : Math.PI * 2;
+        const cx = d * gap, cy = -size * 0.5;
+        ctx.moveTo(cx + Math.cos(startAngle) * size * 0.6, cy + Math.sin(startAngle) * size * 0.6);
+        ctx.arc(cx, cy, size * 0.6, startAngle, endAngle);
+      } else if (kind === 'demon') {
+        ctx.moveTo(d * gap * 0.6, 0);
+        ctx.lineTo(d * gap * 0.9, -size * 0.5);
+        ctx.lineTo(d * gap * 1.1 + d * jitter, -size * 1.1);
+        ctx.lineTo(d * gap * 0.7, -size * 0.5);
+      } else { // antler
+        ctx.moveTo(d * gap * 0.6, 0);
+        ctx.lineTo(d * gap, -size * 0.7);
+        ctx.lineTo(d * gap * 1.2, -size * 0.4);
+        ctx.moveTo(d * gap, -size * 0.7);
+        ctx.lineTo(d * gap * 0.85, -size * 1.0);
+        ctx.lineTo(d * gap * 1.05, -size * 0.85);
+      }
+    }
+
+    // Both horns in one path (two subpaths). No intermediate beginPath() — that would
+    // discard the first horn before the caller can fill/stroke it.
+    return function(ctx) {
+      ctx.beginPath();
+      _hornPath(ctx, 'left');
+      ctx.closePath();
+      _hornPath(ctx, 'right'); // moveTo inside _hornPath starts a new subpath
+      ctx.closePath();
+    };
+  }
+
+  // Pair of wings. kind: 'bat' | 'feather' | 'mech'
+  function wingsPair({ size, kind, seed }) {
+    size = size || 40; kind = kind || 'bat'; seed = seed || 0;
+    const rng = _rng('wings:' + kind + ':' + seed);
+
+    function _wingPath(ctx, side) {
+      const d = side === 'left' ? -1 : 1;
+      const sx = d * 12, sy = 0;
+      if (kind === 'bat') {
+        ctx.moveTo(sx, sy);
+        ctx.bezierCurveTo(d * (12 + size * 0.5), -size * 0.5, d * (12 + size), -size * 0.3, d * (12 + size * 1.1), -size * 0.1);
+        ctx.bezierCurveTo(d * (12 + size * 0.9), -size * 0.1, d * (12 + size * 0.6), size * 0.4, sx, sy + size * 0.25);
+        ctx.closePath();
+      } else if (kind === 'feather') {
+        ctx.moveTo(sx, sy);
+        ctx.lineTo(d * (12 + size * 0.4), -size * 0.6);
+        ctx.lineTo(d * (12 + size * 0.8), -size * 0.35);
+        ctx.lineTo(d * (12 + size * 0.55), -size * 0.55);
+        ctx.lineTo(d * (12 + size * 0.85), -size * 0.15);
+        ctx.lineTo(sx + d * 4, sy + size * 0.2);
+        ctx.closePath();
+      } else { // mech
+        const w = size * 0.45;
+        ctx.moveTo(sx, sy);
+        ctx.lineTo(d * (12 + size * 0.3), -size * 0.7);
+        ctx.lineTo(d * (12 + size * 0.3 + w), -size * 0.7);
+        ctx.lineTo(d * (12 + w), sy);
+        ctx.closePath();
+      }
+    }
+
+    // Both wings in one path. No intermediate beginPath() — _wingPath starts each
+    // side with moveTo, which correctly opens a new subpath without discarding the first.
+    return function(ctx) {
+      ctx.beginPath();
+      _wingPath(ctx, 'left');
+      _wingPath(ctx, 'right');
+    };
+  }
+
+  const shapes = { blob, egg, comicEyesPair, fangGrin, stubArm, bonyArm, tail, hornsPair, wingsPair };
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = shapes;
+  } else {
+    global.shapes = shapes;
+  }
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/claudes-math-marauder/js/fx/wizardRenderer.js
+++ b/claudes-math-marauder/js/fx/wizardRenderer.js
@@ -1,0 +1,171 @@
+(function(global) {
+  'use strict';
+
+  // Fixed wizard portrait layout — always drawn as a 200×240 canvas.
+  const PORTRAIT_W = 200;
+  const PORTRAIT_H = 240;
+
+  // Class palette definitions.
+  const CLASS_PALETTES = {
+    apprentice: { robe: '#4a60a8', hat: '#2a3a78', face: '#f5c89a', staff: '#8b6020', gem: '#40d0f0' },
+    pyromancer: { robe: '#a84030', hat: '#702020', face: '#f5c89a', staff: '#8b6020', gem: '#f07020' },
+    stormcaller: { robe: '#6040a8', hat: '#402870', face: '#f5c89a', staff: '#506080', gem: '#80d0ff' },
+    necromancer: { robe: '#304020', hat: '#202810', face: '#c8c0a0', staff: '#303030', gem: '#80ff80' },
+  };
+
+  class WizardRenderer {
+    constructor(fxCache) {
+      this._cache = fxCache;
+    }
+
+    // Build (or retrieve from cache) the wizard portrait for a given classId.
+    // Returns a compiled object with a single canvas.
+    buildPortrait(classId) {
+      const cacheKey = 'wizard:' + classId;
+      let canvas = this._cache.get(cacheKey);
+      if (!canvas) {
+        canvas = this._cache.build(cacheKey, PORTRAIT_W, PORTRAIT_H, (ctx) => {
+          this._drawPortrait(ctx, classId, PORTRAIT_W, PORTRAIT_H);
+        });
+      }
+      return { canvas, classId };
+    }
+
+    // Draw the wizard portrait onto ctx at (x, y), applying animState transforms.
+    // animState comes from AnimationManager.stateFor().
+    drawPortrait(ctx, x, y, compiled, animState, now) {
+      if (!compiled) return;
+      const { canvas } = compiled;
+
+      ctx.save();
+
+      // Hit flash: portrait shakes and flashes white
+      if (animState && animState.hitFlash > 0) {
+        if (animState.shakeUntilMs > now) {
+          const shake = comicfx.screenShake(now, 5, animState.shakeUntilMs);
+          ctx.translate(shake.dx, shake.dy);
+        }
+        ctx.drawImage(canvas, x, y);
+        ctx.save();
+        ctx.globalAlpha = animState.hitFlash * 0.6;
+        ctx.fillStyle = '#ff4444';
+        ctx.fillRect(x, y, PORTRAIT_W, PORTRAIT_H);
+        ctx.restore();
+      } else {
+        // Idle breath: gentle vertical bob
+        const breathY = animState ? Math.sin((now / 1400) * Math.PI * 2) * 2 : 0;
+        ctx.translate(0, breathY);
+        ctx.drawImage(canvas, x, y);
+      }
+
+      // Ultimate charge: sparkle aura
+      if (animState && animState.chargeGlow > 0) {
+        ctx.save();
+        ctx.globalAlpha = animState.chargeGlow * 0.5;
+        ctx.strokeStyle = '#f0d840';
+        ctx.lineWidth = 3 + animState.chargeGlow * 4;
+        ctx.shadowColor = '#f0d840';
+        ctx.shadowBlur = 12;
+        ctx.strokeRect(x + 4, y + 4, PORTRAIT_W - 8, PORTRAIT_H - 8);
+        ctx.restore();
+      }
+
+      ctx.restore();
+    }
+
+    _drawPortrait(ctx, classId, w, h) {
+      const pal = CLASS_PALETTES[classId] || CLASS_PALETTES.apprentice;
+      const cx = w / 2;
+
+      // Robe body
+      ctx.fillStyle = pal.robe;
+      ctx.beginPath();
+      ctx.moveTo(cx - 55, h);
+      ctx.lineTo(cx - 40, h * 0.42);
+      ctx.lineTo(cx + 40, h * 0.42);
+      ctx.lineTo(cx + 55, h);
+      ctx.closePath();
+      ctx.fill();
+      comicfx.inkOutline(ctx, function(c) {
+        c.beginPath();
+        c.moveTo(cx - 55, h); c.lineTo(cx - 40, h * 0.42);
+        c.lineTo(cx + 40, h * 0.42); c.lineTo(cx + 55, h); c.closePath();
+      }, 3, '#1a1a1a', 0);
+
+      // Staff
+      ctx.save();
+      ctx.strokeStyle = pal.staff;
+      ctx.lineWidth = 5;
+      ctx.lineCap = 'round';
+      ctx.beginPath();
+      ctx.moveTo(cx + 42, h * 0.85);
+      ctx.lineTo(cx + 30, h * 0.15);
+      ctx.stroke();
+      // Staff gem
+      ctx.fillStyle = pal.gem;
+      ctx.beginPath();
+      ctx.arc(cx + 27, h * 0.13, 8, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.lineWidth = 2;
+      ctx.strokeStyle = '#1a1a1a';
+      ctx.stroke();
+      ctx.restore();
+
+      // Face
+      ctx.fillStyle = pal.face;
+      ctx.beginPath();
+      ctx.ellipse(cx, h * 0.32, 26, 30, 0, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.lineWidth = 2.5;
+      ctx.strokeStyle = '#1a1a1a';
+      ctx.stroke();
+
+      // Eyes
+      for (const side of [-1, 1]) {
+        const ex = cx + side * 10, ey = h * 0.29;
+        ctx.fillStyle = '#fff';
+        ctx.beginPath(); ctx.ellipse(ex, ey, 6, 7, 0, 0, Math.PI * 2); ctx.fill();
+        ctx.lineWidth = 1.5; ctx.strokeStyle = '#1a1a1a'; ctx.stroke();
+        ctx.fillStyle = '#2a1a0a';
+        ctx.beginPath(); ctx.arc(ex, ey, 3.5, 0, Math.PI * 2); ctx.fill();
+      }
+
+      // Mouth — slight smile
+      ctx.strokeStyle = '#1a1a1a';
+      ctx.lineWidth = 2;
+      ctx.beginPath();
+      ctx.arc(cx, h * 0.38, 10, 0.15, Math.PI - 0.15);
+      ctx.stroke();
+
+      // Pointed hat
+      ctx.fillStyle = pal.hat;
+      ctx.beginPath();
+      ctx.moveTo(cx, h * 0.02);
+      ctx.lineTo(cx - 34, h * 0.18);
+      ctx.lineTo(cx + 34, h * 0.18);
+      ctx.closePath();
+      ctx.fill();
+      // Hat brim
+      ctx.fillStyle = pal.robe;
+      ctx.beginPath();
+      ctx.ellipse(cx, h * 0.18, 38, 8, 0, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.lineWidth = 2.5; ctx.strokeStyle = '#1a1a1a'; ctx.stroke();
+      // Re-outline hat
+      comicfx.inkOutline(ctx, function(c) {
+        c.beginPath();
+        c.moveTo(cx, h * 0.02); c.lineTo(cx - 34, h * 0.18); c.lineTo(cx + 34, h * 0.18); c.closePath();
+      }, 2.5, '#1a1a1a', 0);
+    }
+
+    invalidate(classId) {
+      this._cache.invalidate('wizard:' + classId);
+    }
+  }
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { WizardRenderer };
+  } else {
+    global.WizardRenderer = WizardRenderer;
+  }
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/claudes-math-marauder/js/game.js
+++ b/claudes-math-marauder/js/game.js
@@ -8,8 +8,81 @@ const STATE = {
   FIGHT: 'FIGHT',
   RESULTS: 'RESULTS',
   PAUSED: 'PAUSED',
+  DEMO: 'DEMO',
 };
 
+// ── Demo monster data ──────────────────────────────────────────────────────────
+const DEMO_MONSTERS = [
+  {
+    id: 'goblin',
+    label: 'Goblin',
+    palette: { body: '#5a8a44', head: '#6a9a54', limbs: '#4a7a34', eyes: '#fff', pupils: '#1a1a1a', mouth: '#1a1a1a', horns: '#c8a040' },
+    shape: {
+      body:  { kind: 'blob',       rx: 36, ry: 42, wobble: 6,  seed: 11 },
+      head:  { kind: 'egg',        rx: 22, ry: 28, tilt: 0.08, seed: 12 },
+      eyes:  { kind: 'comic_pair', size: 11, expr: 'angry',    seed: 13 },
+      mouth: { kind: 'fang_grin',  width: 20, height: 12,      seed: 14 },
+      limbs: [
+        { kind: 'stub_arm', length: 26, width: 8, side: 'left',  seed: 15 },
+        { kind: 'stub_arm', length: 26, width: 8, side: 'right', seed: 16 },
+      ],
+    },
+    layout: {
+      body:  { ox: 0,   oy: 0   },
+      head:  { ox: 0,   oy: -56 },
+      eyes:  { ox: 0,   oy: -60 },
+      mouth: { ox: 0,   oy: -44 },
+      limb0: { ox: -48, oy: -8  },
+      limb1: { ox:  48, oy: -8  },
+    },
+  },
+  {
+    id: 'dragon',
+    label: 'Dragon',
+    palette: { body: '#8b3030', head: '#a03838', limbs: '#6b2020', eyes: '#ffe040', pupils: '#1a1a1a', horns: '#d0b040', wings: '#6a2020' },
+    shape: {
+      body:  { kind: 'blob',       rx: 52, ry: 58, wobble: 8,  seed: 21 },
+      head:  { kind: 'egg',        rx: 30, ry: 36, tilt: -0.1, seed: 22 },
+      eyes:  { kind: 'comic_pair', size: 14, expr: 'angry',    seed: 23 },
+      horns: { kind: 'demon',      size: 22,                   seed: 24 },
+      wings: { kind: 'bat',        size: 55,                   seed: 25 },
+      tail:  { kind: 'tail',       length: 60, segments: 7,    seed: 26 },
+    },
+    layout: {
+      body:  { ox: 0,   oy:  10  },
+      head:  { ox: 0,   oy: -62  },
+      eyes:  { ox: 0,   oy: -68  },
+      horns: { ox: 0,   oy: -82  },
+      wings: { ox: 0,   oy: -10  },
+      tail:  { ox: 50,  oy:  30  },
+    },
+  },
+  {
+    id: 'lich',
+    label: 'Lich',
+    palette: { body: '#303030', head: '#282828', limbs: '#383838', eyes: '#80ff80', pupils: '#1a1a1a', mouth: '#1a1a1a' },
+    shape: {
+      body:  { kind: 'blob',       rx: 30, ry: 52, wobble: 4,  seed: 31 },
+      head:  { kind: 'egg',        rx: 26, ry: 30, tilt: 0,    seed: 32 },
+      eyes:  { kind: 'comic_pair', size: 10, expr: 'dead',     seed: 33 },
+      mouth: { kind: 'fang_grin',  width: 16, height: 10,      seed: 34 },
+      limbs: [
+        { kind: 'bony_arm', length: 32, width: 6, side: 'left',  seed: 35 },
+        { kind: 'bony_arm', length: 32, width: 6, side: 'right', seed: 36 },
+      ],
+    },
+    layout: {
+      body:  { ox: 0,   oy: 10  },
+      head:  { ox: 0,   oy: -60 },
+      eyes:  { ox: 0,   oy: -64 },
+      mouth: { ox: 0,   oy: -50 },
+      limb0: { ox: -42, oy: -5  },
+      limb1: { ox:  42, oy: -5  },
+    },
+  },
+];
+
+// ── Game ──────────────────────────────────────────────────────────────────────
 class Game {
   constructor() {
     this.state = STATE.TITLE;
@@ -19,6 +92,21 @@ class Game {
     this._rafId = 0;
     this._prevState = null;
     this._save = null;
+
+    // FX system — initialised in init()
+    this._fxCache = null;
+    this._animManager = null;
+    this._particles = null;
+    this._monsterRenderer = null;
+    this._wizardRenderer = null;
+
+    // Demo-mode state
+    this._demo = null;
+
+    // FPS tracking
+    this._fpsFrames = 0;
+    this._fpsLast = 0;
+    this._fpsEl = null;
   }
 
   init() {
@@ -38,9 +126,24 @@ class Game {
     if (data.settings.reducedMotion || window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
       document.body.setAttribute('data-reduced-motion', 'true');
     }
-    // Apply font scale
     if (data.settings.fontScale && data.settings.fontScale !== 1.0) {
       document.documentElement.style.fontSize = Math.round(20 * data.settings.fontScale) + 'px';
+    }
+
+    // Initialise FX system
+    this._fxCache = new FxCache(30);
+    this._animManager = new AnimationManager();
+    this._particles = new ParticlePool(128);
+    this._monsterRenderer = new MonsterRenderer(this._fxCache);
+    this._wizardRenderer = new WizardRenderer(this._fxCache);
+
+    // FPS counter
+    this._fpsEl = document.getElementById('fps-counter');
+
+    // Boot into demo mode if ?demo=1
+    if (new URLSearchParams(window.location.search).get('demo') === '1') {
+      this._initDemo();
+      this.setState(STATE.DEMO);
     }
   }
 
@@ -54,30 +157,50 @@ class Game {
     this.ctx.setTransform(1, 0, 0, 1, 0, 0);
     this.ctx.scale(dpr, dpr);
     this.ctx.imageSmoothingEnabled = false;
+    // Invalidate all cached canvases when DPR changes — they were drawn for the old scale.
+    if (this._fxCache) this._fxCache._map.clear();
+    if (this._demo) this._demo.compiled = null; // will rebuild on next frame
   }
 
+  // ── RAF loop ─────────────────────────────────────────────────────────────────
   _loop(now) {
     if (!this._lastFrameTime) this._lastFrameTime = now;
     let dt = now - this._lastFrameTime;
     if (dt > 50) dt = 50;
     this._lastFrameTime = now;
 
-    if (this.state !== STATE.PAUSED) this._update(dt);
-    this._draw();
+    // FPS counter — update DOM 1× per second
+    this._fpsFrames++;
+    if (now - this._fpsLast >= 1000) {
+      if (this._fpsEl) this._fpsEl.textContent = this._fpsFrames + ' fps';
+      this._fpsFrames = 0;
+      this._fpsLast = now;
+    }
+
+    if (this.state !== STATE.PAUSED) this._update(dt, now);
+    this._draw(now);
     this._rafId = requestAnimationFrame(this._loop);
   }
 
-  _update(dt) {
-    // Future sessions drive managers here
+  _update(dt, now) {
+    if (this._animManager) this._animManager.update(dt, now);
+    if (this._particles) this._particles.update(dt);
   }
 
-  _draw() {
+  _draw(now) {
     const w = this.canvas.clientWidth;
     const h = this.canvas.clientHeight;
     this.ctx.fillStyle = '#F5F0E8';
     this.ctx.fillRect(0, 0, w, h);
+
+    if (this.state === STATE.DEMO) {
+      this._drawDemo(now, w, h);
+    }
+
+    if (this._particles) this._particles.draw(this.ctx);
   }
 
+  // ── State machine ─────────────────────────────────────────────────────────────
   setState(next) {
     if (this.state === next) return;
     this._prevState = this.state;
@@ -96,6 +219,7 @@ class Game {
     }
   }
 
+  // ── Title / Pause bindings ────────────────────────────────────────────────────
   _bindTitleScreen() {
     const btn = document.getElementById('start-button');
     if (btn) btn.addEventListener('click', () => this.setState(STATE.HUB));
@@ -112,6 +236,252 @@ class Game {
 
   pause() {
     if (this.state !== STATE.PAUSED) this.setState(STATE.PAUSED);
+  }
+
+  // ── Demo screen ───────────────────────────────────────────────────────────────
+  _initDemo() {
+    // Compile all three demo monsters.
+    const compiled = DEMO_MONSTERS.map(m => this._monsterRenderer.buildCreature(m));
+    // Wizard portrait.
+    const wizard = this._wizardRenderer.buildPortrait('apprentice');
+    // State for the panelFlash tile toggle.
+    let flashOn = false;
+    let shakeUntilMs = 0;
+
+    this._demo = {
+      compiled,
+      wizard,
+      flashOn,
+      shakeUntilMs,
+      monsters: DEMO_MONSTERS,
+    };
+
+    // Bind demo DOM buttons — set up ONCE, not in RAF.
+    this._bindDemoButtons();
+  }
+
+  _bindDemoButtons() {
+    // "Hit me" buttons for each monster.
+    DEMO_MONSTERS.forEach((m, i) => {
+      const btn = document.getElementById('demo-hit-' + i);
+      if (btn) btn.addEventListener('click', () => {
+        this._animManager.begin(m.id, {
+          kind: 'hit',
+          startedAt: performance.now(),
+          duration: 400,
+        });
+        // Spawn particles at monster position.
+        const pos = this._demoMonsterPos(i, this.canvas.clientWidth, this.canvas.clientHeight);
+        for (let p = 0; p < 12; p++) {
+          const rng = mulberry32((Date.now() * 31 + p * 17) | 0);
+          this._particles.spawn('sparkle', pos.x, pos.y - 30,
+            (rng() - 0.5) * 180, -60 - rng() * 120, 500 + rng() * 300, '#f0d840');
+        }
+      });
+    });
+
+    // Flash toggle.
+    const flashBtn = document.getElementById('demo-flash-toggle');
+    if (flashBtn) flashBtn.addEventListener('click', () => {
+      this._demo.flashOn = !this._demo.flashOn;
+      flashBtn.setAttribute('aria-pressed', this._demo.flashOn ? 'true' : 'false');
+    });
+
+    // Screen-shake toggle.
+    const shakeBtn = document.getElementById('demo-shake-toggle');
+    if (shakeBtn) shakeBtn.addEventListener('click', () => {
+      this._demo.shakeUntilMs = performance.now() + 400;
+    });
+  }
+
+  _demoMonsterPos(idx, w, h) {
+    const monsterAreaTop = h * 0.52;
+    const monsterAreaH = h - monsterAreaTop - 60;
+    const slotW = w / 3;
+    return {
+      x: slotW * idx + slotW / 2,
+      y: monsterAreaTop + monsterAreaH * 0.5,
+    };
+  }
+
+  _drawDemo(now, w, h) {
+    const ctx = this.ctx;
+    const demo = this._demo;
+    if (!demo) return;
+
+    // Rebuild compiled parts if cache was cleared (e.g. DPR change).
+    if (!demo.compiled || demo.compiled.some(c => !c)) {
+      demo.compiled = DEMO_MONSTERS.map(m => this._monsterRenderer.buildCreature(m));
+    }
+
+    // ── Primitives grid ─────────────────────────────────────────────────
+    const COLS = 5, ROWS = 2;
+    const GRID_TOP = 12;
+    const TILE_W = Math.floor(w / COLS);
+    const TILE_H = Math.floor((h * 0.46) / ROWS);
+
+    const primitives = [
+      { label: 'inkOutline', draw: (x, y, tw, th) => this._demoInkOutline(ctx, x, y, tw, th) },
+      { label: 'halftoneFill', draw: (x, y, tw, th) => this._demoHalftoneFill(ctx, x, y, tw, th) },
+      { label: 'speedLines', draw: (x, y, tw, th) => this._demoSpeedLines(ctx, x, y, tw, th) },
+      { label: 'burstText ZAP!', draw: (x, y, tw, th) => this._demoBurstText(ctx, x, y, tw, th) },
+      { label: 'inkBurst', draw: (x, y, tw, th) => this._demoInkBurst(ctx, x, y, tw, th) },
+      { label: 'panelFlash', draw: (x, y, tw, th) => this._demoPanelFlash(ctx, x, y, tw, th, now) },
+      { label: 'panelBorder', draw: (x, y, tw, th) => this._demoPanelBorder(ctx, x, y, tw, th) },
+      { label: 'screenShake', draw: (x, y, tw, th) => this._demoScreenShake(ctx, x, y, tw, th, now) },
+      { label: 'wizard', draw: (x, y, tw, th) => this._demoWizard(ctx, x, y, tw, th, now) },
+      { label: 'particles', draw: (x, y, tw, th) => this._demoParticlesTile(ctx, x, y, tw, th) },
+    ];
+
+    for (let i = 0; i < primitives.length; i++) {
+      const col = i % COLS, row = Math.floor(i / COLS);
+      const tx = col * TILE_W, ty = GRID_TOP + row * TILE_H;
+      const pad = 6;
+      ctx.save();
+      ctx.beginPath();
+      ctx.rect(tx + pad, ty + pad, TILE_W - pad * 2, TILE_H - pad * 2);
+      ctx.clip();
+      primitives[i].draw(tx, ty, TILE_W, TILE_H);
+      ctx.restore();
+      comicfx.panelBorder(ctx, tx + pad, ty + pad, TILE_W - pad * 2, TILE_H - pad * 2, 3);
+      // Tile label
+      ctx.fillStyle = '#595143';
+      ctx.font = '11px "OpenDyslexic", "Comic Sans MS", cursive';
+      ctx.textAlign = 'center';
+      ctx.fillText(primitives[i].label, tx + TILE_W / 2, ty + TILE_H - 8);
+    }
+
+    // ── Section divider ──────────────────────────────────────────────────
+    const divY = GRID_TOP + ROWS * TILE_H + 6;
+    ctx.strokeStyle = '#2C2416';
+    ctx.lineWidth = 2;
+    ctx.setLineDash([6, 4]);
+    ctx.beginPath();
+    ctx.moveTo(12, divY); ctx.lineTo(w - 12, divY);
+    ctx.stroke();
+    ctx.setLineDash([]);
+
+    // ── Three demo monsters ──────────────────────────────────────────────
+    const shake = comicfx.screenShake(now, 5, demo.shakeUntilMs);
+
+    for (let i = 0; i < 3; i++) {
+      const pos = this._demoMonsterPos(i, w, h);
+      const animState = this._animManager.stateFor(DEMO_MONSTERS[i].id, now);
+      ctx.save();
+      ctx.translate(shake.dx, shake.dy);
+      this._monsterRenderer.drawCreature(ctx, pos.x, pos.y, demo.compiled[i], animState, now);
+      ctx.restore();
+
+      // Monster label
+      ctx.fillStyle = '#2C2416';
+      ctx.font = 'bold 16px "OpenDyslexic", "Comic Sans MS", cursive';
+      ctx.textAlign = 'center';
+      ctx.fillText(DEMO_MONSTERS[i].label, pos.x, pos.y + 80);
+    }
+
+    // panelFlash — skip when reduced-motion is active (prefers-reduced-motion or manual toggle)
+    if (demo.flashOn && !document.body.hasAttribute('data-reduced-motion')) {
+      const alpha = 0.35 + 0.2 * Math.sin(now / 400);
+      comicfx.panelFlash(ctx, w, h, '#f0d840', alpha);
+    }
+  }
+
+  // ── Primitive tile drawers ────────────────────────────────────────────────────
+  _demoInkOutline(ctx, tx, ty, tw, th) {
+    const blobFn = shapes.blob({ rx: tw * 0.28, ry: th * 0.28, wobble: 8, seed: 99 });
+    ctx.save();
+    ctx.translate(tx + tw / 2, ty + th / 2 - 8);
+    ctx.fillStyle = '#4a60a8';
+    blobFn(ctx); ctx.fill();
+    comicfx.inkOutline(ctx, blobFn, 4, '#1a1a1a', 99);
+    ctx.restore();
+  }
+
+  _demoHalftoneFill(ctx, tx, ty, tw, th) {
+    const pad = 16;
+    comicfx.halftoneFill(ctx, tx + pad, ty + pad, tw - pad * 2, th - pad * 2 - 14, '#4a7a34', 0.055, 7);
+    ctx.strokeStyle = '#1a1a1a';
+    ctx.lineWidth = 2;
+    ctx.strokeRect(tx + pad, ty + pad, tw - pad * 2, th - pad * 2 - 14);
+  }
+
+  _demoSpeedLines(ctx, tx, ty, tw, th) {
+    const cx = tx + tw / 2, cy = ty + th * 0.45;
+    comicfx.speedLines(ctx, cx, cy, 0, 12, Math.min(tw, th) * 0.38, '#1a1a1a');
+    ctx.fillStyle = '#f0d840';
+    ctx.beginPath();
+    ctx.arc(cx, cy, 10, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.lineWidth = 2; ctx.strokeStyle = '#1a1a1a'; ctx.stroke();
+  }
+
+  _demoBurstText(ctx, tx, ty, tw, th) {
+    comicfx.burstText(ctx, tx + tw / 2, ty + th * 0.44, 'ZAP!', Math.min(tw, th) * 0.38, '#f0d840', '#1a1a1a', 5);
+  }
+
+  _demoInkBurst(ctx, tx, ty, tw, th) {
+    const cx = tx + tw / 2, cy = ty + th * 0.44;
+    comicfx.inkBurst(ctx, cx, cy, Math.min(tw, th) * 0.34, '#1a1a1a', 24, 42);
+    ctx.fillStyle = '#c93434';
+    ctx.beginPath();
+    ctx.arc(cx, cy, 7, 0, Math.PI * 2);
+    ctx.fill();
+  }
+
+  _demoPanelFlash(ctx, tx, ty, tw, th, now) {
+    const reducedMotion = document.body.hasAttribute('data-reduced-motion');
+    const alpha = reducedMotion ? 0.3 : (0.25 + 0.2 * Math.sin(now / 350));
+    // panelFlash fills from (0,0) by tw×th; translate so origin is tile top-left.
+    ctx.save();
+    ctx.translate(tx, ty);
+    comicfx.panelFlash(ctx, tw, th - 14, '#c93434', alpha);
+    ctx.restore();
+    ctx.fillStyle = '#2C2416';
+    ctx.font = '12px "OpenDyslexic", "Comic Sans MS", cursive';
+    ctx.textAlign = 'center';
+    ctx.fillText('pulsing', tx + tw / 2, ty + th * 0.44);
+  }
+
+  _demoPanelBorder(ctx, tx, ty, tw, th) {
+    const pad = 14;
+    comicfx.panelBorder(ctx, tx + pad, ty + pad, tw - pad * 2, th - pad * 2 - 14, 6, '#1a1a1a');
+    comicfx.panelBorder(ctx, tx + pad + 6, ty + pad + 6, tw - pad * 2 - 12, th - pad * 2 - 26, 2, '#595143');
+  }
+
+  _demoScreenShake(ctx, tx, ty, tw, th, now) {
+    const shaking = this._demo && this._demo.shakeUntilMs > now;
+    const { dx, dy } = comicfx.screenShake(now, 5, (this._demo && this._demo.shakeUntilMs) || 0);
+    ctx.save();
+    ctx.translate(tx + tw / 2 + dx, ty + th * 0.42 + dy);
+    const sqFn = function(c) {
+      c.beginPath(); c.rect(-20, -20, 40, 40);
+    };
+    ctx.fillStyle = shaking ? '#c93434' : '#2c5fb3';
+    sqFn(ctx); ctx.fill();
+    comicfx.inkOutline(ctx, sqFn, 3, '#1a1a1a', 0);
+    ctx.restore();
+  }
+
+  _demoWizard(ctx, tx, ty, tw, th, now) {
+    const demo = this._demo;
+    if (!demo || !demo.wizard) return;
+    const scale = Math.min(tw / 200, (th - 20) / 240) * 0.85;
+    const wx = tx + tw / 2 - (200 * scale) / 2;
+    const wy = ty + (th - 20) / 2 - (240 * scale) / 2;
+    ctx.save();
+    ctx.translate(wx + (200 * scale) / 2, wy + (240 * scale) / 2);
+    ctx.scale(scale, scale);
+    this._wizardRenderer.drawPortrait(ctx, -100, -120, demo.wizard,
+      this._animManager.stateFor('wizard', now), now);
+    ctx.restore();
+  }
+
+  _demoParticlesTile(ctx, tx, ty, tw, th) {
+    // Particles are drawn globally in _draw(); this tile just shows a label hint.
+    ctx.fillStyle = '#595143';
+    ctx.font = '12px "OpenDyslexic", "Comic Sans MS", cursive';
+    ctx.textAlign = 'center';
+    ctx.fillText('click monsters', tx + tw / 2, ty + th * 0.44);
   }
 }
 

--- a/claudes-math-marauder/js/save.js
+++ b/claudes-math-marauder/js/save.js
@@ -19,7 +19,7 @@
       totalCorrect: 0,
       gold: 0,
       ownedSpellIds: ['ember_bolt'],
-      equippedDeck: ['ember_bolt', null, null, null],
+      equippedDeck: ['ember_bolt', null, null, null, null],
       unlockedClassIds: ['apprentice'],
       selectedClassId: 'apprentice',
       realmStars: {


### PR DESCRIPTION
## Summary

- **Session 1** (already on main): project scaffold, SaveManager with migration, state machine shell, utility modules (rng, shuffle, escHtml, toast), Claude tooling (rules, checklist skill, data-validator skill, web-review agent, PostToolUse hook)
- **Session 2** (already on main): pure-logic combat layer — FactKeys, Leitner mastery engine, weighted problem selection with stretch-fact gate, distractor generation; 51 Node tests, zero failures
- **Session 3** (this PR): comic renderer + monster animation system
  - `fx/cache.js` — offscreen-canvas LRU manager (≤30 canvases)
  - `fx/comicfx.js` — inkOutline, halftoneFill, speedLines, burstText, panelFlash, inkBurst, panelBorder, screenShake; all seeded PRNG
  - `fx/shapes.js` — blob, egg, comicEyesPair, fangGrin, stubArm, bonyArm, tail, hornsPair, wingsPair
  - `fx/monsterRenderer.js` — per-part offscreen caching, Z_ORDER compositing, idle breath, hit flash, death fade, attack lunge
  - `fx/wizardRenderer.js` — class-palette portraits (apprentice, pyromancer, stormcaller, necromancer), hit flash, charge aura
  - `fx/animation.js` — analytical idle breath (no per-monster timers), one-shot hit/attack/death/charge
  - `fx/particles.js` — 128-slot pool, sparkle/ember/inkdot kinds, no heap allocs in update/draw
  - `game.js` — FX system init, `?demo=1` render-demo screen (5×2 primitive grid + 3 monsters + FPS counter), DPR-aware cache invalidation
- **Code-review fixes**: attack lunge moved to creature level (was dead code on slot name), `drawCreature` now receives RAF `now` instead of calling `performance.now()` internally, `equippedDeck` corrected to 5 slots per plan.md, demo button min-height raised to 44px (WCAG touch target), removed unused `_animTimers` Map

## Test plan

- [ ] `node claudes-math-marauder/scripts/test-save-migration.js` — 8 passed, 0 failed
- [ ] `node claudes-math-marauder/scripts/test-fact-keys.js` — 8 passed, 0 failed
- [ ] `node claudes-math-marauder/scripts/test-mastery.js` — 20 passed, 0 failed
- [ ] `node claudes-math-marauder/scripts/test-problem-gen.js` — 15 passed, 0 failed
- [ ] `node claudes-math-marauder/scripts/test-distractors.js` — 8 passed, 0 failed
- [ ] Open `claudes-math-marauder/index.html?demo=1` in Safari — confirm 3 monsters animate at ≥57fps, all 10 primitive tiles render, "Hit" buttons trigger flash + shake + particles
- [ ] Enable `prefers-reduced-motion` in Safari — confirm shake and flash are suppressed
- [ ] Click "Begin" on title screen — confirm transition to HUB (empty placeholder) with no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)