### PR TITLE
Claude's Math Marauder: sessions 3–6 (FX, data, combat, ultimate)

### DIFF
--- a/claudes-math-marauder/css/style.css
+++ b/claudes-math-marauder/css/style.css
@@ -281,6 +281,65 @@ button.danger {
   z-index: 60;
 }
 
+/* ===== Ultimate overlay ===== */
+#ultimate-panel {
+  border-width: 6px;
+  max-width: min(520px, 92vw);
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
+}
+
+#ultimate-problem {
+  font-size: 128px;
+  font-weight: 900;
+  font-family: var(--font-stack);
+  color: var(--text);
+  line-height: 1;
+  letter-spacing: 2px;
+}
+
+#ultimate-sigil {
+  font-size: 96px;
+  font-weight: 900;
+  font-family: var(--font-stack);
+  line-height: 1;
+  min-height: 120px;
+  padding: 16px 32px;
+  border: 4px dashed var(--accent-comic-yellow);
+  border-radius: 12px;
+  background: rgba(240, 216, 64, 0.1);
+  text-shadow: 0 0 12px rgba(240, 216, 64, 0.6);
+  width: 100%;
+  color: var(--text);
+}
+
+.numpad {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-template-rows: repeat(4, 1fr);
+  gap: 12px;
+  width: 100%;
+}
+
+.numpad button {
+  min-width: 72px;
+  min-height: 72px;
+  font-size: 32px;
+  padding: 8px;
+}
+
+.numpad-commit {
+  background: var(--accent-comic-yellow);
+  font-weight: 900;
+}
+
+.numpad-back {
+  background: var(--bg);
+}
+
 /* ===== Demo screen ===== */
 #demo-screen.active {
   display: block;

--- a/claudes-math-marauder/css/style.css
+++ b/claudes-math-marauder/css/style.css
@@ -316,6 +316,20 @@ button.danger {
   color: var(--text);
 }
 
+#ultimate-sigil.committed-correct {
+  border-style: solid;
+  border-color: #4a9a2a;
+  background: rgba(74, 154, 42, 0.18);
+  text-shadow: 0 0 14px rgba(74, 154, 42, 0.7);
+}
+
+#ultimate-sigil.committed-wrong {
+  border-style: solid;
+  border-color: var(--accent-comic-red);
+  background: rgba(201, 52, 52, 0.18);
+  text-shadow: 0 0 14px rgba(201, 52, 52, 0.7);
+}
+
 .numpad {
   display: grid;
   grid-template-columns: repeat(3, 1fr);

--- a/claudes-math-marauder/index.html
+++ b/claudes-math-marauder/index.html
@@ -78,7 +78,8 @@
   <script src="js/fx/particles.js" defer></script>
   <script src="js/fx/monsterRenderer.js" defer></script>
   <script src="js/fx/wizardRenderer.js" defer></script>
-  <!-- Combat + UI (Session 5) -->
+  <!-- Combat + UI (Sessions 5–6) -->
+  <script src="js/combat/ultimate.js" defer></script>
   <script src="js/combat/fight.js" defer></script>
   <script src="js/combat/orbs.js" defer></script>
   <script src="js/ui/hud.js" defer></script>

--- a/claudes-math-marauder/js/combat/fight.js
+++ b/claudes-math-marauder/js/combat/fight.js
@@ -56,6 +56,11 @@ class FightManager {
     this._monsterX = 0;
     this._monsterY = 0;
 
+    // Ultimate helper — created lazily in start() so hud/anim refs are ready.
+    this._ultimate = null;
+    // When set, the next correct orb-cast answer deals half damage (ultimate-miss penalty).
+    this._halfDamageOnNext = false;
+
     this.onComplete = onComplete || null;
     this._lessonComplete = false;
   }
@@ -66,8 +71,9 @@ class FightManager {
     this._orbsRenderer = orbsRenderer;
   }
 
-  start(monster) {
+  start(monster, opts) {
     this.cancel();
+    opts = opts || {};
     this._lessonComplete = false;
     this._monster = monster;
     this._monsterKO = false;
@@ -77,7 +83,8 @@ class FightManager {
     this._streak = 0;
     this._score = 0;
     this._retries = 0;
-    this._ultimateCharge = 0;
+    this._ultimateCharge = opts.startCharged ? 1.0 : 0;
+    this._halfDamageOnNext = false;
     this._recentKeys = [];
     this._burstTexts = [];
     this._problemsAnsweredThisFight = 0;
@@ -85,10 +92,19 @@ class FightManager {
     this._wizardFlavorHp = 60;
     this.state = 'INTRO';
 
+    // Create Ultimate helper once per FightManager lifecycle.
+    if (!this._ultimate) {
+      this._ultimate = new Ultimate({
+        audio: this._audio,
+        hud: this._hud,
+        anim: this._anim,
+      });
+    }
+
     this._hud.show();
     this._hud.setStreak(0);
     this._hud.setScore(0);
-    this._hud.setUltimateCharge(0);
+    this._hud.setUltimateCharge(this._ultimateCharge);
     this._hud.setWizardHp(60);
 
     this._introTimer = setTimeout(() => this._enterProblem(), 1100);
@@ -101,6 +117,7 @@ class FightManager {
     clearTimeout(this._introTimer);        this._introTimer = null;
     clearTimeout(this._resolveTimer);      this._resolveTimer = null;
     clearTimeout(this._wrongRevealTimer);  this._wrongRevealTimer = null;
+    if (this._ultimate) this._ultimate.cancel();
     if (this._anim) this._anim.cancelAll();
     if (this._hud) this._hud.hide();
     this.onComplete = null;
@@ -229,6 +246,14 @@ class FightManager {
       return;
     }
 
+    // Ultimate gate: if meter is full, launch the typed-numpad overlay.
+    if (this._ultimateCharge >= 1.0 && this._ultimate) {
+      this._ultimate.onResolve = (result) => this._resolveUltimate(result);
+      this._ultimate.start(this._currentProblem);
+      this.state = 'ULTIMATE_ANSWERING';
+      return;
+    }
+
     this._currentOrbs = this._distractors.generateDistractors(this._currentProblem, this._rng);
     this._answerStartedAt = performance.now();
     this.state = 'ANSWERING';
@@ -256,7 +281,9 @@ class FightManager {
       this._correctThisFight++;
       const speedBonus = Math.max(0, (5000 - timeMs) / 50);
       const streakMult = 1 + (this._streak * 0.05);
-      const dmg = Math.round((100 + speedBonus) * streakMult);
+      const halfDamage = this._halfDamageOnNext;
+      this._halfDamageOnNext = false;
+      const dmg = Math.round((100 + speedBonus) * streakMult * (halfDamage ? 0.5 : 1));
       this._score += dmg;
       this._streak++;
       this._monsterHpRemaining -= 1;
@@ -284,6 +311,51 @@ class FightManager {
         if (this._wizardFlavorHp <= 0) this._defeatRetry();
         else this._enterProblem();
       }, 1200);
+    }
+  }
+
+  _resolveUltimate({ correct, value, timeMs, escaped }) {
+    this.state = 'RESOLVE';
+    this._problemsAnsweredThisFight++;
+
+    if (!this._currentProblem.isStretch) {
+      this._mastery.recordResolve(this._masteryMap, this._currentProblem.factKey, {
+        correct,
+        timeMs,
+        now: Date.now(),
+        masteredAvgMs: this._mastery.masteredAvgMs(this._masteryMap),
+      });
+    }
+
+    this._recentKeys.push(this._currentProblem.factKey);
+    if (this._recentKeys.length > 5) this._recentKeys.shift();
+
+    this._ultimateCharge = 0;
+    this._hud.setUltimateCharge(0);
+
+    if (correct) {
+      this._correctThisFight++;
+      this._streak++;
+      this._monsterHpRemaining = Math.max(0, this._monsterHpRemaining - 3);
+      this._score += 500;
+      this._hud.setStreak(this._streak);
+      this._hud.setScore(this._score);
+      this._anim.begin(this._monster.id, { kind: 'hit', startedAt: performance.now(), duration: 600 });
+      this._playAudio('ko');
+      this._burst(this._monsterX, this._monsterY - 60, 'ULTIMATE!');
+      this._resolveTimer = setTimeout(() => {
+        if (this._monsterHpRemaining <= 0) this._victory();
+        else this._enterProblem();
+      }, 800);
+    } else {
+      this._streak = 0;
+      this._hud.setStreak(0);
+      this._halfDamageOnNext = true;
+      if (!escaped) {
+        this._narrate('The answer was ' + this._currentProblem.answer + '.');
+        this._hud.flashCorrect(this._currentProblem.answer);
+      }
+      this._resolveTimer = setTimeout(() => this._enterProblem(), 1200);
     }
   }
 

--- a/claudes-math-marauder/js/combat/fight.js
+++ b/claudes-math-marauder/js/combat/fight.js
@@ -248,9 +248,9 @@ class FightManager {
 
     // Ultimate gate: if meter is full, launch the typed-numpad overlay.
     if (this._ultimateCharge >= 1.0 && this._ultimate) {
+      this.state = 'ULTIMATE_ANSWERING';
       this._ultimate.onResolve = (result) => this._resolveUltimate(result);
       this._ultimate.start(this._currentProblem);
-      this.state = 'ULTIMATE_ANSWERING';
       return;
     }
 
@@ -315,6 +315,7 @@ class FightManager {
   }
 
   _resolveUltimate({ correct, value, timeMs, escaped }) {
+    if (this._lessonComplete) return;     // re-entry guard (CLAUDE.md)
     this.state = 'RESOLVE';
     this._problemsAnsweredThisFight++;
 

--- a/claudes-math-marauder/js/combat/ultimate.js
+++ b/claudes-math-marauder/js/combat/ultimate.js
@@ -15,6 +15,8 @@ class Ultimate {
     this._answerStartedAt = 0;
     this._maxDigits = 6;
     this.onResolve = null;
+    // Re-entry/input lock: true while the 400ms post-commit feedback timer runs.
+    this._committing = false;
 
     this._overlay = null;
     this._sigilEl = null;
@@ -30,9 +32,13 @@ class Ultimate {
     this.cancel();
     this._currentProblem = problem;
     this._buf = '';
+    this._committing = false;
     this._answerStartedAt = performance.now();
     this._build();
     if (this._probEl) this._probEl.textContent = problem.displayText;
+    if (this._sigilEl) {
+      this._sigilEl.classList.remove('committed-correct', 'committed-wrong');
+    }
     this._renderSigil();
     this._overlay.classList.add('open');
     this._overlay.setAttribute('aria-hidden', 'false');
@@ -46,11 +52,15 @@ class Ultimate {
       clearTimeout(this._timers._resolveTimer);
       this._timers._resolveTimer = null;
     }
+    this._committing = false;
     this._unbindPhysicalKeys();
     if (this._overlay) {
       const wasOpen = this._overlay.classList.contains('open');
       this._overlay.classList.remove('open');
       this._overlay.setAttribute('aria-hidden', 'true');
+      if (this._sigilEl) {
+        this._sigilEl.classList.remove('committed-correct', 'committed-wrong');
+      }
       // Return focus to body on close so touch-based orb selection works cleanly next round.
       if (wasOpen) document.body.focus();
     }
@@ -112,9 +122,9 @@ class Ultimate {
 
     this._focusables = [];
 
-    for (var ki = 0; ki < KEYS.length; ki++) {
-      var key = KEYS[ki];
-      var btn = document.createElement('button');
+    for (let ki = 0; ki < KEYS.length; ki++) {
+      const key = KEYS[ki];
+      const btn = document.createElement('button');
       btn.type = 'button';
       btn.textContent = key.label;
       btn.setAttribute('aria-label', key.ariaLabel);
@@ -131,9 +141,8 @@ class Ultimate {
         this._commitBtn = btn;
         btn.addEventListener('click', () => this._onCommit());
       } else {
-        (function(digit) {
-          btn.addEventListener('click', function() { this._onDigit(digit); }.bind(this));
-        }).call(this, key.digit);
+        const digit = key.digit;
+        btn.addEventListener('click', () => this._onDigit(digit));
       }
 
       numpad.appendChild(btn);
@@ -146,29 +155,39 @@ class Ultimate {
   }
 
   _onDigit(d) {
+    if (this._committing) return;
     if (this._buf.length >= this._maxDigits) return;
+    // Strip leading zeros: '0' + any digit replaces with that digit (no '07' display).
+    if (this._buf === '0') this._buf = '';
     this._buf += d;
     this._renderSigil();
   }
 
   _onBackspace() {
+    if (this._committing) return;
     this._buf = this._buf.slice(0, -1);
     this._renderSigil();
   }
 
   _onCommit() {
+    if (this._committing) return;
     if (this._buf.length === 0) return;
-    var value = parseInt(this._buf, 10);
-    var timeMs = performance.now() - this._answerStartedAt;
-    var correct = value === this._currentProblem.answer;
+    this._committing = true;
+
+    const value = parseInt(this._buf, 10);
+    const timeMs = performance.now() - this._answerStartedAt;
+    const correct = value === this._currentProblem.answer;
     if (this._audio) this._audio.play(correct ? 'ultimateFire' : 'wrong');
-    var cb = this.onResolve;      // save BEFORE cancel() nulls it (CLAUDE.md pattern)
-    this.cancel();
-    var resolvedValue = value;
-    var resolvedTimeMs = timeMs;
-    var resolvedCorrect = correct;
-    this._timers._resolveTimer = setTimeout(function() {
-      if (cb) cb({ correct: resolvedCorrect, value: resolvedValue, timeMs: resolvedTimeMs });
+
+    // Visual feedback ON the overlay during the 400ms close delay.
+    if (this._sigilEl) {
+      this._sigilEl.classList.add(correct ? 'committed-correct' : 'committed-wrong');
+    }
+
+    const cb = this.onResolve;   // save BEFORE cancel() nulls it (CLAUDE.md pattern)
+    this._timers._resolveTimer = setTimeout(() => {
+      this.cancel();
+      if (cb) cb({ correct, value, timeMs });
     }, 400);
   }
 
@@ -194,38 +213,40 @@ class Ultimate {
   }
 
   _bindPhysicalKeys() {
-    var self = this;
-    this._physicalKeyHandler = function(e) {
+    this._physicalKeyHandler = (e) => {
       // Guard: only handle when overlay is open (stale-handler safety, CLAUDE.md).
-      if (!self._overlay || !self._overlay.classList.contains('open')) return;
+      if (!this._overlay || !this._overlay.classList.contains('open')) return;
 
       if (e.key >= '0' && e.key <= '9') {
-        self._onDigit(e.key);
+        this._onDigit(e.key);
         e.preventDefault();
       } else if (e.key === 'Backspace') {
-        self._onBackspace();
+        this._onBackspace();
         e.preventDefault();
       } else if (e.key === 'Enter') {
-        self._onCommit();
+        this._onCommit();
         e.preventDefault();
       } else if (e.key === 'Escape') {
         // Escape guard: classList.contains check (CLAUDE.md focus-trap rule).
-        if (self._overlay.classList.contains('open')) {
-          var cb = self.onResolve;
-          var timeMs = performance.now() - self._answerStartedAt;
-          self.cancel();
+        // Also bail if a commit is mid-flight (avoid double-resolve).
+        if (this._committing) { e.preventDefault(); return; }
+        if (this._overlay.classList.contains('open')) {
+          const cb = this.onResolve;
+          const timeMs = performance.now() - this._answerStartedAt;
+          this.cancel();
           if (cb) cb({ correct: false, value: null, timeMs: timeMs, escaped: true });
         }
+        e.preventDefault();
       } else if (e.key === 'Tab') {
         // Focus trap: cycle Tab/Shift-Tab within the numpad buttons.
         e.preventDefault();
-        var focused = document.activeElement;
-        var idx = self._focusables.indexOf(focused);
+        const focused = document.activeElement;
+        const idx = this._focusables.indexOf(focused);
         if (e.shiftKey) {
-          var prev = (idx <= 0) ? self._focusables[self._focusables.length - 1] : self._focusables[idx - 1];
+          const prev = (idx <= 0) ? this._focusables[this._focusables.length - 1] : this._focusables[idx - 1];
           if (prev) prev.focus();
         } else {
-          var next = (idx >= self._focusables.length - 1) ? self._focusables[0] : self._focusables[idx + 1];
+          const next = (idx >= this._focusables.length - 1) ? this._focusables[0] : this._focusables[idx + 1];
           if (next) next.focus();
         }
       }

--- a/claudes-math-marauder/js/combat/ultimate.js
+++ b/claudes-math-marauder/js/combat/ultimate.js
@@ -1,0 +1,242 @@
+'use strict';
+
+// Ultimate — typed-numpad overlay for the ultimate spell.
+// DOM-based (not canvas), so it can be a dialog with full focus management.
+// Created once per FightManager lifecycle; shown/hidden via .open class.
+class Ultimate {
+  constructor({ audio, hud, anim }) {
+    this._audio = audio || null;
+    this._hud = hud;
+    this._anim = anim;
+
+    this._timers = { _resolveTimer: null };
+    this._buf = '';
+    this._currentProblem = null;
+    this._answerStartedAt = 0;
+    this._maxDigits = 6;
+    this.onResolve = null;
+
+    this._overlay = null;
+    this._sigilEl = null;
+    this._probEl = null;
+    this._physicalKeyHandler = null;
+    this._backBtn = null;
+    this._commitBtn = null;
+    // Ordered list for focus trap: ⌫ first (CLAUDE.md: first focusable = close analog), ✓ last.
+    this._focusables = [];
+  }
+
+  start(problem) {
+    this.cancel();
+    this._currentProblem = problem;
+    this._buf = '';
+    this._answerStartedAt = performance.now();
+    this._build();
+    if (this._probEl) this._probEl.textContent = problem.displayText;
+    this._renderSigil();
+    this._overlay.classList.add('open');
+    this._overlay.setAttribute('aria-hidden', 'false');
+    this._focusBackButton();
+    this._bindPhysicalKeys();
+    this._narrate('Speak the truth!');
+  }
+
+  cancel() {
+    if (this._timers._resolveTimer) {
+      clearTimeout(this._timers._resolveTimer);
+      this._timers._resolveTimer = null;
+    }
+    this._unbindPhysicalKeys();
+    if (this._overlay) {
+      const wasOpen = this._overlay.classList.contains('open');
+      this._overlay.classList.remove('open');
+      this._overlay.setAttribute('aria-hidden', 'true');
+      // Return focus to body on close so touch-based orb selection works cleanly next round.
+      if (wasOpen) document.body.focus();
+    }
+    this.onResolve = null;
+  }
+
+  // ── Private ────────────────────────────────────────────────────────────────
+
+  _build() {
+    if (this._overlay) return; // Build DOM once; reuse on subsequent starts.
+
+    this._overlay = document.createElement('div');
+    this._overlay.id = 'ultimate-overlay';
+    this._overlay.className = 'overlay';
+    this._overlay.setAttribute('role', 'dialog');
+    this._overlay.setAttribute('aria-modal', 'true');
+    this._overlay.setAttribute('aria-label', 'Ultimate spell');
+    this._overlay.setAttribute('aria-hidden', 'true');
+
+    const panel = document.createElement('div');
+    panel.className = 'panel';
+    panel.id = 'ultimate-panel';
+
+    // Problem text — large display
+    this._probEl = document.createElement('div');
+    this._probEl.id = 'ultimate-problem';
+    panel.appendChild(this._probEl);
+
+    // Sigil — echoes typed digits at 96px before commit.
+    // No aria-live (CLAUDE.md: no aria-live + aria-label on same element).
+    // Dynamic aria-label is updated in _renderSigil() alongside textContent.
+    this._sigilEl = document.createElement('div');
+    this._sigilEl.id = 'ultimate-sigil';
+    this._sigilEl.setAttribute('aria-label', 'No digits entered');
+    panel.appendChild(this._sigilEl);
+
+    // Numpad — 3×4 grid (role="group" per CLAUDE.md; not role="list")
+    const numpad = document.createElement('div');
+    numpad.className = 'numpad';
+    numpad.setAttribute('role', 'group');
+    numpad.setAttribute('aria-label', 'Number pad');
+
+    // DOM order: ⌫ first (focus-trap close analog per CLAUDE.md), then digits, ✓ last.
+    // CSS grid positions each button independently so visual layout is correct.
+    const KEYS = [
+      { label: '⌫', ariaLabel: 'backspace', digit: null, row: 4, col: 1, isBack:   true  },
+      { label: '7', ariaLabel: 'seven',     digit: '7',  row: 1, col: 1 },
+      { label: '8', ariaLabel: 'eight',     digit: '8',  row: 1, col: 2 },
+      { label: '9', ariaLabel: 'nine',      digit: '9',  row: 1, col: 3 },
+      { label: '4', ariaLabel: 'four',      digit: '4',  row: 2, col: 1 },
+      { label: '5', ariaLabel: 'five',      digit: '5',  row: 2, col: 2 },
+      { label: '6', ariaLabel: 'six',       digit: '6',  row: 2, col: 3 },
+      { label: '1', ariaLabel: 'one',       digit: '1',  row: 3, col: 1 },
+      { label: '2', ariaLabel: 'two',       digit: '2',  row: 3, col: 2 },
+      { label: '3', ariaLabel: 'three',     digit: '3',  row: 3, col: 3 },
+      { label: '0', ariaLabel: 'zero',      digit: '0',  row: 4, col: 2 },
+      { label: '✓', ariaLabel: 'commit',    digit: null, row: 4, col: 3, isCommit: true  },
+    ];
+
+    this._focusables = [];
+
+    for (var ki = 0; ki < KEYS.length; ki++) {
+      var key = KEYS[ki];
+      var btn = document.createElement('button');
+      btn.type = 'button';
+      btn.textContent = key.label;
+      btn.setAttribute('aria-label', key.ariaLabel);
+      // Grid position set inline — layout property, not visibility toggle (CLAUDE.md allows this).
+      btn.style.gridRow = key.row;
+      btn.style.gridColumn = key.col;
+
+      if (key.isBack) {
+        btn.classList.add('numpad-back');
+        this._backBtn = btn;
+        btn.addEventListener('click', () => this._onBackspace());
+      } else if (key.isCommit) {
+        btn.classList.add('numpad-commit');
+        this._commitBtn = btn;
+        btn.addEventListener('click', () => this._onCommit());
+      } else {
+        (function(digit) {
+          btn.addEventListener('click', function() { this._onDigit(digit); }.bind(this));
+        }).call(this, key.digit);
+      }
+
+      numpad.appendChild(btn);
+      this._focusables.push(btn);
+    }
+
+    panel.appendChild(numpad);
+    this._overlay.appendChild(panel);
+    document.getElementById('overlay-root').appendChild(this._overlay);
+  }
+
+  _onDigit(d) {
+    if (this._buf.length >= this._maxDigits) return;
+    this._buf += d;
+    this._renderSigil();
+  }
+
+  _onBackspace() {
+    this._buf = this._buf.slice(0, -1);
+    this._renderSigil();
+  }
+
+  _onCommit() {
+    if (this._buf.length === 0) return;
+    var value = parseInt(this._buf, 10);
+    var timeMs = performance.now() - this._answerStartedAt;
+    var correct = value === this._currentProblem.answer;
+    if (this._audio) this._audio.play(correct ? 'ultimateFire' : 'wrong');
+    var cb = this.onResolve;      // save BEFORE cancel() nulls it (CLAUDE.md pattern)
+    this.cancel();
+    var resolvedValue = value;
+    var resolvedTimeMs = timeMs;
+    var resolvedCorrect = correct;
+    this._timers._resolveTimer = setTimeout(function() {
+      if (cb) cb({ correct: resolvedCorrect, value: resolvedValue, timeMs: resolvedTimeMs });
+    }, 400);
+  }
+
+  _renderSigil() {
+    if (!this._sigilEl) return;
+    this._sigilEl.textContent = this._buf || ' '; // NBSP to maintain height when empty
+    // Dynamic aria-label updated alongside textContent (CLAUDE.md).
+    // No aria-live here (CLAUDE.md: no aria-live + aria-label on same element).
+    this._sigilEl.setAttribute('aria-label',
+      this._buf ? 'Entered ' + this._buf : 'No digits entered');
+  }
+
+  _focusBackButton() {
+    if (this._backBtn) this._backBtn.focus();
+  }
+
+  _narrate(text) {
+    if (!('speechSynthesis' in window)) return;
+    speechSynthesis.cancel();
+    setTimeout(function() {
+      speechSynthesis.speak(new SpeechSynthesisUtterance(text));
+    }, 50);
+  }
+
+  _bindPhysicalKeys() {
+    var self = this;
+    this._physicalKeyHandler = function(e) {
+      // Guard: only handle when overlay is open (stale-handler safety, CLAUDE.md).
+      if (!self._overlay || !self._overlay.classList.contains('open')) return;
+
+      if (e.key >= '0' && e.key <= '9') {
+        self._onDigit(e.key);
+        e.preventDefault();
+      } else if (e.key === 'Backspace') {
+        self._onBackspace();
+        e.preventDefault();
+      } else if (e.key === 'Enter') {
+        self._onCommit();
+        e.preventDefault();
+      } else if (e.key === 'Escape') {
+        // Escape guard: classList.contains check (CLAUDE.md focus-trap rule).
+        if (self._overlay.classList.contains('open')) {
+          var cb = self.onResolve;
+          var timeMs = performance.now() - self._answerStartedAt;
+          self.cancel();
+          if (cb) cb({ correct: false, value: null, timeMs: timeMs, escaped: true });
+        }
+      } else if (e.key === 'Tab') {
+        // Focus trap: cycle Tab/Shift-Tab within the numpad buttons.
+        e.preventDefault();
+        var focused = document.activeElement;
+        var idx = self._focusables.indexOf(focused);
+        if (e.shiftKey) {
+          var prev = (idx <= 0) ? self._focusables[self._focusables.length - 1] : self._focusables[idx - 1];
+          if (prev) prev.focus();
+        } else {
+          var next = (idx >= self._focusables.length - 1) ? self._focusables[0] : self._focusables[idx + 1];
+          if (next) next.focus();
+        }
+      }
+    };
+    window.addEventListener('keydown', this._physicalKeyHandler);
+  }
+
+  _unbindPhysicalKeys() {
+    if (this._physicalKeyHandler) {
+      window.removeEventListener('keydown', this._physicalKeyHandler);
+      this._physicalKeyHandler = null;
+    }
+  }
+}

--- a/claudes-math-marauder/js/game.js
+++ b/claudes-math-marauder/js/game.js
@@ -272,8 +272,9 @@ class Game {
 
   // ── Fight management ──────────────────────────────────────────────────────────
 
-  _startFight(monster, realm, masteryMap, allowStretch) {
+  _startFight(monster, realm, masteryMap, allowStretch, opts) {
     this._exitFight();
+    opts = opts || {};
 
     const rng = mulberry32((Date.now() ^ (monster.id.charCodeAt(0) * 31)) | 0);
 
@@ -298,7 +299,7 @@ class Game {
       allowStretch,
     });
     this._fightManager.setOrbsRenderer(this._orbsRenderer);
-    this._fightManager.start(monster);
+    this._fightManager.start(monster, opts);
     this.setState(STATE.FIGHT);
   }
 
@@ -351,7 +352,8 @@ class Game {
       }
       const data = SaveManager.load();
       const allowStretch = data.settings.allowStretchFacts !== false;
-      this._startFight(monster, realm, data.mastery, allowStretch);
+      const startCharged = params.get('ultimate') === '1';
+      this._startFight(monster, realm, data.mastery, allowStretch, { startCharged });
     } catch (err) {
       console.error('[Game] Debug fight load failed:', err);
     }


### PR DESCRIPTION
## Summary

Implements Sessions 3–6 of the Claude's Math Marauder plan:

- **Session 3** — Comic renderer + monster schema + procedural creature animation (`fx/`)
- **Session 4** — Realm/monster/boss/spell/class/story/events JSON for Realm 1
- **Session 5** — Orb-cast combat loop: FightManager state machine, OrbsRenderer, HUD overlay, retry-on-defeat
- **Session 6** — Typed ultimate spell: numpad (≥72px keys, focus-trapped dialog, physical-keyboard support), 96px digit-echo sigil, big-damage payoff, fail-down-to-orb half-damage path

Plus a self-review fix pass for Session 6 covering:
- Overlay flashes green/red during the 400ms commit-feedback window (sigil stays visible instead of blank-gap close)
- Input lock (\`_committing\` flag) blocks rapid double-resolve via digits / Enter / Escape
- Leading-zero strip on numpad ('0' + '7' → '7')
- \`_resolveUltimate\` re-entry guard symmetric with \`_victory\`
- Cleaner closures + arrow-function keydown handler

## Test plan

- [x] All 51 Layer-1 unit tests pass (\`scripts/test-fact-keys.js\`, \`test-mastery.js\`, \`test-problem-gen.js\`, \`test-distractors.js\`)
- [x] \`scripts/validate-data.js\` reports 0 critical issues
- [x] All session-5/6 JS files pass \`node --check\` syntax validation
- [x] No \`Math.random()\` in combat modules, no \`style.display\` in JS, no \`aria-live\` + \`aria-label\` collisions
- [ ] Manual playtest \`?fight=goblin_grunt\` — orb tap KO + retry on wrong
- [ ] Manual playtest \`?fight=goblin_grunt&ultimate=1\` — numpad opens immediately, ⌫/✓/Tab/Esc all work, physical keys work, focus trap stays inside numpad
- [ ] iPad Safari 60fps verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)