### PR TITLE
feat(marauder): sessions 7-8 — boss fight, hub screen, audio + settings

### DIFF
--- a/claudes-math-marauder/css/style.css
+++ b/claudes-math-marauder/css/style.css
@@ -423,6 +423,26 @@ button.danger {
   margin-bottom: 40px;
 }
 
+/* ===== Boss phase label ===== */
+#hud-boss-phase-label {
+  position: fixed;
+  top: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+  text-align: center;
+  font-size: 20px;
+  font-weight: 700;
+  font-family: var(--font-stack);
+  color: #F5F0E8;
+  background: rgba(26,10,10,0.72);
+  border: 3px solid #c93434;
+  border-radius: 8px;
+  padding: 6px 20px;
+  pointer-events: none;
+  z-index: 55;
+  letter-spacing: 0.04em;
+}
+
 /* ===== Reduced motion ===== */
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after {
@@ -430,4 +450,240 @@ button.danger {
     animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;
   }
+}
+body[data-reduced-motion] *, body[data-reduced-motion] *::before, body[data-reduced-motion] *::after {
+  animation-duration: 0.01ms !important;
+  animation-iteration-count: 1 !important;
+  transition-duration: 0.01ms !important;
+}
+
+/* ===== Settings gear button (title / hub) ===== */
+.settings-gear-btn {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  min-width: 44px;
+  min-height: 44px;
+  padding: 8px 12px;
+  font-size: 22px;
+  line-height: 1;
+  border-radius: 50%;
+}
+
+/* ===== Settings panel ===== */
+.settings-panel {
+  position: relative;
+  width: min(520px, 94vw);
+  max-height: 88vh;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.settings-close-btn {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  min-width: 44px;
+  min-height: 44px;
+  padding: 8px;
+  border-radius: 50%;
+  font-size: 20px;
+  line-height: 1;
+}
+
+.settings-heading {
+  margin: 0 0 4px;
+  padding-right: 48px;
+  font-size: 24px;
+}
+
+.settings-panel section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.settings-panel h3 {
+  margin: 0;
+  font-size: 18px;
+  color: var(--text-secondary);
+  border-bottom: 2px solid var(--accent-ink);
+  padding-bottom: 4px;
+}
+
+.settings-row {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.settings-row label {
+  font-size: 16px;
+  font-family: var(--font-stack);
+  color: var(--text);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.settings-check-row label {
+  flex-direction: row;
+  align-items: center;
+  gap: 10px;
+  min-height: 44px;
+  cursor: pointer;
+}
+
+.settings-check-row input[type="checkbox"] {
+  width: 22px;
+  height: 22px;
+  accent-color: var(--text);
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.settings-slider-val {
+  margin-left: 8px;
+  font-size: 16px;
+  color: var(--text-secondary);
+}
+
+.settings-row input[type="range"] {
+  width: 100%;
+  accent-color: var(--text);
+  height: 28px;
+}
+
+.settings-select {
+  width: 100%;
+  font-family: var(--font-stack);
+  font-size: 16px;
+  padding: 8px 12px;
+  border: 3px solid var(--accent-ink);
+  border-radius: 8px;
+  background: var(--bg);
+  color: var(--text);
+  min-height: 44px;
+}
+
+.settings-test-btn {
+  align-self: flex-start;
+}
+
+.settings-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding-top: 4px;
+}
+
+/* ===== Hub screen ===== */
+.hub-title {
+  font-size: clamp(28px, 5vw, 48px);
+  font-weight: 900;
+  letter-spacing: 2px;
+  text-align: center;
+  margin-bottom: 24px;
+}
+
+.hub-loading-text {
+  font-size: 20px;
+  color: var(--text-secondary);
+  text-align: center;
+}
+
+.hub-realm-section {
+  width: 100%;
+  max-width: 720px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+}
+
+.hub-realm-name {
+  font-size: 22px;
+  font-weight: 700;
+  letter-spacing: 1px;
+  text-align: center;
+  margin: 0;
+}
+
+.hub-intro {
+  font-size: 18px;
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+.hub-monster-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  justify-content: center;
+  width: 100%;
+}
+
+.hub-card {
+  background: var(--bg);
+  border: var(--panel-stroke) solid var(--accent-ink);
+  border-radius: 16px;
+  padding: 20px 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  min-width: 160px;
+  max-width: 200px;
+}
+
+.hub-boss-card {
+  border-color: var(--accent-comic-red);
+  position: relative;
+}
+
+.hub-boss-badge {
+  background: var(--accent-comic-red);
+  color: #fff;
+  font-size: 13px;
+  font-weight: 900;
+  letter-spacing: 2px;
+  padding: 2px 10px;
+  border-radius: 6px;
+}
+
+.hub-card-name {
+  font-size: 20px;
+  font-weight: 700;
+  margin: 0;
+  text-align: center;
+}
+
+.hub-card-tier {
+  font-size: 16px;
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+.hub-fight-btn {
+  width: 100%;
+  margin-top: 4px;
+}
+
+/* ===== Read-aloud button ===== */
+.read-aloud {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 44px;
+  min-height: 44px;
+  padding: 6px 10px;
+  font-size: 20px;
+  background: var(--bg);
+  border: 2px solid var(--accent-ink);
+  border-radius: 10px;
+  cursor: pointer;
+  margin-left: 8px;
+  vertical-align: middle;
 }

--- a/claudes-math-marauder/css/style.css
+++ b/claudes-math-marauder/css/style.css
@@ -580,6 +580,15 @@ body[data-reduced-motion] *, body[data-reduced-motion] *::before, body[data-redu
 }
 
 /* ===== Hub screen ===== */
+.hub-back-btn {
+  position: absolute;
+  top: 16px;
+  left: 16px;
+  min-height: 44px;
+  padding: 8px 16px;
+  font-size: 16px;
+}
+
 .hub-title {
   font-size: clamp(28px, 5vw, 48px);
   font-weight: 900;

--- a/claudes-math-marauder/index.html
+++ b/claudes-math-marauder/index.html
@@ -19,8 +19,9 @@
 
   <!-- TITLE screen -->
   <section id="title-screen" class="screen active" aria-label="Title screen">
+    <button id="title-settings-btn" class="secondary settings-gear-btn" aria-label="Open settings" aria-expanded="false">⚙️</button>
     <h1>Claude's Math Marauder</h1>
-    <p class="subtitle">A game by Claude</p>
+    <p class="subtitle" id="title-subtitle">A game by Claude</p>
     <button id="start-button" class="primary" aria-label="Begin game">Begin</button>
   </section>
 
@@ -83,7 +84,13 @@
   <script src="js/combat/fight.js" defer></script>
   <script src="js/combat/bossFight.js" defer></script>
   <script src="js/combat/orbs.js" defer></script>
+  <script src="js/combat/bossFight.js" defer></script>
   <script src="js/ui/hud.js" defer></script>
+  <script src="js/ui/hub.js" defer></script>
+  <!-- Audio + Settings (Session 8) -->
+  <script src="js/audio/sfx.js" defer></script>
+  <script src="js/audio/speech.js" defer></script>
+  <script src="js/ui/settings.js" defer></script>
   <!-- Game orchestration -->
   <script src="js/game.js" defer></script>
 </body>

--- a/claudes-math-marauder/js/audio/sfx.js
+++ b/claudes-math-marauder/js/audio/sfx.js
@@ -1,0 +1,447 @@
+(function(global) {
+  'use strict';
+
+  function _makeNoise(ctx, durationSec) {
+    const bufSize = Math.floor(ctx.sampleRate * durationSec);
+    const buf = ctx.createBuffer(1, bufSize, ctx.sampleRate);
+    const data = buf.getChannelData(0);
+    for (let i = 0; i < bufSize; i++) data[i] = Math.random() * 2 - 1;
+    return buf;
+  }
+
+  const SFX_RECIPES = {
+    orbHover(ctx, out) {
+      const filter = ctx.createBiquadFilter();
+      filter.type = 'lowpass';
+      filter.frequency.value = 1500;
+      filter.connect(out);
+      const osc = ctx.createOscillator();
+      const gain = ctx.createGain();
+      osc.type = 'sine';
+      osc.frequency.value = 600;
+      gain.gain.setValueAtTime(0, ctx.currentTime);
+      gain.gain.linearRampToValueAtTime(0.2, ctx.currentTime + 0.01);
+      gain.gain.linearRampToValueAtTime(0, ctx.currentTime + 0.08);
+      osc.connect(gain);
+      gain.connect(filter);
+      osc.start(ctx.currentTime);
+      osc.stop(ctx.currentTime + 0.09);
+    },
+
+    orbCorrect(ctx, out) {
+      const osc = ctx.createOscillator();
+      const gain = ctx.createGain();
+      osc.type = 'square';
+      osc.frequency.setValueAtTime(220, ctx.currentTime);
+      osc.frequency.linearRampToValueAtTime(880, ctx.currentTime + 0.12);
+      gain.gain.setValueAtTime(0.12, ctx.currentTime);
+      gain.gain.linearRampToValueAtTime(0, ctx.currentTime + 0.12);
+      osc.connect(gain);
+      gain.connect(out);
+      osc.start(ctx.currentTime);
+      osc.stop(ctx.currentTime + 0.13);
+    },
+
+    spellCast(ctx, out) {
+      const osc = ctx.createOscillator();
+      const oscGain = ctx.createGain();
+      osc.type = 'triangle';
+      osc.frequency.setValueAtTime(330, ctx.currentTime);
+      osc.frequency.linearRampToValueAtTime(660, ctx.currentTime + 0.1);
+      oscGain.gain.setValueAtTime(0.18, ctx.currentTime);
+      oscGain.gain.linearRampToValueAtTime(0, ctx.currentTime + 0.2);
+      osc.connect(oscGain);
+      oscGain.connect(out);
+      osc.start(ctx.currentTime);
+      osc.stop(ctx.currentTime + 0.21);
+      const src = ctx.createBufferSource();
+      const filter = ctx.createBiquadFilter();
+      const noiseGain = ctx.createGain();
+      src.buffer = _makeNoise(ctx, 0.2);
+      filter.type = 'bandpass';
+      filter.frequency.value = 1200;
+      filter.Q.value = 2;
+      noiseGain.gain.setValueAtTime(0.06, ctx.currentTime);
+      noiseGain.gain.linearRampToValueAtTime(0, ctx.currentTime + 0.2);
+      src.connect(filter);
+      filter.connect(noiseGain);
+      noiseGain.connect(out);
+      src.start(ctx.currentTime);
+    },
+
+    hit(ctx, out) {
+      const osc = ctx.createOscillator();
+      const oscGain = ctx.createGain();
+      osc.type = 'square';
+      osc.frequency.setValueAtTime(110, ctx.currentTime);
+      osc.frequency.linearRampToValueAtTime(55, ctx.currentTime + 0.15);
+      oscGain.gain.setValueAtTime(0.15, ctx.currentTime);
+      oscGain.gain.linearRampToValueAtTime(0, ctx.currentTime + 0.15);
+      osc.connect(oscGain);
+      oscGain.connect(out);
+      osc.start(ctx.currentTime);
+      osc.stop(ctx.currentTime + 0.16);
+      const src = ctx.createBufferSource();
+      const filter = ctx.createBiquadFilter();
+      const noiseGain = ctx.createGain();
+      src.buffer = _makeNoise(ctx, 0.1);
+      filter.type = 'lowpass';
+      filter.frequency.value = 300;
+      noiseGain.gain.setValueAtTime(0.12, ctx.currentTime);
+      noiseGain.gain.linearRampToValueAtTime(0, ctx.currentTime + 0.1);
+      src.connect(filter);
+      filter.connect(noiseGain);
+      noiseGain.connect(out);
+      src.start(ctx.currentTime);
+    },
+
+    critHit(ctx, out) {
+      SFX_RECIPES.hit(ctx, out);
+      [1760, 2093, 2637].forEach(function(freq, i) {
+        const osc = ctx.createOscillator();
+        const gain = ctx.createGain();
+        const t = ctx.currentTime + i * 0.06;
+        osc.type = 'sine';
+        osc.frequency.value = freq;
+        gain.gain.setValueAtTime(0.08, t);
+        gain.gain.exponentialRampToValueAtTime(0.001, t + 0.12);
+        osc.connect(gain);
+        gain.connect(out);
+        osc.start(t);
+        osc.stop(t + 0.13);
+      });
+    },
+
+    wrong(ctx, out) {
+      const osc = ctx.createOscillator();
+      const gain = ctx.createGain();
+      osc.type = 'triangle';
+      osc.frequency.value = 80;
+      gain.gain.setValueAtTime(0.1, ctx.currentTime);
+      gain.gain.linearRampToValueAtTime(0, ctx.currentTime + 0.2);
+      osc.connect(gain);
+      gain.connect(out);
+      osc.start(ctx.currentTime);
+      osc.stop(ctx.currentTime + 0.21);
+    },
+
+    streakChime3(ctx, out) {
+      [523, 659, 784].forEach(function(freq, i) {
+        const osc = ctx.createOscillator();
+        const gain = ctx.createGain();
+        const t = ctx.currentTime + i * 0.1;
+        osc.type = 'sine';
+        osc.frequency.value = freq;
+        gain.gain.setValueAtTime(0.15, t);
+        gain.gain.exponentialRampToValueAtTime(0.001, t + 0.2);
+        osc.connect(gain);
+        gain.connect(out);
+        osc.start(t);
+        osc.stop(t + 0.3);
+      });
+    },
+
+    streakChime5(ctx, out) {
+      [659, 784, 988, 1047, 1319].forEach(function(freq, i) {
+        const osc = ctx.createOscillator();
+        const gain = ctx.createGain();
+        const t = ctx.currentTime + i * 0.08;
+        osc.type = 'sine';
+        osc.frequency.value = freq;
+        gain.gain.setValueAtTime(0.14, t);
+        gain.gain.exponentialRampToValueAtTime(0.001, t + 0.2);
+        osc.connect(gain);
+        gain.connect(out);
+        osc.start(t);
+        osc.stop(t + 0.28);
+      });
+    },
+
+    streakChime10(ctx, out) {
+      [784, 988, 1047, 1319, 1568, 2093].forEach(function(freq, i) {
+        const osc = ctx.createOscillator();
+        const gain = ctx.createGain();
+        const t = ctx.currentTime + i * 0.07;
+        osc.type = 'sine';
+        osc.frequency.value = freq;
+        gain.gain.setValueAtTime(0.13, t);
+        gain.gain.exponentialRampToValueAtTime(0.001, t + 0.3);
+        osc.connect(gain);
+        gain.connect(out);
+        osc.start(t);
+        osc.stop(t + 0.4);
+      });
+      // Reverb tail
+      [784, 988, 1047].forEach(function(freq, i) {
+        const osc = ctx.createOscillator();
+        const gain = ctx.createGain();
+        const t = ctx.currentTime + 0.5 + i * 0.12;
+        osc.type = 'sine';
+        osc.frequency.value = freq;
+        gain.gain.setValueAtTime(0.05, t);
+        gain.gain.exponentialRampToValueAtTime(0.001, t + 0.4);
+        osc.connect(gain);
+        gain.connect(out);
+        osc.start(t);
+        osc.stop(t + 0.5);
+      });
+    },
+
+    ultimateChargeFull(ctx, out) {
+      const osc = ctx.createOscillator();
+      const gain = ctx.createGain();
+      osc.type = 'sine';
+      osc.frequency.setValueAtTime(220, ctx.currentTime);
+      osc.frequency.linearRampToValueAtTime(880, ctx.currentTime + 0.6);
+      gain.gain.setValueAtTime(0.18, ctx.currentTime);
+      gain.gain.linearRampToValueAtTime(0, ctx.currentTime + 0.6);
+      osc.connect(gain);
+      gain.connect(out);
+      osc.start(ctx.currentTime);
+      osc.stop(ctx.currentTime + 0.65);
+    },
+
+    ultimateFire(ctx, out) {
+      [[110, 440], [165, 660], [220, 880]].forEach(function(pair, i) {
+        const osc = ctx.createOscillator();
+        const gain = ctx.createGain();
+        const t = ctx.currentTime + i * 0.05;
+        osc.type = 'sawtooth';
+        osc.frequency.setValueAtTime(pair[0], t);
+        osc.frequency.linearRampToValueAtTime(pair[1], t + 0.35);
+        gain.gain.setValueAtTime(0.1, t);
+        gain.gain.linearRampToValueAtTime(0, t + 0.5);
+        osc.connect(gain);
+        gain.connect(out);
+        osc.start(t);
+        osc.stop(t + 0.55);
+      });
+      const src = ctx.createBufferSource();
+      const filter = ctx.createBiquadFilter();
+      const noiseGain = ctx.createGain();
+      src.buffer = _makeNoise(ctx, 0.3);
+      filter.type = 'highpass';
+      filter.frequency.value = 800;
+      noiseGain.gain.setValueAtTime(0.06, ctx.currentTime);
+      noiseGain.gain.linearRampToValueAtTime(0, ctx.currentTime + 0.3);
+      src.connect(filter);
+      filter.connect(noiseGain);
+      noiseGain.connect(out);
+      src.start(ctx.currentTime);
+    },
+
+    bossSpawn(ctx, out) {
+      const src = ctx.createBufferSource();
+      const filter = ctx.createBiquadFilter();
+      const noiseGain = ctx.createGain();
+      src.buffer = _makeNoise(ctx, 0.5);
+      filter.type = 'lowpass';
+      filter.frequency.value = 180;
+      noiseGain.gain.setValueAtTime(0.15, ctx.currentTime);
+      noiseGain.gain.linearRampToValueAtTime(0, ctx.currentTime + 0.5);
+      src.connect(filter);
+      filter.connect(noiseGain);
+      noiseGain.connect(out);
+      src.start(ctx.currentTime);
+      [110, 165].forEach(function(freq) {
+        const osc = ctx.createOscillator();
+        const gain = ctx.createGain();
+        osc.type = 'sawtooth';
+        osc.frequency.value = freq;
+        gain.gain.setValueAtTime(0.12, ctx.currentTime);
+        gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + 0.5);
+        osc.connect(gain);
+        gain.connect(out);
+        osc.start(ctx.currentTime);
+        osc.stop(ctx.currentTime + 0.55);
+      });
+    },
+
+    ko(ctx, out) {
+      [523, 659, 784, 1047].forEach(function(freq, i) {
+        const osc = ctx.createOscillator();
+        const gain = ctx.createGain();
+        const t = ctx.currentTime + i * 0.12;
+        osc.type = 'sine';
+        osc.frequency.value = freq;
+        gain.gain.setValueAtTime(0.16, t);
+        gain.gain.exponentialRampToValueAtTime(0.001, t + 0.25);
+        osc.connect(gain);
+        gain.connect(out);
+        osc.start(t);
+        osc.stop(t + 0.35);
+      });
+    },
+
+    bossKo(ctx, out) {
+      SFX_RECIPES.ko(ctx, out);
+      [1047, 1319, 1568].forEach(function(freq, i) {
+        const osc = ctx.createOscillator();
+        const gain = ctx.createGain();
+        const t = ctx.currentTime + 0.5 + i * 0.14;
+        osc.type = 'sine';
+        osc.frequency.value = freq;
+        gain.gain.setValueAtTime(0.14, t);
+        gain.gain.exponentialRampToValueAtTime(0.001, t + 0.3);
+        osc.connect(gain);
+        gain.connect(out);
+        osc.start(t);
+        osc.stop(t + 0.4);
+      });
+      const boom = ctx.createOscillator();
+      const boomGain = ctx.createGain();
+      boom.type = 'sine';
+      boom.frequency.setValueAtTime(80, ctx.currentTime + 0.5);
+      boom.frequency.linearRampToValueAtTime(30, ctx.currentTime + 1.0);
+      boomGain.gain.setValueAtTime(0.2, ctx.currentTime + 0.5);
+      boomGain.gain.linearRampToValueAtTime(0, ctx.currentTime + 1.0);
+      boom.connect(boomGain);
+      boomGain.connect(out);
+      boom.start(ctx.currentTime + 0.5);
+      boom.stop(ctx.currentTime + 1.05);
+    },
+
+    pageFlip(ctx, out) {
+      const src = ctx.createBufferSource();
+      const filter = ctx.createBiquadFilter();
+      const gain = ctx.createGain();
+      src.buffer = _makeNoise(ctx, 0.08);
+      filter.type = 'bandpass';
+      filter.frequency.value = 3000;
+      filter.Q.value = 0.5;
+      gain.gain.setValueAtTime(0, ctx.currentTime);
+      gain.gain.linearRampToValueAtTime(0.12, ctx.currentTime + 0.02);
+      gain.gain.linearRampToValueAtTime(0, ctx.currentTime + 0.08);
+      src.connect(filter);
+      filter.connect(gain);
+      gain.connect(out);
+      src.start(ctx.currentTime);
+    },
+
+    uiTap(ctx, out) {
+      const osc = ctx.createOscillator();
+      const gain = ctx.createGain();
+      osc.type = 'triangle';
+      osc.frequency.value = 1200;
+      gain.gain.setValueAtTime(0, ctx.currentTime);
+      gain.gain.linearRampToValueAtTime(0.12, ctx.currentTime + 0.005);
+      gain.gain.linearRampToValueAtTime(0, ctx.currentTime + 0.04);
+      osc.connect(gain);
+      gain.connect(out);
+      osc.start(ctx.currentTime);
+      osc.stop(ctx.currentTime + 0.05);
+    },
+
+    phaseBreak(ctx, out) {
+      const src = ctx.createBufferSource();
+      const filter = ctx.createBiquadFilter();
+      const noiseGain = ctx.createGain();
+      src.buffer = _makeNoise(ctx, 0.05);
+      filter.type = 'highpass';
+      filter.frequency.value = 2000;
+      noiseGain.gain.setValueAtTime(0.18, ctx.currentTime);
+      noiseGain.gain.linearRampToValueAtTime(0, ctx.currentTime + 0.05);
+      src.connect(filter);
+      filter.connect(noiseGain);
+      noiseGain.connect(out);
+      src.start(ctx.currentTime);
+      [1319, 1568, 2093].forEach(function(freq, i) {
+        const osc = ctx.createOscillator();
+        const gain = ctx.createGain();
+        const t = ctx.currentTime + 0.04 + i * 0.05;
+        osc.type = 'sine';
+        osc.frequency.value = freq;
+        gain.gain.setValueAtTime(0.1, t);
+        gain.gain.exponentialRampToValueAtTime(0.001, t + 0.12);
+        osc.connect(gain);
+        gain.connect(out);
+        osc.start(t);
+        osc.stop(t + 0.15);
+      });
+    },
+
+    monsterSpawn(ctx, out) {
+      const osc = ctx.createOscillator();
+      const gain = ctx.createGain();
+      osc.type = 'triangle';
+      osc.frequency.setValueAtTime(80, ctx.currentTime);
+      osc.frequency.linearRampToValueAtTime(120, ctx.currentTime + 0.08);
+      gain.gain.setValueAtTime(0.12, ctx.currentTime);
+      gain.gain.linearRampToValueAtTime(0, ctx.currentTime + 0.1);
+      osc.connect(gain);
+      gain.connect(out);
+      osc.start(ctx.currentTime);
+      osc.stop(ctx.currentTime + 0.1);
+      const osc2 = ctx.createOscillator();
+      const gain2 = ctx.createGain();
+      osc2.type = 'sine';
+      osc2.frequency.setValueAtTime(600, ctx.currentTime + 0.1);
+      osc2.frequency.linearRampToValueAtTime(900, ctx.currentTime + 0.22);
+      gain2.gain.setValueAtTime(0.08, ctx.currentTime + 0.1);
+      gain2.gain.linearRampToValueAtTime(0, ctx.currentTime + 0.24);
+      osc2.connect(gain2);
+      gain2.connect(out);
+      osc2.start(ctx.currentTime + 0.1);
+      osc2.stop(ctx.currentTime + 0.25);
+    },
+
+    goblinGrunt(ctx, out) {
+      const osc = ctx.createOscillator();
+      const gain = ctx.createGain();
+      osc.type = 'sine';
+      osc.frequency.setValueAtTime(500, ctx.currentTime);
+      osc.frequency.linearRampToValueAtTime(700, ctx.currentTime + 0.08);
+      osc.frequency.linearRampToValueAtTime(400, ctx.currentTime + 0.15);
+      gain.gain.setValueAtTime(0.1, ctx.currentTime);
+      gain.gain.linearRampToValueAtTime(0, ctx.currentTime + 0.18);
+      osc.connect(gain);
+      gain.connect(out);
+      osc.start(ctx.currentTime);
+      osc.stop(ctx.currentTime + 0.2);
+    },
+  };
+
+  class SfxBank {
+    constructor() {
+      this._ctx = null;
+      this._volume = 0.7;
+      this._muted = false;
+    }
+
+    _getCtx() {
+      if (this._ctx) return this._ctx;
+      const Ctor = window.AudioContext || window.webkitAudioContext;
+      if (!Ctor) return null;
+      try {
+        this._ctx = new Ctor();
+      } catch (e) { return null; }
+      return this._ctx;
+    }
+
+    play(name) {
+      if (this._muted) return;
+      const ctx = this._getCtx();
+      if (!ctx) return;
+      ctx.resume().then(() => this._schedule(name, ctx)).catch(function() {});
+    }
+
+    setVolume(v) { this._volume = Math.max(0, Math.min(1, v)); }
+
+    setMuted(m) {
+      this._muted = !!m;
+      if (m) { try { if (this._ctx) this._ctx.suspend(); } catch (e) {} }
+      else   { try { if (this._ctx) this._ctx.resume();  } catch (e) {} }
+    }
+
+    _schedule(name, ctx) {
+      const fn = SFX_RECIPES[name];
+      if (!fn) return;
+      const g = ctx.createGain();
+      g.gain.value = this._volume;
+      g.connect(ctx.destination);
+      fn(ctx, g);
+    }
+  }
+
+  global.SfxBank = SfxBank;
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/claudes-math-marauder/js/audio/speech.js
+++ b/claudes-math-marauder/js/audio/speech.js
@@ -7,6 +7,7 @@
       this._voiceURI = null;
       this._rate = 1.0;
       this._autoNarrate = true;
+      this._muted = false;
       this._enabled = ('speechSynthesis' in window);
       if (this._enabled) {
         window.speechSynthesis.onvoiceschanged = () => this._loadVoices();
@@ -19,14 +20,19 @@
       this._voices = window.speechSynthesis.getVoices();
     }
 
-    setSettings({ voiceURI, rate, autoNarrate } = {}) {
+    setSettings({ voiceURI, rate, autoNarrate, muted } = {}) {
       if (voiceURI !== undefined) this._voiceURI = voiceURI;
       if (rate !== undefined) this._rate = rate;
       if (autoNarrate !== undefined) this._autoNarrate = autoNarrate;
+      if (muted !== undefined) {
+        this._muted = !!muted;
+        if (this._muted) this.cancel();
+      }
     }
 
     speak(text, opts) {
       if (!this._enabled) return;
+      if (this._muted) return;
       if (!text) return;
       opts = opts || {};
       const u = new SpeechSynthesisUtterance(text);

--- a/claudes-math-marauder/js/audio/speech.js
+++ b/claudes-math-marauder/js/audio/speech.js
@@ -1,0 +1,81 @@
+(function(global) {
+  'use strict';
+
+  class SpeechManager {
+    constructor() {
+      this._voices = [];
+      this._voiceURI = null;
+      this._rate = 1.0;
+      this._autoNarrate = true;
+      this._enabled = ('speechSynthesis' in window);
+      if (this._enabled) {
+        window.speechSynthesis.onvoiceschanged = () => this._loadVoices();
+        this._loadVoices();
+      }
+    }
+
+    _loadVoices() {
+      if (!this._enabled) return;
+      this._voices = window.speechSynthesis.getVoices();
+    }
+
+    setSettings({ voiceURI, rate, autoNarrate } = {}) {
+      if (voiceURI !== undefined) this._voiceURI = voiceURI;
+      if (rate !== undefined) this._rate = rate;
+      if (autoNarrate !== undefined) this._autoNarrate = autoNarrate;
+    }
+
+    speak(text, opts) {
+      if (!this._enabled) return;
+      if (!text) return;
+      opts = opts || {};
+      const u = new SpeechSynthesisUtterance(text);
+      u.rate = opts.rate !== undefined ? opts.rate : this._rate;
+      u.pitch = opts.pitch !== undefined ? opts.pitch : 1.0;
+      if (this._voiceURI) {
+        const v = this._voices.find(x => x.voiceURI === this._voiceURI);
+        if (v) u.voice = v;
+      } else {
+        const preferred = ['Daniel', 'Karen', 'Samantha', 'Moira'];
+        const v = this._voices.find(x => preferred.some(p => x.name.includes(p)));
+        if (v) u.voice = v;
+      }
+      // iOS quirk: cancel silences an immediately-following speak()
+      window.speechSynthesis.cancel();
+      setTimeout(function() {
+        try { window.speechSynthesis.speak(u); } catch (e) {}
+      }, 50);
+    }
+
+    cancel() {
+      if (!this._enabled) return;
+      try { window.speechSynthesis.cancel(); } catch (e) {}
+    }
+
+    pause() { if (this._enabled) try { window.speechSynthesis.pause(); } catch (e) {} }
+    resume() { if (this._enabled) try { window.speechSynthesis.resume(); } catch (e) {} }
+
+    speakIfAuto(text, opts) { if (this._autoNarrate) this.speak(text, opts); }
+
+    isSupported() { return this._enabled; }
+    getVoices() { return this._voices.slice(); }
+  }
+
+  // Attaches a 🔊 button to parent that reads text via window.speech.
+  function attachReadAloud(parent, getText, opts) {
+    opts = opts || {};
+    const btn = document.createElement('button');
+    btn.className = 'read-aloud';
+    btn.setAttribute('aria-label', 'Read aloud');
+    btn.innerHTML = '🔊';
+    btn.addEventListener('click', function() {
+      if (window.speech) window.speech.speak(getText());
+    });
+    if (!window.speech || !window.speech.isSupported()) btn.disabled = true;
+    parent.appendChild(btn);
+    return btn;
+  }
+
+  global.SpeechManager = SpeechManager;
+  global.attachReadAloud = attachReadAloud;
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/claudes-math-marauder/js/combat/bossFight.js
+++ b/claudes-math-marauder/js/combat/bossFight.js
@@ -70,7 +70,11 @@ class BossFightManager {
   }
 
   start(boss, realm, masteryMap) {
+    // cancel() nulls onComplete to prevent stale callbacks; preserve the
+    // caller-supplied callback across the defensive cancel at start().
+    const savedCb = this.onComplete;
     this.cancel();
+    this.onComplete = savedCb;
     this._lessonComplete = false;
     this._boss = boss;
     this._realm = realm;
@@ -211,7 +215,7 @@ class BossFightManager {
   notifyPaused() {
     if (this._pausedAt) return;
     this._pausedAt = performance.now();
-    if ('speechSynthesis' in window) speechSynthesis.pause();
+    // game.js already pauses window.speech; don't double-pause here
   }
 
   notifyResumed() {
@@ -219,7 +223,6 @@ class BossFightManager {
     const pausedFor = performance.now() - this._pausedAt;
     if (this._answerStartedAt) this._answerStartedAt += pausedFor;
     this._pausedAt = 0;
-    if ('speechSynthesis' in window) speechSynthesis.resume();
   }
 
   // Called by game.js pointer handler when state === 'PHASE_ORB'
@@ -415,16 +418,11 @@ class BossFightManager {
   }
 
   _narrate(text, voice) {
-    if (!('speechSynthesis' in window)) return;
-    speechSynthesis.cancel();
-    setTimeout(function() {
-      const utt = new SpeechSynthesisUtterance(text);
-      if (voice && voice.voiceProfile) {
-        utt.pitch = voice.voiceProfile.pitch;
-        utt.rate = voice.voiceProfile.rate;
-      }
-      speechSynthesis.speak(utt);
-    }, 50);
+    if (!window.speech) return;
+    const opts = (voice && voice.voiceProfile)
+      ? { pitch: voice.voiceProfile.pitch, rate: voice.voiceProfile.rate }
+      : undefined;
+    window.speech.speakIfAuto(text, opts);
   }
 
   _playAudio(name) {

--- a/claudes-math-marauder/js/combat/fight.js
+++ b/claudes-math-marauder/js/combat/fight.js
@@ -72,7 +72,11 @@ class FightManager {
   }
 
   start(monster, opts) {
+    // cancel() nulls onComplete to prevent stale callbacks; preserve the
+    // caller-supplied callback across the defensive cancel at start().
+    const savedCb = this.onComplete;
     this.cancel();
+    this.onComplete = savedCb;
     opts = opts || {};
     this._lessonComplete = false;
     this._monster = monster;
@@ -417,17 +421,12 @@ class FightManager {
   }
 
   _narrate(text) {
-    if (!('speechSynthesis' in window)) return;
-    speechSynthesis.cancel();
+    if (!window.speech) return;
     const monster = this._monster;
-    setTimeout(function() {
-      const utt = new SpeechSynthesisUtterance(text);
-      if (monster && monster.voiceProfile) {
-        utt.pitch = monster.voiceProfile.pitch;
-        utt.rate = monster.voiceProfile.rate;
-      }
-      speechSynthesis.speak(utt);
-    }, 50);
+    const opts = (monster && monster.voiceProfile)
+      ? { pitch: monster.voiceProfile.pitch, rate: monster.voiceProfile.rate }
+      : undefined;
+    window.speech.speakIfAuto(text, opts);
   }
 
   _pickTaunt(monster) {

--- a/claudes-math-marauder/js/game.js
+++ b/claudes-math-marauder/js/game.js
@@ -124,17 +124,22 @@ class Game {
     this._loop = this._loop.bind(this);
     this._rafId = requestAnimationFrame(this._loop);
 
-    this._bindTitleScreen();
-    this._bindPauseScreen();
-
     this._save = SaveManager.load();
     const data = this._save;
-    if (data.settings.reducedMotion || window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
-      document.body.setAttribute('data-reduced-motion', 'true');
-    }
-    if (data.settings.fontScale && data.settings.fontScale !== 1.0) {
-      document.documentElement.style.fontSize = Math.round(20 * data.settings.fontScale) + 'px';
-    }
+
+    // Audio + speech — created before binding so gesture handlers can call them
+    window.speech = new SpeechManager();
+    window.sfx = new SfxBank();
+    window.settingsPanel = new SettingsPanel();
+
+    // Hub screen — stub for session 9 run-map replacement
+    window.hubScreen = new HubScreen();
+
+    // Apply persisted settings immediately
+    this._applySettings(data.settings);
+
+    this._bindTitleScreen();
+    this._bindPauseScreen();
 
     // Initialise FX system
     this._fxCache = new FxCache(30);
@@ -159,7 +164,7 @@ class Game {
     // Boot into a fight directly if ?fight=<monsterId>
     const fightParam = params.get('fight');
     if (fightParam) {
-      this._launchDebugFight(fightParam);
+      this._launchDebugFight(fightParam, params.get('ultimate') === '1');
     }
 
     // Boot directly into a boss fight if ?boss=<bossId>
@@ -201,6 +206,7 @@ class Game {
 
     if (this.state !== STATE.PAUSED) this._update(dt, now);
     this._draw(now);
+
     this._rafId = requestAnimationFrame(this._loop);
   }
 
@@ -252,12 +258,52 @@ class Game {
     } else {
       console.warn('[Game] No screen element for state:', this.state, '(expected #' + id + ')');
     }
+    if (this.state === STATE.HUB && window.hubScreen) {
+      window.hubScreen.show();
+    }
+  }
+
+  // ── Settings integration ──────────────────────────────────────────────────────
+  _applySettings(s) {
+    // Font scale
+    document.documentElement.style.fontSize = Math.round(20 * (s.fontScale || 1.0)) + 'px';
+    // Reduced motion (manual override OR OS preference)
+    if (s.reducedMotion || window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      document.body.setAttribute('data-reduced-motion', 'true');
+    } else {
+      document.body.removeAttribute('data-reduced-motion');
+    }
+    // Audio
+    if (window.sfx) {
+      window.sfx.setMuted(s.muteAll);
+      window.sfx.setVolume(s.sfxVolume !== undefined ? s.sfxVolume : 0.7);
+    }
+    // Speech
+    if (window.speech) {
+      window.speech.setSettings({
+        voiceURI: s.speechVoiceURI,
+        rate: s.speechRate,
+        autoNarrate: s.autoNarrate,
+      });
+    }
   }
 
   // ── Title / Pause bindings ────────────────────────────────────────────────────
   _bindTitleScreen() {
-    const btn = document.getElementById('start-button');
-    if (btn) btn.addEventListener('click', () => this.setState(STATE.HUB));
+    const startBtn = document.getElementById('start-button');
+    if (startBtn) startBtn.addEventListener('click', () => this.setState(STATE.HUB));
+
+    // Gear button → settings panel
+    const gearBtn = document.getElementById('title-settings-btn');
+    if (gearBtn) gearBtn.addEventListener('click', () => {
+      if (window.settingsPanel) window.settingsPanel.open(gearBtn);
+    });
+
+    // Read-aloud button on subtitle
+    const subtitle = document.getElementById('title-subtitle');
+    if (subtitle && typeof attachReadAloud === 'function') {
+      attachReadAloud(subtitle, () => subtitle.textContent);
+    }
   }
 
   _bindPauseScreen() {
@@ -270,7 +316,7 @@ class Game {
       if (this._fightManager) this._fightManager.notifyPaused();
       if (this._bossFightManager) this._bossFightManager.notifyPaused();
       this.setState(STATE.PAUSED);
-      if ('speechSynthesis' in window) speechSynthesis.pause();
+      if (window.speech) window.speech.pause();
     }
   }
 
@@ -279,7 +325,7 @@ class Game {
       this.setState(this._prevState);
       if (this._fightManager) this._fightManager.notifyResumed();
       if (this._bossFightManager) this._bossFightManager.notifyResumed();
-      if ('speechSynthesis' in window) speechSynthesis.resume();
+      if (window.speech) window.speech.resume();
     }
   }
 
@@ -361,7 +407,7 @@ class Game {
   _onFightComplete(result) {
     console.log('[Game] Fight complete:', result);
     this._exitFight();
-    this.setState(STATE.TITLE);
+    this.setState(STATE.HUB);
   }
 
   _onPointerDown(e) {
@@ -398,8 +444,7 @@ class Game {
     }
   }
 
-  async _launchDebugFight(monsterId) {
-    const params = new URLSearchParams(window.location.search);
+  async _launchDebugFight(monsterId, startCharged) {
     try {
       const [monstersData, realmsData] = await Promise.all([
         fetch('data/monsters.json').then(function(r) { return r.json(); }),
@@ -417,8 +462,7 @@ class Game {
       }
       const data = SaveManager.load();
       const allowStretch = data.settings.allowStretchFacts !== false;
-      const startCharged = params.get('ultimate') === '1';
-      this._startFight(monster, realm, data.mastery, allowStretch, { startCharged });
+      this._startFight(monster, realm, data.mastery, allowStretch, { startCharged: !!startCharged });
     } catch (err) {
       console.error('[Game] Debug fight load failed:', err);
     }

--- a/claudes-math-marauder/js/game.js
+++ b/claudes-math-marauder/js/game.js
@@ -278,12 +278,13 @@ class Game {
       window.sfx.setMuted(s.muteAll);
       window.sfx.setVolume(s.sfxVolume !== undefined ? s.sfxVolume : 0.7);
     }
-    // Speech
+    // Speech — muteAll silences both SFX and narration
     if (window.speech) {
       window.speech.setSettings({
         voiceURI: s.speechVoiceURI,
         rate: s.speechRate,
         autoNarrate: s.autoNarrate,
+        muted: s.muteAll,
       });
     }
   }
@@ -349,7 +350,7 @@ class Game {
       distractors: Distractors,
       mastery: Mastery,
       onComplete: (result) => this._onFightComplete(result),
-      audio: null,
+      audio: window.sfx || null,
       monsterRenderer: this._monsterRenderer,
       wizardRenderer: this._wizardRenderer,
       hud: this._hud,
@@ -378,7 +379,7 @@ class Game {
       problemGen: ProblemGen,
       distractors: Distractors,
       mastery: Mastery,
-      audio: null,
+      audio: window.sfx || null,
       monsterRenderer: this._monsterRenderer,
       wizardRenderer: this._wizardRenderer,
       hud: this._hud,
@@ -400,6 +401,7 @@ class Game {
       this._bossFightManager.cancel();
       this._bossFightManager = null;
     }
+    if (window.speech) window.speech.cancel();
     this._orbsRenderer = null;
     this._hud = null;
   }

--- a/claudes-math-marauder/js/ui/hub.js
+++ b/claudes-math-marauder/js/ui/hub.js
@@ -1,0 +1,197 @@
+(function(global) {
+  'use strict';
+
+  // Minimal hub screen: loads Goblin Forest data and lets the player pick a fight.
+  // Populates #hub-screen on show(). Session 9 will replace this with the full
+  // run-map system; this stub makes the game playable end-to-end in the meantime.
+  class HubScreen {
+    constructor() {
+      this._root = null;
+      this._realm = null;
+      this._monsters = null;
+      this._boss = null;
+      this._loaded = false;
+      this._loading = false;
+    }
+
+    show() {
+      this._root = document.getElementById('hub-screen');
+      if (!this._root) return;
+      this._root.innerHTML = '';
+      this._renderSkeleton();
+      if (this._loaded) {
+        this._renderContent();
+      } else if (!this._loading) {
+        this._loadData();
+      }
+    }
+
+    // ── Private ───────────────────────────────────────────────────────────────
+
+    _renderSkeleton() {
+      // Gear button (top-right, same as title screen)
+      const gear = document.createElement('button');
+      gear.className = 'secondary settings-gear-btn';
+      gear.setAttribute('aria-label', 'Open settings');
+      gear.setAttribute('aria-expanded', 'false');
+      gear.textContent = '⚙️';
+      gear.addEventListener('click', function() {
+        if (window.settingsPanel) window.settingsPanel.open(gear);
+      });
+      this._root.appendChild(gear);
+
+      const heading = document.createElement('h2');
+      heading.className = 'hub-title';
+      heading.textContent = "Wizard's Tower";
+      this._root.appendChild(heading);
+
+      const loading = document.createElement('p');
+      loading.id = 'hub-loading';
+      loading.className = 'hub-loading-text';
+      loading.textContent = 'Loading…';
+      this._root.appendChild(loading);
+    }
+
+    async _loadData() {
+      this._loading = true;
+      try {
+        const [monstersData, realmsData, bossesData] = await Promise.all([
+          fetch('data/monsters.json').then(function(r) { return r.json(); }),
+          fetch('data/realms.json').then(function(r) { return r.json(); }),
+          fetch('data/bosses.json').then(function(r) { return r.json(); }),
+        ]);
+
+        this._realm = realmsData.realms.find(function(r) { return r.id === 'goblin_forest'; });
+        const poolIds = this._realm ? (this._realm.monsterPool || []) : [];
+        this._monsters = poolIds.map(function(id) {
+          return monstersData.monsters.find(function(m) { return m.id === id; });
+        }).filter(Boolean);
+        this._boss = bossesData.bosses.find(function(b) { return b.realmId === 'goblin_forest'; });
+
+        this._loaded = true;
+        this._loading = false;
+
+        // Only render if hub screen is still active
+        if (this._root && this._root.classList.contains('active')) {
+          this._renderContent();
+        }
+      } catch (err) {
+        this._loading = false;
+        console.error('[HubScreen] Load failed:', err);
+        if (this._root) {
+          const loadingEl = this._root.querySelector('#hub-loading');
+          if (loadingEl) loadingEl.textContent = 'Could not load game data. Try refreshing.';
+        }
+      }
+    }
+
+    _renderContent() {
+      const loadingEl = this._root.querySelector('#hub-loading');
+      if (loadingEl) loadingEl.remove();
+
+      const realmName = this._realm ? (this._realm.name || 'Goblin Forest') : 'Goblin Forest';
+
+      const section = document.createElement('section');
+      section.setAttribute('aria-labelledby', 'hub-realm-heading');
+      section.className = 'hub-realm-section';
+
+      const realmHeading = document.createElement('h3');
+      realmHeading.id = 'hub-realm-heading';
+      realmHeading.className = 'hub-realm-name';
+      realmHeading.textContent = realmName + ' — Realm 1';
+      section.appendChild(realmHeading);
+
+      const intro = document.createElement('p');
+      intro.className = 'hub-intro';
+      intro.textContent = 'Choose a fight:';
+      section.appendChild(intro);
+
+      const grid = document.createElement('div');
+      grid.className = 'hub-monster-grid';
+      grid.setAttribute('role', 'group');
+      grid.setAttribute('aria-label', 'Monsters');
+
+      // Regular monster cards
+      const monsters = this._monsters || [];
+      monsters.forEach((monster) => {
+        grid.appendChild(this._makeMonsterCard(monster));
+      });
+
+      // Boss card
+      if (this._boss) {
+        grid.appendChild(this._makeBossCard(this._boss));
+      }
+
+      section.appendChild(grid);
+      this._root.appendChild(section);
+    }
+
+    _makeMonsterCard(monster) {
+      const card = document.createElement('div');
+      card.className = 'hub-card';
+
+      const name = document.createElement('h4');
+      name.className = 'hub-card-name';
+      name.textContent = monster.name || monster.id;
+      card.appendChild(name);
+
+      const tier = document.createElement('p');
+      tier.className = 'hub-card-tier';
+      tier.textContent = 'Tier ' + (monster.tier || 1);
+      card.appendChild(tier);
+
+      const btn = document.createElement('button');
+      btn.className = 'primary hub-fight-btn';
+      btn.setAttribute('aria-label', 'Fight ' + (monster.name || monster.id));
+      btn.textContent = 'Fight!';
+      btn.addEventListener('click', () => this._startMonsterFight(monster));
+      card.appendChild(btn);
+
+      return card;
+    }
+
+    _makeBossCard(boss) {
+      const card = document.createElement('div');
+      card.className = 'hub-card hub-boss-card';
+
+      const label = document.createElement('span');
+      label.className = 'hub-boss-badge';
+      label.textContent = 'BOSS';
+      card.appendChild(label);
+
+      const name = document.createElement('h4');
+      name.className = 'hub-card-name';
+      name.textContent = boss.name || boss.id;
+      card.appendChild(name);
+
+      const phases = document.createElement('p');
+      phases.className = 'hub-card-tier';
+      phases.textContent = (boss.phases ? boss.phases.length : 3) + ' phases';
+      card.appendChild(phases);
+
+      const btn = document.createElement('button');
+      btn.className = 'primary hub-fight-btn';
+      btn.setAttribute('aria-label', 'Challenge ' + (boss.name || boss.id));
+      btn.textContent = 'Challenge!';
+      btn.addEventListener('click', () => this._startBossFight(boss));
+      card.appendChild(btn);
+
+      return card;
+    }
+
+    _startMonsterFight(monster) {
+      if (!window.game || !this._realm) return;
+      const data = SaveManager.load();
+      const allowStretch = data.settings.allowStretchFacts !== false;
+      window.game._startFight(monster, this._realm, data.mastery, allowStretch, {});
+    }
+
+    _startBossFight(boss) {
+      if (!window.game || !this._realm) return;
+      const data = SaveManager.load();
+      window.game._startBossFight(boss, this._realm, data.mastery);
+    }
+  }
+
+  global.HubScreen = HubScreen;
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/claudes-math-marauder/js/ui/hub.js
+++ b/claudes-math-marauder/js/ui/hub.js
@@ -29,6 +29,16 @@
     // ── Private ───────────────────────────────────────────────────────────────
 
     _renderSkeleton() {
+      // Back button (top-left) — returns to title screen so users aren't trapped in hub
+      const back = document.createElement('button');
+      back.className = 'secondary hub-back-btn';
+      back.setAttribute('aria-label', 'Back to title screen');
+      back.textContent = '← Title';
+      back.addEventListener('click', function() {
+        if (window.game) window.game.setState('TITLE');
+      });
+      this._root.appendChild(back);
+
       // Gear button (top-right, same as title screen)
       const gear = document.createElement('button');
       gear.className = 'secondary settings-gear-btn';

--- a/claudes-math-marauder/js/ui/hud.js
+++ b/claudes-math-marauder/js/ui/hud.js
@@ -16,8 +16,8 @@ class HUD {
     this._ultimateEl = null;
     this._wizardHpFillEl = null;
     this._correctionEl = null;
-    this._bossPhaseEl = null;
     this._correctionTimer = null;
+    this._bossPhaseEl = null;
     this._build();
   }
 
@@ -62,6 +62,17 @@ class HUD {
     this._correctionTimer = setTimeout(() => {
       this._correctionEl.classList.add('hidden');
     }, 1100);
+  }
+
+  // Updates the boss phase label. Pass empty string to hide.
+  // Live region — textContent drives announcement (no aria-label per CLAUDE.md rule).
+  setBossPhaseLabel(text) {
+    this._bossPhaseEl.textContent = text;
+    if (text) {
+      this._bossPhaseEl.classList.remove('hidden');
+    } else {
+      this._bossPhaseEl.classList.add('hidden');
+    }
   }
 
   // Hides the entire HUD using .hidden class (display:none).

--- a/claudes-math-marauder/js/ui/settings.js
+++ b/claudes-math-marauder/js/ui/settings.js
@@ -1,0 +1,483 @@
+(function(global) {
+  'use strict';
+
+  const FONT_SCALES = [
+    { value: '0.9',  label: 'Small (90%)' },
+    { value: '1.0',  label: 'Default' },
+    { value: '1.1',  label: 'Larger (110%)' },
+    { value: '1.25', label: 'Large (125%)' },
+    { value: '1.5',  label: 'Extra large (150%)' },
+  ];
+
+  class SettingsPanel {
+    constructor() {
+      this._overlay = null;
+      this._closeBtn = null;
+      this._trigger = null;
+      this._data = null;
+      this._resetStep = 0;
+      this._resetTimer = null;
+
+      // Form controls (set in _buildDOM)
+      this._voiceSelect = null;
+      this._rateSlider = null;
+      this._rateLabel = null;
+      this._autoNarrateChk = null;
+      this._sfxVolSlider = null;
+      this._sfxVolLabel = null;
+      this._muteChk = null;
+      this._reducedMotionChk = null;
+      this._fontScaleSelect = null;
+      this._showTimerChk = null;
+      this._stretchChk = null;
+
+      this._buildDOM();
+    }
+
+    _buildDOM() {
+      const overlay = document.createElement('div');
+      overlay.id = 'settings-overlay';
+      overlay.className = 'overlay';
+      overlay.setAttribute('role', 'dialog');
+      overlay.setAttribute('aria-modal', 'true');
+      overlay.setAttribute('aria-label', 'Settings');
+      overlay.setAttribute('aria-hidden', 'true');
+      this._overlay = overlay;
+
+      const panel = document.createElement('div');
+      panel.className = 'panel settings-panel';
+
+      // Close button — must be first focusable element
+      const closeBtn = document.createElement('button');
+      closeBtn.className = 'secondary settings-close-btn';
+      closeBtn.setAttribute('aria-label', 'Close settings');
+      closeBtn.textContent = '✕';
+      closeBtn.addEventListener('click', () => this.close());
+      this._closeBtn = closeBtn;
+      panel.appendChild(closeBtn);
+
+      const heading = document.createElement('h2');
+      heading.textContent = 'Settings';
+      heading.className = 'settings-heading';
+      panel.appendChild(heading);
+
+      panel.appendChild(this._buildSpeechSection());
+      panel.appendChild(this._buildAudioSection());
+      panel.appendChild(this._buildDisplaySection());
+      panel.appendChild(this._buildGameSection());
+      panel.appendChild(this._buildActionsSection());
+
+      overlay.appendChild(panel);
+
+      overlay.addEventListener('keydown', (e) => this._onKeyDown(e));
+
+      const root = document.getElementById('overlay-root') || document.body;
+      root.appendChild(overlay);
+    }
+
+    _buildSpeechSection() {
+      const section = document.createElement('section');
+      section.setAttribute('aria-labelledby', 'settings-speech-heading');
+
+      const h = document.createElement('h3');
+      h.id = 'settings-speech-heading';
+      h.textContent = 'Speech';
+      section.appendChild(h);
+
+      // Voice picker
+      const voiceRow = this._row('Voice', 'settings-voice');
+      const voiceSelect = document.createElement('select');
+      voiceSelect.id = 'settings-voice';
+      voiceSelect.className = 'settings-select';
+      const noVoiceOpt = document.createElement('option');
+      noVoiceOpt.value = '';
+      noVoiceOpt.textContent = 'Default voice';
+      voiceSelect.appendChild(noVoiceOpt);
+      voiceRow.appendChild(voiceSelect);
+      this._voiceSelect = voiceSelect;
+      section.appendChild(voiceRow);
+
+      // Rate slider
+      const rateRow = this._row('Speech rate', 'settings-rate');
+      const rateLabel = document.createElement('span');
+      rateLabel.id = 'settings-rate-label';
+      rateLabel.className = 'settings-slider-val';
+      rateLabel.textContent = '1.0×';
+      rateRow.querySelector('label').appendChild(rateLabel);
+      const rateSlider = document.createElement('input');
+      rateSlider.type = 'range';
+      rateSlider.id = 'settings-rate';
+      rateSlider.min = '0.7';
+      rateSlider.max = '1.3';
+      rateSlider.step = '0.1';
+      rateSlider.value = '1.0';
+      rateSlider.setAttribute('aria-valuetext', '1.0 times speed');
+      rateRow.appendChild(rateSlider);
+      this._rateSlider = rateSlider;
+      this._rateLabel = rateLabel;
+      section.appendChild(rateRow);
+
+      // Auto-narrate checkbox
+      const autoNarrateRow = this._checkRow('Read aloud automatically', 'settings-auto-narrate');
+      this._autoNarrateChk = autoNarrateRow.querySelector('input');
+      section.appendChild(autoNarrateRow);
+
+      // Test speech button
+      const testBtn = document.createElement('button');
+      testBtn.className = 'secondary settings-test-btn';
+      testBtn.setAttribute('aria-label', 'Test speech — speaks hello message');
+      testBtn.textContent = '🔊 Test voice';
+      testBtn.addEventListener('click', () => {
+        if (window.speech) window.speech.speak('Hello, math marauder!');
+      });
+      section.appendChild(testBtn);
+
+      return section;
+    }
+
+    _buildAudioSection() {
+      const section = document.createElement('section');
+      section.setAttribute('aria-labelledby', 'settings-audio-heading');
+
+      const h = document.createElement('h3');
+      h.id = 'settings-audio-heading';
+      h.textContent = 'Audio';
+      section.appendChild(h);
+
+      // SFX volume slider
+      const volRow = this._row('Sound effects volume', 'settings-sfx-vol');
+      const volLabel = document.createElement('span');
+      volLabel.id = 'settings-sfx-vol-label';
+      volLabel.className = 'settings-slider-val';
+      volLabel.textContent = '70%';
+      volRow.querySelector('label').appendChild(volLabel);
+      const volSlider = document.createElement('input');
+      volSlider.type = 'range';
+      volSlider.id = 'settings-sfx-vol';
+      volSlider.min = '0';
+      volSlider.max = '1';
+      volSlider.step = '0.1';
+      volSlider.value = '0.7';
+      volRow.appendChild(volSlider);
+      this._sfxVolSlider = volSlider;
+      this._sfxVolLabel = volLabel;
+      section.appendChild(volRow);
+
+      // Mute checkbox
+      const muteRow = this._checkRow('Mute all sounds', 'settings-mute');
+      this._muteChk = muteRow.querySelector('input');
+      section.appendChild(muteRow);
+
+      return section;
+    }
+
+    _buildDisplaySection() {
+      const section = document.createElement('section');
+      section.setAttribute('aria-labelledby', 'settings-display-heading');
+
+      const h = document.createElement('h3');
+      h.id = 'settings-display-heading';
+      h.textContent = 'Display';
+      section.appendChild(h);
+
+      // Reduced motion checkbox
+      const rmRow = this._checkRow('Reduced motion', 'settings-reduced-motion');
+      this._reducedMotionChk = rmRow.querySelector('input');
+      section.appendChild(rmRow);
+
+      // Font scale dropdown
+      const fontRow = this._row('Text size', 'settings-font-scale');
+      const fontSelect = document.createElement('select');
+      fontSelect.id = 'settings-font-scale';
+      fontSelect.className = 'settings-select';
+      FONT_SCALES.forEach(function(s) {
+        const opt = document.createElement('option');
+        opt.value = s.value;
+        opt.textContent = s.label;
+        fontSelect.appendChild(opt);
+      });
+      fontRow.appendChild(fontSelect);
+      this._fontScaleSelect = fontSelect;
+      section.appendChild(fontRow);
+
+      return section;
+    }
+
+    _buildGameSection() {
+      const section = document.createElement('section');
+      section.setAttribute('aria-labelledby', 'settings-game-heading');
+
+      const h = document.createElement('h3');
+      h.id = 'settings-game-heading';
+      h.textContent = 'Game';
+      section.appendChild(h);
+
+      const timerRow = this._checkRow('Show speed timer', 'settings-show-timer');
+      this._showTimerChk = timerRow.querySelector('input');
+      section.appendChild(timerRow);
+
+      const stretchRow = this._checkRow('Allow bonus problems', 'settings-stretch');
+      this._stretchChk = stretchRow.querySelector('input');
+      section.appendChild(stretchRow);
+
+      return section;
+    }
+
+    _buildActionsSection() {
+      const section = document.createElement('section');
+      section.className = 'settings-actions';
+
+      const resetBtn = document.createElement('button');
+      resetBtn.id = 'settings-reset-btn';
+      resetBtn.className = 'secondary danger';
+      resetBtn.setAttribute('aria-label', 'Reset all progress — requires confirmation');
+      resetBtn.textContent = 'Reset progress';
+      resetBtn.addEventListener('click', () => this._onResetClick(resetBtn));
+      section.appendChild(resetBtn);
+
+      return section;
+    }
+
+    // Helper: labeled row wrapping label + for=""
+    _row(labelText, forId) {
+      const row = document.createElement('div');
+      row.className = 'settings-row';
+      const label = document.createElement('label');
+      label.setAttribute('for', forId);
+      label.textContent = labelText;
+      row.appendChild(label);
+      return row;
+    }
+
+    // Helper: checkbox row with label wrapping
+    _checkRow(labelText, id) {
+      const row = document.createElement('div');
+      row.className = 'settings-row settings-check-row';
+      const label = document.createElement('label');
+      const chk = document.createElement('input');
+      chk.type = 'checkbox';
+      chk.id = id;
+      label.appendChild(chk);
+      label.appendChild(document.createTextNode(' ' + labelText));
+      row.appendChild(label);
+      return row;
+    }
+
+    // ── Public API ────────────────────────────────────────────────────
+
+    open(triggerEl) {
+      this._trigger = triggerEl || null;
+      this._data = SaveManager.load();
+      this._resetStep = 0;
+      clearTimeout(this._resetTimer);
+      this._resetTimer = null;
+      const resetBtn = this._overlay.querySelector('#settings-reset-btn');
+      if (resetBtn) {
+        resetBtn.textContent = 'Reset progress';
+        resetBtn.setAttribute('aria-label', 'Reset all progress — requires confirmation');
+      }
+
+      this._populateVoices();
+      this._populate(this._data.settings);
+      this._bindControls();
+
+      this._overlay.setAttribute('aria-hidden', 'false');
+      this._overlay.classList.add('open');
+      if (triggerEl) triggerEl.setAttribute('aria-expanded', 'true');
+      this._closeBtn.focus();
+    }
+
+    close() {
+      clearTimeout(this._resetTimer);
+      this._resetTimer = null;
+      this._overlay.setAttribute('aria-hidden', 'true');
+      this._overlay.classList.remove('open');
+      if (this._trigger) {
+        this._trigger.setAttribute('aria-expanded', 'false');
+        this._trigger.focus();
+      }
+      this._trigger = null;
+    }
+
+    // ── Internal ──────────────────────────────────────────────────────
+
+    _populateVoices() {
+      if (!window.speech) return;
+      const voices = window.speech.getVoices();
+      const select = this._voiceSelect;
+      // Clear all but default option
+      while (select.options.length > 1) select.remove(1);
+      if (!window.speech.isSupported()) {
+        select.disabled = true;
+        select.options[0].textContent = 'Speech not supported';
+        return;
+      }
+      if (voices.length === 0) {
+        select.disabled = true;
+        select.options[0].textContent = 'No voices available';
+        return;
+      }
+      select.disabled = false;
+      select.options[0].textContent = 'Default voice';
+      voices.forEach(function(v) {
+        const opt = document.createElement('option');
+        opt.value = v.voiceURI;
+        opt.textContent = v.name + (v.lang ? ' (' + v.lang + ')' : '');
+        select.appendChild(opt);
+      });
+    }
+
+    _populate(s) {
+      if (s.speechVoiceURI && this._voiceSelect) {
+        this._voiceSelect.value = s.speechVoiceURI;
+      }
+      if (this._rateSlider) {
+        const rate = s.speechRate || 1.0;
+        this._rateSlider.value = String(rate);
+        this._rateLabel.textContent = rate.toFixed(1) + '×';
+        this._rateSlider.setAttribute('aria-valuetext', rate.toFixed(1) + ' times speed');
+      }
+      if (this._autoNarrateChk) this._autoNarrateChk.checked = s.autoNarrate !== false;
+      if (this._sfxVolSlider) {
+        const vol = s.sfxVolume !== undefined ? s.sfxVolume : 0.7;
+        this._sfxVolSlider.value = String(vol);
+        this._sfxVolLabel.textContent = Math.round(vol * 100) + '%';
+      }
+      if (this._muteChk) this._muteChk.checked = !!s.muteAll;
+      if (this._reducedMotionChk) this._reducedMotionChk.checked = !!s.reducedMotion;
+      if (this._fontScaleSelect) {
+        const scale = s.fontScale || 1.0;
+        const match = FONT_SCALES.find(function(f) { return parseFloat(f.value) === scale; });
+        this._fontScaleSelect.value = match ? match.value : '1.0';
+      }
+      if (this._showTimerChk) this._showTimerChk.checked = !!s.showSpeedTimer;
+      if (this._stretchChk) this._stretchChk.checked = s.allowStretchFacts !== false;
+    }
+
+    _bindControls() {
+      // Remove previous listeners by replacing nodes — simplest approach is to
+      // use a stored flag; since we rebuild the listener each open(), use capture
+      // at overlay level with event delegation
+      this._overlay.onchange = (e) => this._onAnyChange(e);
+      this._rateSlider.oninput = () => {
+        const rate = parseFloat(this._rateSlider.value);
+        this._rateLabel.textContent = rate.toFixed(1) + '×';
+        this._rateSlider.setAttribute('aria-valuetext', rate.toFixed(1) + ' times speed');
+        this._saveAndApply();
+      };
+      this._sfxVolSlider.oninput = () => {
+        const vol = parseFloat(this._sfxVolSlider.value);
+        this._sfxVolLabel.textContent = Math.round(vol * 100) + '%';
+        this._saveAndApply();
+      };
+    }
+
+    _onAnyChange(e) {
+      const t = e.target;
+      if (t === this._rateSlider || t === this._sfxVolSlider) return; // handled by oninput
+      this._saveAndApply();
+    }
+
+    _saveAndApply() {
+      if (!this._data) return;
+      const s = this._data.settings;
+      s.speechVoiceURI = this._voiceSelect.value || null;
+      s.speechRate = parseFloat(this._rateSlider.value);
+      s.autoNarrate = this._autoNarrateChk.checked;
+      s.sfxVolume = parseFloat(this._sfxVolSlider.value);
+      s.muteAll = this._muteChk.checked;
+      s.reducedMotion = this._reducedMotionChk.checked;
+      s.fontScale = parseFloat(this._fontScaleSelect.value);
+      s.showSpeedTimer = this._showTimerChk.checked;
+      s.allowStretchFacts = this._stretchChk.checked;
+      SaveManager.save(this._data);
+      this._applySettings(s);
+    }
+
+    _applySettings(s) {
+      // Font scale
+      document.documentElement.style.fontSize = Math.round(20 * (s.fontScale || 1.0)) + 'px';
+
+      // Reduced motion (manual toggle OR OS preference)
+      const forceReduced = s.reducedMotion ||
+        window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+      if (forceReduced) {
+        document.body.setAttribute('data-reduced-motion', 'true');
+      } else {
+        document.body.removeAttribute('data-reduced-motion');
+      }
+
+      // Mute + volume
+      if (window.sfx) {
+        window.sfx.setMuted(s.muteAll);
+        window.sfx.setVolume(s.sfxVolume !== undefined ? s.sfxVolume : 0.7);
+      }
+
+      // Speech settings
+      if (window.speech) {
+        window.speech.setSettings({
+          voiceURI: s.speechVoiceURI,
+          rate: s.speechRate,
+          autoNarrate: s.autoNarrate,
+        });
+      }
+    }
+
+    _onResetClick(btn) {
+      if (this._resetStep === 0) {
+        this._resetStep = 1;
+        btn.textContent = 'Tap again to confirm reset';
+        btn.setAttribute('aria-label', 'Confirm reset — tap again to erase all progress');
+        clearTimeout(this._resetTimer);
+        this._resetTimer = setTimeout(() => {
+          this._resetTimer = null;
+          this._resetStep = 0;
+          btn.textContent = 'Reset progress';
+          btn.setAttribute('aria-label', 'Reset all progress — requires confirmation');
+        }, 3000);
+      } else {
+        // Debounce to prevent double-tap
+        btn.disabled = true;
+        clearTimeout(this._resetTimer);
+        this._resetTimer = null;
+        SaveManager.reset();
+        this._data = SaveManager.load();
+        this._populate(this._data.settings);
+        this._applySettings(this._data.settings);
+        this._resetStep = 0;
+        btn.textContent = 'Reset progress';
+        btn.setAttribute('aria-label', 'Reset all progress — requires confirmation');
+        btn.disabled = false;
+        if (typeof showToast === 'function') showToast('Progress reset.', 2500);
+      }
+    }
+
+    _onKeyDown(e) {
+      if (e.key === 'Escape') {
+        if (this._overlay.classList.contains('open')) this.close();
+        return;
+      }
+      if (e.key === 'Tab') {
+        const focusables = Array.from(this._overlay.querySelectorAll(
+          'button:not([disabled]), select:not([disabled]), input[type="range"], input[type="checkbox"]'
+        ));
+        if (!focusables.length) return;
+        const first = focusables[0];
+        const last = focusables[focusables.length - 1];
+        if (e.shiftKey) {
+          if (document.activeElement === first) {
+            e.preventDefault();
+            last.focus();
+          }
+        } else {
+          if (document.activeElement === last) {
+            e.preventDefault();
+            first.focus();
+          }
+        }
+      }
+    }
+  }
+
+  global.SettingsPanel = SettingsPanel;
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/claudes-math-marauder/js/ui/settings.js
+++ b/claudes-math-marauder/js/ui/settings.js
@@ -413,12 +413,13 @@
         window.sfx.setVolume(s.sfxVolume !== undefined ? s.sfxVolume : 0.7);
       }
 
-      // Speech settings
+      // Speech settings — muteAll silences both SFX and narration
       if (window.speech) {
         window.speech.setSettings({
           voiceURI: s.speechVoiceURI,
           rate: s.speechRate,
           autoNarrate: s.autoNarrate,
+          muted: s.muteAll,
         });
       }
     }
@@ -441,14 +442,9 @@
         clearTimeout(this._resetTimer);
         this._resetTimer = null;
         SaveManager.reset();
-        this._data = SaveManager.load();
-        this._populate(this._data.settings);
-        this._applySettings(this._data.settings);
-        this._resetStep = 0;
-        btn.textContent = 'Reset progress';
-        btn.setAttribute('aria-label', 'Reset all progress — requires confirmation');
-        btn.disabled = false;
-        if (typeof showToast === 'function') showToast('Progress reset.', 2500);
+        if (typeof showToast === 'function') showToast('Progress reset. Reloading…', 2000);
+        // Reload so in-memory game state (mastery, run, hub data) is rebuilt from defaults
+        setTimeout(function() { window.location.reload(); }, 600);
       }
     }
 


### PR DESCRIPTION
## Summary

- **Session 7 (boss fight):** `BossFightManager` multi-phase state machine (IDLE → INTRO → PHASE_ORB → PHASE_ULTIMATE → PHASE_BREAK → VICTORY/DEFEAT_RETRY); boss phase label in HUD; high-contrast phase-bar; re-entry guard + `_currentProblem` null-check; orbs cleared between phases
- **Session 8 (audio + settings):** `SfxBank` with 18 Web Audio recipes and lazy `AudioContext`; `SpeechManager` with iOS 50ms cancel+speak guard; `SettingsPanel` (font scale, mute, SFX volume, speech voice/rate, reduced motion, 2-step reset-progress); gear button on title + hub screens
- **Hub screen (bug fix):** `HubScreen` stub loads Goblin Forest monsters/boss and presents fight-selection cards — **fixes the empty page after clicking "Begin" on the deployed build**. Session 9 replaces this with the full run-map system
- **Flow fix:** fights complete back to HUB (was returning to TITLE)

## Test Plan

- [ ] Click "Begin" → Wizard's Tower shows Goblin Forest monsters + boss card
- [ ] Click "Fight!" on a monster → combat starts, completes back to hub
- [ ] Click "Challenge!" on Goblin Warlord → boss fight starts, phase bar visible
- [ ] Settings gear (title + hub) opens panel; changes persist across page reload
- [ ] Font scale slider resizes all text via `documentElement.style.fontSize`
- [ ] Mute/SFX volume controls silence Web Audio
- [ ] Speech voice/rate dropdowns update read-aloud button on title screen
- [ ] Reduced motion removes animations
- [ ] Reset progress: 2-step confirm + 3s debounce, reloads page
- [ ] All 59 layer-1 tests pass, 0 data validator criticals

🤖 Generated with [Claude Code](https://claude.com/claude-code)