### PR TITLE
feat(marauder): Session 9 — run map, branching graph, Realm 1 playable

### DIFF
--- a/claudes-math-marauder/css/style.css
+++ b/claudes-math-marauder/css/style.css
@@ -680,6 +680,299 @@ body[data-reduced-motion] *, body[data-reduced-motion] *::before, body[data-redu
   margin-top: 4px;
 }
 
+/* ===== Hub: Begin/Resume Run buttons ===== */
+.hub-begin-run-btn {
+  font-size: 22px;
+  padding: 16px 40px;
+  margin: 24px auto 8px;
+  display: block;
+  min-width: 200px;
+}
+
+.hub-resume-run-btn {
+  display: block;
+  margin: 0 auto 16px;
+  min-width: 160px;
+}
+
+/* ===== Run map screen ===== */
+#run-map-screen.active {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  justify-content: flex-start;
+  padding: 0;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+}
+
+.run-map-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  border-bottom: 3px solid var(--accent-ink);
+  flex-shrink: 0;
+  gap: 12px;
+}
+
+.run-map-realm-name {
+  font-size: 22px;
+  font-weight: 700;
+  margin: 0;
+  flex: 1;
+  text-align: center;
+}
+
+.run-map-gold {
+  font-size: 18px;
+  font-weight: 700;
+  color: #b07a00;
+  min-width: 60px;
+  text-align: right;
+}
+
+.run-map-quit-btn {
+  font-size: 16px;
+  padding: 8px 14px;
+  min-width: 80px;
+  min-height: 44px;
+}
+
+.run-map-area {
+  position: relative;
+  flex: 1;
+  overflow: hidden;
+  min-height: 0;
+}
+
+.run-map-edges {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+
+.run-map-edge {
+  stroke: #b0a898;
+  stroke-width: 1.5;
+  stroke-linecap: round;
+}
+
+.run-map-edge.completed {
+  stroke: #5a8a3a;
+  stroke-width: 2;
+}
+
+.run-map-node {
+  position: absolute;
+  transform: translate(-50%, -50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
+  min-width: 64px;
+  min-height: 64px;
+  padding: 8px 6px;
+  border-radius: 14px;
+  background: var(--bg);
+  border: var(--panel-stroke) solid var(--accent-ink);
+  font-family: var(--font-stack);
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.run-map-node:not([disabled]):hover {
+  transform: translate(-50%, -50%) scale(1.08);
+  box-shadow: 0 4px 14px rgba(0,0,0,0.18);
+}
+
+.run-map-node-icon {
+  font-size: 24px;
+  line-height: 1;
+}
+
+.run-map-node-label {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--text-secondary);
+  text-align: center;
+  line-height: 1;
+}
+
+.run-map-node.glow {
+  border-color: var(--accent-comic-yellow);
+  box-shadow: 0 0 12px 3px rgba(240, 216, 64, 0.6);
+  animation: map-node-pulse 1.6s ease-in-out infinite;
+}
+
+@keyframes map-node-pulse {
+  0%, 100% { box-shadow: 0 0 10px 2px rgba(240, 216, 64, 0.5); }
+  50%       { box-shadow: 0 0 20px 6px rgba(240, 216, 64, 0.85); }
+}
+
+.run-map-node.completed {
+  border-color: #5a8a3a;
+  background: #f0f8ea;
+  opacity: 0.7;
+}
+
+.run-map-node.locked {
+  opacity: 0.35;
+  cursor: default;
+}
+
+.run-map-status {
+  text-align: center;
+  font-size: 18px;
+  color: var(--text-secondary);
+  padding: 10px;
+  flex-shrink: 0;
+  margin: 0;
+}
+
+/* ===== Event overlay ===== */
+.event-panel {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  max-width: 440px;
+  width: 90%;
+  max-height: 90vh;
+  overflow-y: auto;
+  padding: 24px;
+}
+
+.event-icon {
+  font-size: 48px;
+  line-height: 1;
+}
+
+.event-prompt {
+  font-size: 20px;
+  line-height: 1.5;
+  text-align: center;
+  margin: 0;
+}
+
+.event-choices {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  width: 100%;
+}
+
+.event-choice-btn {
+  width: 100%;
+  font-size: 18px;
+  text-align: left;
+  padding: 12px 16px;
+  white-space: normal;
+  min-height: 44px;
+}
+
+/* ===== Shop overlay ===== */
+.shop-panel {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  max-width: 480px;
+  width: 92%;
+  max-height: 92vh;
+  overflow-y: auto;
+  padding: 24px;
+}
+
+.shop-heading {
+  font-size: 26px;
+  font-weight: 900;
+  margin: 0;
+}
+
+.shop-gold-display {
+  font-size: 18px;
+  font-weight: 700;
+  color: #b07a00;
+  margin: 0;
+}
+
+.shop-empty {
+  font-size: 18px;
+  color: var(--text-secondary);
+  text-align: center;
+}
+
+.shop-offerings {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  width: 100%;
+}
+
+.shop-card {
+  border: var(--panel-stroke) solid var(--accent-ink);
+  border-radius: 14px;
+  padding: 16px;
+  background: var(--bg);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.shop-card.rarity-rare   { border-color: #2c5fb3; }
+.shop-card.rarity-epic   { border-color: #8a34c9; }
+
+.shop-card-name {
+  font-size: 20px;
+  font-weight: 700;
+  margin: 0;
+}
+
+.shop-card-rarity {
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+.shop-card.rarity-rare .shop-card-rarity   { color: #2c5fb3; }
+.shop-card.rarity-epic .shop-card-rarity   { color: #8a34c9; }
+
+.shop-card-cost {
+  font-size: 16px;
+  color: #b07a00;
+  margin: 0;
+}
+
+.shop-card-actions {
+  display: flex;
+  gap: 10px;
+  margin-top: 6px;
+}
+
+.shop-buy-btn,
+.shop-skip-btn {
+  flex: 1;
+  min-height: 44px;
+}
+
+/* ===== Overlay close button ===== */
+.overlay-close-btn {
+  align-self: flex-end;
+  margin-bottom: 4px;
+  min-width: 44px;
+  min-height: 44px;
+  font-size: 20px;
+  padding: 6px 12px;
+}
+
 /* ===== Read-aloud button ===== */
 .read-aloud {
   display: inline-flex;

--- a/claudes-math-marauder/data/monsters.json
+++ b/claudes-math-marauder/data/monsters.json
@@ -4,283 +4,781 @@
       "id": "goblin_grunt",
       "name": "Goblin Grunt",
       "tier": 1,
-      "hp": 1,
-      "size": [180, 220],
+      "hp": 3,
+      "size": [
+        180,
+        220
+      ],
       "palette": {
-        "body":   "#3a6b2c",
-        "head":   "#4a7b3c",
-        "limbs":  "#2a5b1c",
-        "eyes":   "#ffffff",
+        "body": "#3a6b2c",
+        "head": "#4a7b3c",
+        "limbs": "#2a5b1c",
+        "eyes": "#ffffff",
         "pupils": "#1a1a1a",
-        "mouth":  "#1a1a1a",
-        "horns":  "#f0d840"
+        "mouth": "#1a1a1a",
+        "horns": "#f0d840"
       },
       "shape": {
-        "body":  { "kind": "blob",       "rx": 40, "ry": 46, "wobble": 6, "seed": 101 },
-        "head":  { "kind": "egg",        "rx": 26, "ry": 32, "tilt": -0.05, "seed": 102 },
-        "eyes":  { "kind": "comic_pair", "size": 12, "expr": "angry",        "seed": 103 },
-        "mouth": { "kind": "fang_grin",  "width": 22, "height": 12,         "seed": 104 },
+        "body": {
+          "kind": "blob",
+          "rx": 40,
+          "ry": 46,
+          "wobble": 6,
+          "seed": 101
+        },
+        "head": {
+          "kind": "egg",
+          "rx": 26,
+          "ry": 32,
+          "tilt": -0.05,
+          "seed": 102
+        },
+        "eyes": {
+          "kind": "comic_pair",
+          "size": 12,
+          "expr": "angry",
+          "seed": 103
+        },
+        "mouth": {
+          "kind": "fang_grin",
+          "width": 22,
+          "height": 12,
+          "seed": 104
+        },
         "limbs": [
-          { "kind": "stub_arm", "length": 28, "width": 8, "side": "left",  "seed": 105 },
-          { "kind": "stub_arm", "length": 28, "width": 8, "side": "right", "seed": 106 }
+          {
+            "kind": "stub_arm",
+            "length": 28,
+            "width": 8,
+            "side": "left",
+            "seed": 105
+          },
+          {
+            "kind": "stub_arm",
+            "length": 28,
+            "width": 8,
+            "side": "right",
+            "seed": 106
+          }
         ],
         "horns": null,
-        "tail":  null
+        "tail": null
       },
       "layout": {
-        "body":  { "ox": 0,   "oy": 4   },
-        "head":  { "ox": 0,   "oy": -52 },
-        "eyes":  { "ox": 0,   "oy": -56 },
-        "mouth": { "ox": 0,   "oy": -40 },
-        "limb0": { "ox": -42, "oy": -2  },
-        "limb1": { "ox":  42, "oy": -2  }
+        "body": {
+          "ox": 0,
+          "oy": 4
+        },
+        "head": {
+          "ox": 0,
+          "oy": -52
+        },
+        "eyes": {
+          "ox": 0,
+          "oy": -56
+        },
+        "mouth": {
+          "ox": 0,
+          "oy": -40
+        },
+        "limb0": {
+          "ox": -42,
+          "oy": -2
+        },
+        "limb1": {
+          "ox": 42,
+          "oy": -2
+        }
       },
-      "anim": { "idle": "bob", "attack": "lunge", "hit": "squash" },
-      "voiceTaunts": ["Tiny wizard! Easy lunch!", "Numbers won't save you!", "Hee hee, you're no match for ME!"],
-      "voiceProfile": { "pitch": 1.1, "rate": 1.1 },
+      "anim": {
+        "idle": "bob",
+        "attack": "lunge",
+        "hit": "squash"
+      },
+      "voiceTaunts": [
+        "Tiny wizard! Easy lunch!",
+        "Numbers won't save you!",
+        "Hee hee, you're no match for ME!"
+      ],
+      "voiceProfile": {
+        "pitch": 1.1,
+        "rate": 1.1
+      },
       "spawnSfx": "goblinGrunt"
     },
     {
       "id": "goblin_runt",
       "name": "Goblin Runt",
       "tier": 1,
-      "hp": 1,
-      "size": [160, 200],
+      "hp": 3,
+      "size": [
+        160,
+        200
+      ],
       "palette": {
-        "body":   "#4a8c3a",
-        "head":   "#5a9c4a",
-        "limbs":  "#3a7c2a",
-        "eyes":   "#ffffff",
+        "body": "#4a8c3a",
+        "head": "#5a9c4a",
+        "limbs": "#3a7c2a",
+        "eyes": "#ffffff",
         "pupils": "#1a1a1a",
-        "mouth":  "#1a1a1a"
+        "mouth": "#1a1a1a"
       },
       "shape": {
-        "body":  { "kind": "blob",       "rx": 32, "ry": 38, "wobble": 8, "seed": 201 },
-        "head":  { "kind": "egg",        "rx": 24, "ry": 28, "tilt": 0.08, "seed": 202 },
-        "eyes":  { "kind": "comic_pair", "size": 11, "expr": "surprised",  "seed": 203 },
-        "mouth": { "kind": "fang_grin",  "width": 16, "height": 10,        "seed": 204 },
+        "body": {
+          "kind": "blob",
+          "rx": 32,
+          "ry": 38,
+          "wobble": 8,
+          "seed": 201
+        },
+        "head": {
+          "kind": "egg",
+          "rx": 24,
+          "ry": 28,
+          "tilt": 0.08,
+          "seed": 202
+        },
+        "eyes": {
+          "kind": "comic_pair",
+          "size": 11,
+          "expr": "surprised",
+          "seed": 203
+        },
+        "mouth": {
+          "kind": "fang_grin",
+          "width": 16,
+          "height": 10,
+          "seed": 204
+        },
         "limbs": [
-          { "kind": "stub_arm", "length": 22, "width": 6, "side": "left",  "seed": 205 },
-          { "kind": "stub_arm", "length": 22, "width": 6, "side": "right", "seed": 206 }
+          {
+            "kind": "stub_arm",
+            "length": 22,
+            "width": 6,
+            "side": "left",
+            "seed": 205
+          },
+          {
+            "kind": "stub_arm",
+            "length": 22,
+            "width": 6,
+            "side": "right",
+            "seed": 206
+          }
         ],
         "horns": null,
-        "tail":  null
+        "tail": null
       },
       "layout": {
-        "body":  { "ox": 0,   "oy": 6   },
-        "head":  { "ox": 0,   "oy": -42 },
-        "eyes":  { "ox": 0,   "oy": -46 },
-        "mouth": { "ox": 0,   "oy": -32 },
-        "limb0": { "ox": -34, "oy": 0   },
-        "limb1": { "ox":  34, "oy": 0   }
+        "body": {
+          "ox": 0,
+          "oy": 6
+        },
+        "head": {
+          "ox": 0,
+          "oy": -42
+        },
+        "eyes": {
+          "ox": 0,
+          "oy": -46
+        },
+        "mouth": {
+          "ox": 0,
+          "oy": -32
+        },
+        "limb0": {
+          "ox": -34,
+          "oy": 0
+        },
+        "limb1": {
+          "ox": 34,
+          "oy": 0
+        }
       },
-      "anim": { "idle": "tremble", "attack": "dart", "hit": "spin" },
-      "voiceTaunts": ["D-don't hurt me! I'm just the runt!", "I'm too quick for you!", "Eep! Don't look at me!"],
-      "voiceProfile": { "pitch": 1.4, "rate": 1.2 },
+      "anim": {
+        "idle": "tremble",
+        "attack": "dart",
+        "hit": "spin"
+      },
+      "voiceTaunts": [
+        "D-don't hurt me! I'm just the runt!",
+        "I'm too quick for you!",
+        "Eep! Don't look at me!"
+      ],
+      "voiceProfile": {
+        "pitch": 1.4,
+        "rate": 1.2
+      },
       "spawnSfx": "goblinSqueak"
     },
     {
       "id": "tree_imp",
       "name": "Tree Imp",
       "tier": 1,
-      "hp": 1,
-      "size": [170, 210],
+      "hp": 3,
+      "size": [
+        170,
+        210
+      ],
       "palette": {
-        "body":   "#5c7a2a",
-        "head":   "#6c8a3a",
-        "limbs":  "#3c5a1a",
-        "eyes":   "#fff4d0",
+        "body": "#5c7a2a",
+        "head": "#6c8a3a",
+        "limbs": "#3c5a1a",
+        "eyes": "#fff4d0",
         "pupils": "#1a1a1a",
-        "mouth":  "#1a1a1a",
-        "horns":  "#8a6a3a"
+        "mouth": "#1a1a1a",
+        "horns": "#8a6a3a"
       },
       "shape": {
-        "body":  { "kind": "blob",       "rx": 36, "ry": 44, "wobble": 5, "seed": 301 },
-        "head":  { "kind": "egg",        "rx": 22, "ry": 26, "tilt": 0.12, "seed": 302 },
-        "eyes":  { "kind": "comic_pair", "size": 12, "expr": "happy",      "seed": 303 },
-        "mouth": { "kind": "fang_grin",  "width": 18, "height": 10,        "seed": 304 },
+        "body": {
+          "kind": "blob",
+          "rx": 36,
+          "ry": 44,
+          "wobble": 5,
+          "seed": 301
+        },
+        "head": {
+          "kind": "egg",
+          "rx": 22,
+          "ry": 26,
+          "tilt": 0.12,
+          "seed": 302
+        },
+        "eyes": {
+          "kind": "comic_pair",
+          "size": 12,
+          "expr": "happy",
+          "seed": 303
+        },
+        "mouth": {
+          "kind": "fang_grin",
+          "width": 18,
+          "height": 10,
+          "seed": 304
+        },
         "limbs": [
-          { "kind": "stub_arm", "length": 30, "width": 6, "side": "left",  "seed": 305 },
-          { "kind": "stub_arm", "length": 30, "width": 6, "side": "right", "seed": 306 }
+          {
+            "kind": "stub_arm",
+            "length": 30,
+            "width": 6,
+            "side": "left",
+            "seed": 305
+          },
+          {
+            "kind": "stub_arm",
+            "length": 30,
+            "width": 6,
+            "side": "right",
+            "seed": 306
+          }
         ],
-        "horns": { "kind": "twig_nubs", "size": 14, "seed": 307 },
-        "tail":  null
+        "horns": {
+          "kind": "twig_nubs",
+          "size": 14,
+          "seed": 307
+        },
+        "tail": null
       },
       "layout": {
-        "body":  { "ox": 0,   "oy": 4   },
-        "head":  { "ox": 0,   "oy": -50 },
-        "eyes":  { "ox": 0,   "oy": -54 },
-        "mouth": { "ox": 0,   "oy": -40 },
-        "horns": { "ox": 0,   "oy": -76 },
-        "limb0": { "ox": -40, "oy": -4  },
-        "limb1": { "ox":  40, "oy": -4  }
+        "body": {
+          "ox": 0,
+          "oy": 4
+        },
+        "head": {
+          "ox": 0,
+          "oy": -50
+        },
+        "eyes": {
+          "ox": 0,
+          "oy": -54
+        },
+        "mouth": {
+          "ox": 0,
+          "oy": -40
+        },
+        "horns": {
+          "ox": 0,
+          "oy": -76
+        },
+        "limb0": {
+          "ox": -40,
+          "oy": -4
+        },
+        "limb1": {
+          "ox": 40,
+          "oy": -4
+        }
       },
-      "anim": { "idle": "sway", "attack": "swipe", "hit": "wobble" },
-      "voiceTaunts": ["You'll never solve that in the forest!", "My roots go deeper than your spell!", "Multiply THIS, little mage!"],
-      "voiceProfile": { "pitch": 0.95, "rate": 0.9 },
+      "anim": {
+        "idle": "sway",
+        "attack": "swipe",
+        "hit": "wobble"
+      },
+      "voiceTaunts": [
+        "You'll never solve that in the forest!",
+        "My roots go deeper than your spell!",
+        "Multiply THIS, little mage!"
+      ],
+      "voiceProfile": {
+        "pitch": 0.95,
+        "rate": 0.9
+      },
       "spawnSfx": "creakBranch"
     },
     {
       "id": "fungal_creep",
       "name": "Fungal Creep",
       "tier": 1,
-      "hp": 1,
-      "size": [200, 200],
+      "hp": 4,
+      "size": [
+        200,
+        200
+      ],
       "palette": {
-        "body":   "#8a6b3a",
-        "head":   "#d4a0d0",
-        "limbs":  "#5a3b1a",
-        "eyes":   "#ffffff",
+        "body": "#8a6b3a",
+        "head": "#d4a0d0",
+        "limbs": "#5a3b1a",
+        "eyes": "#ffffff",
         "pupils": "#3a1a3a",
-        "mouth":  "#3a1a3a"
+        "mouth": "#3a1a3a"
       },
       "shape": {
-        "body":  { "kind": "blob", "rx": 50, "ry": 40, "wobble": 4, "seed": 401 },
-        "head":  { "kind": "egg",  "rx": 32, "ry": 22, "tilt": 0.02, "seed": 402 },
-        "eyes":  { "kind": "comic_pair", "size": 10, "expr": "neutral",   "seed": 403 },
-        "mouth": { "kind": "fang_grin",  "width": 18, "height": 8,        "seed": 404 },
+        "body": {
+          "kind": "blob",
+          "rx": 50,
+          "ry": 40,
+          "wobble": 4,
+          "seed": 401
+        },
+        "head": {
+          "kind": "egg",
+          "rx": 32,
+          "ry": 22,
+          "tilt": 0.02,
+          "seed": 402
+        },
+        "eyes": {
+          "kind": "comic_pair",
+          "size": 10,
+          "expr": "neutral",
+          "seed": 403
+        },
+        "mouth": {
+          "kind": "fang_grin",
+          "width": 18,
+          "height": 8,
+          "seed": 404
+        },
         "limbs": [
-          { "kind": "stub_arm", "length": 24, "width": 8, "side": "left",  "seed": 405 },
-          { "kind": "stub_arm", "length": 24, "width": 8, "side": "right", "seed": 406 }
+          {
+            "kind": "stub_arm",
+            "length": 24,
+            "width": 8,
+            "side": "left",
+            "seed": 405
+          },
+          {
+            "kind": "stub_arm",
+            "length": 24,
+            "width": 8,
+            "side": "right",
+            "seed": 406
+          }
         ],
         "horns": null,
-        "tail":  null
+        "tail": null
       },
       "layout": {
-        "body":  { "ox": 0,   "oy": 10 },
-        "head":  { "ox": 0,   "oy": -38 },
-        "eyes":  { "ox": 0,   "oy": -42 },
-        "mouth": { "ox": 0,   "oy": -32 },
-        "limb0": { "ox": -50, "oy": 8 },
-        "limb1": { "ox":  50, "oy": 8 }
+        "body": {
+          "ox": 0,
+          "oy": 10
+        },
+        "head": {
+          "ox": 0,
+          "oy": -38
+        },
+        "eyes": {
+          "ox": 0,
+          "oy": -42
+        },
+        "mouth": {
+          "ox": 0,
+          "oy": -32
+        },
+        "limb0": {
+          "ox": -50,
+          "oy": 8
+        },
+        "limb1": {
+          "ox": 50,
+          "oy": 8
+        }
       },
-      "anim": { "idle": "pulse", "attack": "spore_burst", "hit": "deflate" },
-      "voiceTaunts": ["My spores cloud your mind!", "Numbers? I count mushrooms.", "Your spell smells wrong!"],
-      "voiceProfile": { "pitch": 0.8, "rate": 0.8 },
+      "anim": {
+        "idle": "pulse",
+        "attack": "spore_burst",
+        "hit": "deflate"
+      },
+      "voiceTaunts": [
+        "My spores cloud your mind!",
+        "Numbers? I count mushrooms.",
+        "Your spell smells wrong!"
+      ],
+      "voiceProfile": {
+        "pitch": 0.8,
+        "rate": 0.8
+      },
       "spawnSfx": "sporeCloud"
     },
     {
       "id": "goblin_brute",
       "name": "Goblin Brute",
       "tier": 1,
-      "hp": 2,
-      "size": [220, 260],
+      "hp": 5,
+      "size": [
+        220,
+        260
+      ],
       "palette": {
-        "body":   "#2a5b1c",
-        "head":   "#3a6b2c",
-        "limbs":  "#1a4b0c",
-        "eyes":   "#ffe080",
+        "body": "#2a5b1c",
+        "head": "#3a6b2c",
+        "limbs": "#1a4b0c",
+        "eyes": "#ffe080",
         "pupils": "#1a1a1a",
-        "mouth":  "#1a1a1a",
-        "horns":  "#a07028"
+        "mouth": "#1a1a1a",
+        "horns": "#a07028"
       },
       "shape": {
-        "body":  { "kind": "blob",       "rx": 54, "ry": 60, "wobble": 7, "seed": 501 },
-        "head":  { "kind": "egg",        "rx": 32, "ry": 36, "tilt": -0.08, "seed": 502 },
-        "eyes":  { "kind": "comic_pair", "size": 14, "expr": "angry",       "seed": 503 },
-        "mouth": { "kind": "fang_grin",  "width": 28, "height": 16,         "seed": 504 },
+        "body": {
+          "kind": "blob",
+          "rx": 54,
+          "ry": 60,
+          "wobble": 7,
+          "seed": 501
+        },
+        "head": {
+          "kind": "egg",
+          "rx": 32,
+          "ry": 36,
+          "tilt": -0.08,
+          "seed": 502
+        },
+        "eyes": {
+          "kind": "comic_pair",
+          "size": 14,
+          "expr": "angry",
+          "seed": 503
+        },
+        "mouth": {
+          "kind": "fang_grin",
+          "width": 28,
+          "height": 16,
+          "seed": 504
+        },
         "limbs": [
-          { "kind": "stub_arm", "length": 36, "width": 12, "side": "left",  "seed": 505 },
-          { "kind": "stub_arm", "length": 36, "width": 12, "side": "right", "seed": 506 }
+          {
+            "kind": "stub_arm",
+            "length": 36,
+            "width": 12,
+            "side": "left",
+            "seed": 505
+          },
+          {
+            "kind": "stub_arm",
+            "length": 36,
+            "width": 12,
+            "side": "right",
+            "seed": 506
+          }
         ],
-        "horns": { "kind": "twig_nubs", "size": 18, "seed": 507 },
-        "tail":  null
+        "horns": {
+          "kind": "twig_nubs",
+          "size": 18,
+          "seed": 507
+        },
+        "tail": null
       },
       "layout": {
-        "body":  { "ox": 0,   "oy": 6   },
-        "head":  { "ox": 0,   "oy": -68 },
-        "eyes":  { "ox": 0,   "oy": -72 },
-        "mouth": { "ox": 0,   "oy": -54 },
-        "horns": { "ox": 0,   "oy": -100 },
-        "limb0": { "ox": -58, "oy": -6  },
-        "limb1": { "ox":  58, "oy": -6  }
+        "body": {
+          "ox": 0,
+          "oy": 6
+        },
+        "head": {
+          "ox": 0,
+          "oy": -68
+        },
+        "eyes": {
+          "ox": 0,
+          "oy": -72
+        },
+        "mouth": {
+          "ox": 0,
+          "oy": -54
+        },
+        "horns": {
+          "ox": 0,
+          "oy": -100
+        },
+        "limb0": {
+          "ox": -58,
+          "oy": -6
+        },
+        "limb1": {
+          "ox": 58,
+          "oy": -6
+        }
       },
-      "anim": { "idle": "menacing_breath", "attack": "club_swing", "hit": "stagger" },
-      "voiceTaunts": ["BRUTE SMASH!", "Wizard go SPLAT!", "Big fists, little wizard!"],
-      "voiceProfile": { "pitch": 0.7, "rate": 0.85 },
+      "anim": {
+        "idle": "menacing_breath",
+        "attack": "club_swing",
+        "hit": "stagger"
+      },
+      "voiceTaunts": [
+        "BRUTE SMASH!",
+        "Wizard go SPLAT!",
+        "Big fists, little wizard!"
+      ],
+      "voiceProfile": {
+        "pitch": 0.7,
+        "rate": 0.85
+      },
       "spawnSfx": "goblinRoar"
     },
     {
       "id": "gem_sprite",
       "name": "Gem Sprite",
       "tier": 2,
-      "hp": 1,
-      "size": [160, 200],
+      "hp": 3,
+      "size": [
+        160,
+        200
+      ],
       "palette": {
-        "body":   "#7070cc",
-        "head":   "#8080dc",
-        "limbs":  "#4040aa",
-        "eyes":   "#eeeeff",
+        "body": "#7070cc",
+        "head": "#8080dc",
+        "limbs": "#4040aa",
+        "eyes": "#eeeeff",
         "pupils": "#1a1a3a",
-        "mouth":  "#1a1a3a",
-        "horns":  "#bbbbff"
+        "mouth": "#1a1a3a",
+        "horns": "#bbbbff"
       },
       "shape": {
-        "body":  { "kind": "blob",       "rx": 34, "ry": 40, "wobble": 3, "seed": 601 },
-        "head":  { "kind": "egg",        "rx": 22, "ry": 26, "tilt": -0.1, "seed": 602 },
-        "eyes":  { "kind": "comic_pair", "size": 12, "expr": "neutral",    "seed": 603 },
-        "mouth": { "kind": "fang_grin",  "width": 14, "height": 6,         "seed": 604 },
+        "body": {
+          "kind": "blob",
+          "rx": 34,
+          "ry": 40,
+          "wobble": 3,
+          "seed": 601
+        },
+        "head": {
+          "kind": "egg",
+          "rx": 22,
+          "ry": 26,
+          "tilt": -0.1,
+          "seed": 602
+        },
+        "eyes": {
+          "kind": "comic_pair",
+          "size": 12,
+          "expr": "neutral",
+          "seed": 603
+        },
+        "mouth": {
+          "kind": "fang_grin",
+          "width": 14,
+          "height": 6,
+          "seed": 604
+        },
         "limbs": [
-          { "kind": "stub_arm", "length": 24, "width": 6, "side": "left",  "seed": 605 },
-          { "kind": "stub_arm", "length": 24, "width": 6, "side": "right", "seed": 606 }
+          {
+            "kind": "stub_arm",
+            "length": 24,
+            "width": 6,
+            "side": "left",
+            "seed": 605
+          },
+          {
+            "kind": "stub_arm",
+            "length": 24,
+            "width": 6,
+            "side": "right",
+            "seed": 606
+          }
         ],
-        "horns": { "kind": "twig_nubs", "size": 16, "seed": 607 },
-        "tail":  null
+        "horns": {
+          "kind": "twig_nubs",
+          "size": 16,
+          "seed": 607
+        },
+        "tail": null
       },
       "layout": {
-        "body":  { "ox": 0,   "oy": 6   },
-        "head":  { "ox": 0,   "oy": -48 },
-        "eyes":  { "ox": 0,   "oy": -52 },
-        "mouth": { "ox": 0,   "oy": -38 },
-        "horns": { "ox": 0,   "oy": -76 },
-        "limb0": { "ox": -36, "oy": -2  },
-        "limb1": { "ox":  36, "oy": -2  }
+        "body": {
+          "ox": 0,
+          "oy": 6
+        },
+        "head": {
+          "ox": 0,
+          "oy": -48
+        },
+        "eyes": {
+          "ox": 0,
+          "oy": -52
+        },
+        "mouth": {
+          "ox": 0,
+          "oy": -38
+        },
+        "horns": {
+          "ox": 0,
+          "oy": -76
+        },
+        "limb0": {
+          "ox": -36,
+          "oy": -2
+        },
+        "limb1": {
+          "ox": 36,
+          "oy": -2
+        }
       },
-      "anim": { "idle": "float", "attack": "shard_throw", "hit": "crack" },
-      "voiceTaunts": ["Your arithmetic is cloudy.", "Refract THAT, wizard.", "Your formula is shattered!"],
-      "voiceProfile": { "pitch": 1.05, "rate": 0.95 },
+      "anim": {
+        "idle": "float",
+        "attack": "shard_throw",
+        "hit": "crack"
+      },
+      "voiceTaunts": [
+        "Your arithmetic is cloudy.",
+        "Refract THAT, wizard.",
+        "Your formula is shattered!"
+      ],
+      "voiceProfile": {
+        "pitch": 1.05,
+        "rate": 0.95
+      },
       "spawnSfx": "crystalChime"
     },
     {
       "id": "ember_imp",
       "name": "Ember Imp",
       "tier": 3,
-      "hp": 1,
-      "size": [170, 210],
+      "hp": 3,
+      "size": [
+        170,
+        210
+      ],
       "palette": {
-        "body":   "#cc4422",
-        "head":   "#dd5533",
-        "limbs":  "#882200",
-        "eyes":   "#ffee80",
+        "body": "#cc4422",
+        "head": "#dd5533",
+        "limbs": "#882200",
+        "eyes": "#ffee80",
         "pupils": "#3a0000",
-        "mouth":  "#3a0000",
-        "horns":  "#3a0000"
+        "mouth": "#3a0000",
+        "horns": "#3a0000"
       },
       "shape": {
-        "body":  { "kind": "blob",       "rx": 36, "ry": 44, "wobble": 7, "seed": 701 },
-        "head":  { "kind": "egg",        "rx": 24, "ry": 28, "tilt": -0.08, "seed": 702 },
-        "eyes":  { "kind": "comic_pair", "size": 13, "expr": "angry",       "seed": 703 },
-        "mouth": { "kind": "fang_grin",  "width": 20, "height": 12,         "seed": 704 },
+        "body": {
+          "kind": "blob",
+          "rx": 36,
+          "ry": 44,
+          "wobble": 7,
+          "seed": 701
+        },
+        "head": {
+          "kind": "egg",
+          "rx": 24,
+          "ry": 28,
+          "tilt": -0.08,
+          "seed": 702
+        },
+        "eyes": {
+          "kind": "comic_pair",
+          "size": 13,
+          "expr": "angry",
+          "seed": 703
+        },
+        "mouth": {
+          "kind": "fang_grin",
+          "width": 20,
+          "height": 12,
+          "seed": 704
+        },
         "limbs": [
-          { "kind": "stub_arm", "length": 28, "width": 7, "side": "left",  "seed": 705 },
-          { "kind": "stub_arm", "length": 28, "width": 7, "side": "right", "seed": 706 }
+          {
+            "kind": "stub_arm",
+            "length": 28,
+            "width": 7,
+            "side": "left",
+            "seed": 705
+          },
+          {
+            "kind": "stub_arm",
+            "length": 28,
+            "width": 7,
+            "side": "right",
+            "seed": 706
+          }
         ],
-        "horns": { "kind": "twig_nubs", "size": 16, "seed": 707 },
-        "tail":  { "kind": "tail", "length": 38, "segments": 4, "seed": 708 }
+        "horns": {
+          "kind": "twig_nubs",
+          "size": 16,
+          "seed": 707
+        },
+        "tail": {
+          "kind": "tail",
+          "length": 38,
+          "segments": 4,
+          "seed": 708
+        }
       },
       "layout": {
-        "body":  { "ox": 0,   "oy": 6   },
-        "head":  { "ox": 0,   "oy": -52 },
-        "eyes":  { "ox": 0,   "oy": -56 },
-        "mouth": { "ox": 0,   "oy": -42 },
-        "horns": { "ox": 0,   "oy": -82 },
-        "limb0": { "ox": -42, "oy": -2  },
-        "limb1": { "ox":  42, "oy": -2  },
-        "tail":  { "ox": 30,  "oy": 30  }
+        "body": {
+          "ox": 0,
+          "oy": 6
+        },
+        "head": {
+          "ox": 0,
+          "oy": -52
+        },
+        "eyes": {
+          "ox": 0,
+          "oy": -56
+        },
+        "mouth": {
+          "ox": 0,
+          "oy": -42
+        },
+        "horns": {
+          "ox": 0,
+          "oy": -82
+        },
+        "limb0": {
+          "ox": -42,
+          "oy": -2
+        },
+        "limb1": {
+          "ox": 42,
+          "oy": -2
+        },
+        "tail": {
+          "ox": 30,
+          "oy": 30
+        }
       },
-      "anim": { "idle": "flicker", "attack": "fire_swipe", "hit": "smoke_puff" },
-      "voiceTaunts": ["Your numbers burn like paper!", "Too slow — I'm already on fire!", "Math? I prefer scorched earth!"],
-      "voiceProfile": { "pitch": 1.15, "rate": 1.05 },
+      "anim": {
+        "idle": "flicker",
+        "attack": "fire_swipe",
+        "hit": "smoke_puff"
+      },
+      "voiceTaunts": [
+        "Your numbers burn like paper!",
+        "Too slow \u2014 I'm already on fire!",
+        "Math? I prefer scorched earth!"
+      ],
+      "voiceProfile": {
+        "pitch": 1.15,
+        "rate": 1.05
+      },
       "spawnSfx": "emberCrackle"
     }
   ]

--- a/claudes-math-marauder/index.html
+++ b/claudes-math-marauder/index.html
@@ -84,13 +84,18 @@
   <script src="js/combat/fight.js" defer></script>
   <script src="js/combat/bossFight.js" defer></script>
   <script src="js/combat/orbs.js" defer></script>
-  <script src="js/combat/bossFight.js" defer></script>
   <script src="js/ui/hud.js" defer></script>
   <script src="js/ui/hub.js" defer></script>
   <!-- Audio + Settings (Session 8) -->
   <script src="js/audio/sfx.js" defer></script>
   <script src="js/audio/speech.js" defer></script>
   <script src="js/ui/settings.js" defer></script>
+  <!-- Run map system (Session 9) -->
+  <script src="js/run/mapGen.js" defer></script>
+  <script src="js/run/runtime.js" defer></script>
+  <script src="js/run/mapScreen.js" defer></script>
+  <script src="js/run/events.js" defer></script>
+  <script src="js/run/shop.js" defer></script>
   <!-- Game orchestration -->
   <script src="js/game.js" defer></script>
 </body>

--- a/claudes-math-marauder/js/game.js
+++ b/claudes-math-marauder/js/game.js
@@ -106,6 +106,12 @@ class Game {
     this._orbsRenderer = null;
     this._hud = null;
 
+    // Run-map state — set when a run is active
+    this._currentMap = null;
+    this._currentActiveRun = null;
+    this._currentNodeId = null;
+    this._currentNode = null;
+
     // Demo-mode state
     this._demo = null;
 
@@ -132,7 +138,13 @@ class Game {
     window.sfx = new SfxBank();
     window.settingsPanel = new SettingsPanel();
 
-    // Hub screen — stub for session 9 run-map replacement
+    // Run-map system
+    window.runtime = new Runtime();
+    window.mapScreen = new MapScreen();
+    window.eventResolver = new EventResolver();
+    window.spellShop = new SpellShop();
+
+    // Hub screen
     window.hubScreen = new HubScreen();
 
     // Apply persisted settings immediately
@@ -159,18 +171,27 @@ class Game {
     if (params.get('demo') === '1') {
       this._initDemo();
       this.setState(STATE.DEMO);
+      return;
     }
 
     // Boot into a fight directly if ?fight=<monsterId>
     const fightParam = params.get('fight');
     if (fightParam) {
       this._launchDebugFight(fightParam, params.get('ultimate') === '1');
+      return;
     }
 
     // Boot directly into a boss fight if ?boss=<bossId>
     const bossParam = params.get('boss');
     if (bossParam) {
       this._launchDebugBoss(bossParam);
+      return;
+    }
+
+    // Resume an active run if one was saved mid-session.
+    const savedData = this._save;
+    if (savedData.activeRun) {
+      this._resumeActiveRun(savedData.activeRun);
     }
   }
 
@@ -261,6 +282,14 @@ class Game {
     if (this.state === STATE.HUB && window.hubScreen) {
       window.hubScreen.show();
     }
+    if (this.state === STATE.RUN_MAP && window.mapScreen && this._currentMap && this._currentActiveRun) {
+      window.mapScreen.show(
+        this._currentMap,
+        this._currentActiveRun,
+        window.runtime,
+        (nodeId, node) => this._onNodeSelected(nodeId, node)
+      );
+    }
   }
 
   // ── Settings integration ──────────────────────────────────────────────────────
@@ -336,7 +365,7 @@ class Game {
     this._exitFight();
     opts = opts || {};
 
-    const rng = mulberry32((Date.now() ^ (monster.id.charCodeAt(0) * 31)) | 0);
+    const rng = mulberry32(((Date.now() + Math.floor(Math.random() * 0x10000)) ^ (monster.id.charCodeAt(0) * 31)) | 0);
 
     const hudRoot = document.getElementById('hud-root');
     this._hud = new HUD(hudRoot);
@@ -366,7 +395,7 @@ class Game {
   _startBossFight(boss, realm, masteryMap) {
     this._exitFight();
 
-    const rng = mulberry32((Date.now() ^ (boss.id.charCodeAt(0) * 31)) | 0);
+    const rng = mulberry32(((Date.now() + Math.floor(Math.random() * 0x10000)) ^ (boss.id.charCodeAt(0) * 31)) | 0);
 
     const hudRoot = document.getElementById('hud-root');
     this._hud = new HUD(hudRoot);
@@ -409,7 +438,151 @@ class Game {
   _onFightComplete(result) {
     console.log('[Game] Fight complete:', result);
     this._exitFight();
-    this.setState(STATE.HUB);
+    const activeRun = window.runtime ? window.runtime.resume() : null;
+    if (activeRun && this._currentNodeId) {
+      this._onRunFightComplete(result, this._currentNodeId);
+    } else {
+      this.setState(STATE.HUB);
+    }
+  }
+
+  // ── Run-map system ────────────────────────────────────────────────────────────
+
+  async _startRun(realmId) {
+    try {
+      await window.runtime.loadData();
+      const realm = window.runtime.getRealmById(realmId);
+      if (!realm) { console.error('[Game] Realm not found:', realmId); return; }
+      const { run, map } = window.runtime.startRun(realm);
+      this._currentMap = map;
+      this._currentActiveRun = run;
+      this._currentNodeId = null;
+      this._currentNode = null;
+      this.setState(STATE.RUN_MAP);
+    } catch (err) {
+      console.error('[Game] _startRun failed:', err);
+    }
+  }
+
+  async _resumeActiveRun(activeRun) {
+    try {
+      await window.runtime.loadData();
+      const map = window.runtime.buildMap(activeRun);
+      if (!map) { window.runtime.abandonRun(); return; }
+      this._currentMap = map;
+      this._currentActiveRun = activeRun;
+      this._currentNodeId = null;
+      this._currentNode = null;
+      this.setState(STATE.RUN_MAP);
+    } catch (err) {
+      console.error('[Game] _resumeActiveRun failed:', err);
+    }
+  }
+
+  _onNodeSelected(nodeId, node) {
+    this._currentNodeId = nodeId;
+    this._currentNode = node;
+    window.runtime.advanceTo(nodeId);
+
+    const kind = node.kind;
+    if (kind === 'combat' || kind === 'elite' || kind === 'boss') {
+      this._launchRunFight(node);
+    } else if (kind === 'mystery') {
+      this._launchEvent(nodeId, node);
+    } else if (kind === 'spellshop') {
+      this._launchShop(nodeId, node);
+    } else if (kind === 'rest') {
+      this._resolveRestNode(nodeId, node);
+    } else {
+      // Unknown node kind — complete it immediately and return to map.
+      this._returnToRunMap(nodeId, null);
+    }
+  }
+
+  _launchRunFight(node) {
+    const run = window.runtime.resume();
+    const realm = window.runtime.getRealmById(run ? run.realmId : null);
+    const data = SaveManager.load();
+    const allowStretch = data.settings.allowStretchFacts !== false;
+
+    if (node.kind === 'boss') {
+      const boss = window.runtime.getRealmBoss(realm);
+      if (!boss || !realm) { this._returnToRunMap(node.id, null); return; }
+      this._startBossFight(boss, realm, data.mastery);
+    } else {
+      // Pick a random monster from the pool using the node id as seed offset.
+      const monsters = window.runtime.getMonstersForRealm(realm);
+      if (!monsters.length || !realm) { this._returnToRunMap(node.id, null); return; }
+      const pickSeed = (hashString(node.id) ^ (run ? run.seed : 0)) & 0x7fffffff;
+      const pickRng = mulberry32(pickSeed);
+      const monster = monsters[Math.floor(pickRng() * monsters.length)];
+      const opts = node.kind === 'elite' ? { startCharged: false } : {};
+      this._startFight(monster, realm, data.mastery, allowStretch, opts);
+    }
+  }
+
+  _launchEvent(nodeId, node) {
+    const events = window.runtime.getEvents();
+    if (!events.length) { this._returnToRunMap(nodeId, null); return; }
+    const pickSeed = (hashString(nodeId) ^ (window.runtime.resume() || { seed: 0 }).seed) & 0x7fffffff;
+    const pickRng = mulberry32(pickSeed);
+    const event = events[Math.floor(pickRng() * events.length)];
+
+    window.eventResolver.open(event, window.runtime, (resolved) => {
+      this._returnToRunMap(nodeId, null);
+    });
+  }
+
+  _launchShop(nodeId, node) {
+    window.spellShop.open(nodeId, window.runtime, (resolved) => {
+      this._returnToRunMap(nodeId, null);
+    });
+  }
+
+  _resolveRestNode(nodeId, node) {
+    // Flavor only in B3 — show a toast then return to map.
+    if (window.showToast) showToast('You rest at the campfire. The forest is quiet.', 2500);
+    this._returnToRunMap(nodeId, null);
+  }
+
+  _returnToRunMap(nodeId, outcome) {
+    const updatedRun = window.runtime.completeNode(nodeId, outcome);
+    if (!updatedRun) { this.setState(STATE.HUB); return; }
+    this._currentActiveRun = updatedRun;
+    const newMap = window.runtime.buildMap(updatedRun);
+    if (!newMap) { this.setState(STATE.HUB); return; }
+    this._currentMap = newMap;
+    this._currentNodeId = null;
+    this._currentNode = null;
+    this.setState(STATE.RUN_MAP);
+  }
+
+  _onRunFightComplete(result, nodeId) {
+    const node = this._currentNode;
+    const isBoss = node && node.kind === 'boss';
+    // Award random 5-15 gold per fight (not in combat module — game.js is UI orchestration).
+    const goldEarned = 5 + Math.floor(Math.random() * 11);
+    const outcome = {
+      goldDelta: goldEarned,
+      retries: result.retries || 0,
+      score: result.score || 0,
+    };
+
+    if (isBoss) {
+      // Complete the boss node first so mapNodes is current.
+      window.runtime.completeNode(nodeId, outcome);
+      const finalResult = window.runtime.finishRun({ outcome: result.outcome, score: result.score });
+      this._currentMap = null;
+      this._currentActiveRun = null;
+      this._currentNodeId = null;
+      this._currentNode = null;
+      this.setState(STATE.HUB);
+      const stars = finalResult ? finalResult.stars : 1;
+      const goldMsg = finalResult ? finalResult.gold + ' gold earned' : '';
+      if (window.showToast) showToast('Run complete! ' + '⭐'.repeat(stars) + (goldMsg ? ' · ' + goldMsg : ''), 4000);
+    } else {
+      this._returnToRunMap(nodeId, outcome);
+    }
   }
 
   _onPointerDown(e) {

--- a/claudes-math-marauder/js/run/events.js
+++ b/claudes-math-marauder/js/run/events.js
@@ -1,0 +1,172 @@
+(function(global) {
+  'use strict';
+
+  class EventResolver {
+    constructor() {
+      this._overlay = null;
+      this._opener = null;
+      this._onComplete = null;
+      this._runtime = null;
+      this._keydownHandler = null;
+    }
+
+    open(event, runtime, onComplete) {
+      this._runtime = runtime;
+      this._onComplete = onComplete;
+      this._opener = document.activeElement;
+      this._render(event);
+    }
+
+    // ── Private ───────────────────────────────────────────────────────────────
+
+    _render(event) {
+      const overlay = document.createElement('div');
+      overlay.className = 'overlay event-overlay';
+      overlay.setAttribute('role', 'dialog');
+      overlay.setAttribute('aria-modal', 'true');
+      overlay.setAttribute('aria-label', 'Mystery Event');
+      overlay.setAttribute('aria-hidden', 'true');
+
+      const panel = document.createElement('div');
+      panel.className = 'panel event-panel';
+
+      // Close button — first focusable element per CLAUDE.md
+      const closeBtn = document.createElement('button');
+      closeBtn.className = 'secondary overlay-close-btn';
+      closeBtn.setAttribute('aria-label', 'Skip this event');
+      closeBtn.textContent = '✕';
+      closeBtn.addEventListener('click', () => this._close(false));
+      panel.appendChild(closeBtn);
+
+      const iconEl = document.createElement('div');
+      iconEl.className = 'event-icon';
+      iconEl.setAttribute('aria-hidden', 'true');
+      iconEl.textContent = '🔮';
+      panel.appendChild(iconEl);
+
+      const promptEl = document.createElement('p');
+      promptEl.className = 'event-prompt';
+      promptEl.textContent = event.prompt;
+      panel.appendChild(promptEl);
+
+      if (typeof SpeechManager !== 'undefined' && window.speech) {
+        const speakBtn = document.createElement('button');
+        speakBtn.className = 'secondary read-aloud';
+        speakBtn.setAttribute('aria-label', 'Read event aloud');
+        speakBtn.textContent = '🔊';
+        speakBtn.addEventListener('click', () => {
+          if (window.speech) window.speech.speak(event.prompt, { interrupt: true });
+        });
+        panel.appendChild(speakBtn);
+      }
+
+      const choicesEl = document.createElement('div');
+      choicesEl.className = 'event-choices';
+      event.choices.forEach((choice) => {
+        const btn = document.createElement('button');
+        btn.className = 'primary event-choice-btn';
+        btn.textContent = choice.text;
+        btn.addEventListener('click', () => this._choose(event, choice));
+        choicesEl.appendChild(btn);
+      });
+      panel.appendChild(choicesEl);
+
+      overlay.appendChild(panel);
+
+      const root = document.getElementById('overlay-root') || document.body;
+      root.appendChild(overlay);
+      this._overlay = overlay;
+
+      // Open
+      overlay.setAttribute('aria-hidden', 'false');
+      overlay.classList.add('open');
+      closeBtn.focus();
+
+      // Focus trap
+      this._keydownHandler = (e) => this._onKeyDown(e, overlay);
+      overlay.addEventListener('keydown', this._keydownHandler);
+    }
+
+    _onKeyDown(e, overlay) {
+      if (e.key === 'Escape') {
+        if (overlay.classList.contains('open')) this._close(false);
+        return;
+      }
+      if (e.key === 'Tab') {
+        const focusables = Array.from(overlay.querySelectorAll('button:not([disabled])'));
+        if (!focusables.length) return;
+        const first = focusables[0];
+        const last  = focusables[focusables.length - 1];
+        if (e.shiftKey) {
+          if (document.activeElement === first) { e.preventDefault(); last.focus(); }
+        } else {
+          if (document.activeElement === last)  { e.preventDefault(); first.focus(); }
+        }
+      }
+    }
+
+    _choose(event, choice) {
+      // Apply outcomes
+      (choice.outcomes || []).forEach((outcome) => {
+        switch (outcome.kind) {
+          case 'gold':
+            if (this._runtime) this._runtime.modifyGold(outcome.delta || 0);
+            break;
+          case 'spell': {
+            if (!this._runtime) break;
+            const data = SaveManager.load();
+            const ownedIds = data.ownedSpellIds || [];
+            const available = this._runtime.getSpells().filter(function(s) {
+              return s.rarity === outcome.rarity && !ownedIds.includes(s.id);
+            });
+            if (available.length > 0) {
+              // Use a simple deterministic pick based on event+choice for reproducibility,
+              // but Math.random() is fine here (not a combat module).
+              const pick = available[Math.floor(Math.random() * available.length)];
+              this._runtime.addSpell(pick.id);
+              if (window.showToast) showToast('Gained spell: ' + pick.name + '!', 3000);
+            }
+            break;
+          }
+          // 'heal', 'damage', 'streak_bonus' — flavor only in B3 (no real HP)
+          default:
+            break;
+        }
+      });
+
+      this._close(true);
+    }
+
+    _close(resolved) {
+      if (!this._overlay) return;
+      const overlay = this._overlay;
+      this._overlay = null;
+
+      if (this._keydownHandler) {
+        overlay.removeEventListener('keydown', this._keydownHandler);
+        this._keydownHandler = null;
+      }
+
+      overlay.classList.remove('open');
+      overlay.setAttribute('aria-hidden', 'true');
+
+      // Remove from DOM after transition
+      setTimeout(function() {
+        if (overlay.parentNode) overlay.parentNode.removeChild(overlay);
+      }, 300);
+
+      // Return focus to opener
+      if (this._opener && document.contains(this._opener)) {
+        this._opener.focus();
+      }
+      this._opener = null;
+
+      const cb = this._onComplete;
+      this._onComplete = null;
+      this._runtime = null;
+      if (cb) cb(resolved);
+    }
+  }
+
+  global.EventResolver = EventResolver;
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/claudes-math-marauder/js/run/mapGen.js
+++ b/claudes-math-marauder/js/run/mapGen.js
@@ -1,0 +1,146 @@
+(function(global) {
+  'use strict';
+
+  // Build a deterministic branching map from (seed, realm).
+  // Returns { nodes: Map(id -> nodeRecord), startId, bossId, columns: [[ids], [ids], ...] }
+  // Node record: { id, kind, column, row, edgesOut: [ids], visited: false, completed: false }
+  function generateMap(seed, realm) {
+    const rng = _mulberry32(seed);
+
+    const counts = Object.assign({}, realm.nodeCounts);
+    const pool = [];
+    Object.entries(counts).forEach(function(entry) {
+      const kind = entry[0], n = entry[1];
+      for (let i = 0; i < n; i++) pool.push(kind);
+    });
+
+    // Fisher-Yates with seeded rng
+    for (let i = pool.length - 1; i > 0; i--) {
+      const j = Math.floor(rng() * (i + 1));
+      const tmp = pool[i]; pool[i] = pool[j]; pool[j] = tmp;
+    }
+
+    // 4 middle columns + start + boss
+    const layout = _layoutForRealm(pool.length);
+    const columns = [];
+    columns.push(['start']);
+    let idCounter = 1;
+    const poolCopy = pool.slice();
+    layout.forEach(function(size) {
+      const col = [];
+      for (let i = 0; i < size; i++) {
+        const kind = poolCopy.shift();
+        col.push('n' + idCounter + ':' + kind);
+        idCounter++;
+      }
+      columns.push(col);
+    });
+    columns.push(['boss']);
+
+    // Build nodes Map
+    const nodes = new Map();
+    columns.forEach(function(col, ci) {
+      col.forEach(function(rawId, ri) {
+        const kind = rawId === 'start' ? 'start' : rawId === 'boss' ? 'boss' : rawId.split(':')[1];
+        nodes.set(rawId, {
+          id: rawId, kind: kind, column: ci, row: ri,
+          edgesOut: [], visited: false, completed: false,
+        });
+      });
+    });
+
+    // Connect each column to the next
+    for (let ci = 0; ci < columns.length - 1; ci++) {
+      _connectColumns(columns[ci], columns[ci + 1], nodes, rng);
+    }
+
+    return {
+      nodes: nodes,
+      startId: 'start',
+      bossId: 'boss',
+      columns: columns.map(function(c) { return c.slice(); }),
+    };
+  }
+
+  // Split poolSize across 4 columns; remainder goes to earlier middle columns.
+  function _layoutForRealm(poolSize) {
+    const nCols = 4;
+    const base = Math.floor(poolSize / nCols);
+    const extra = poolSize - base * nCols;
+    const sizes = [];
+    for (let i = 0; i < nCols; i++) sizes.push(base);
+    for (let i = 0; i < extra; i++) sizes[i + 1 < nCols ? i + 1 : i] += 1;
+    return sizes;
+  }
+
+  function _connectColumns(fromCol, toCol, nodes, rng) {
+    // Each fromNode connects to 1-2 toNodes within row ±1.
+    fromCol.forEach(function(fromId, fromRow) {
+      const candidates = toCol.filter(function(_, toRow) {
+        return Math.abs(toRow - fromRow) <= 1;
+      });
+      const nEdges = candidates.length === 1 ? 1 : (rng() < 0.5 ? 1 : 2);
+      const picks = _pickN(candidates, Math.min(nEdges, candidates.length), rng);
+      picks.forEach(function(toId) {
+        const fn = nodes.get(fromId);
+        if (!fn.edgesOut.includes(toId)) fn.edgesOut.push(toId);
+      });
+    });
+
+    // Ensure every toNode has at least one incoming edge.
+    toCol.forEach(function(toId, toRow) {
+      const hasIncoming = fromCol.some(function(fromId) {
+        return nodes.get(fromId).edgesOut.includes(toId);
+      });
+      if (!hasIncoming) {
+        let bestFrom = fromCol[0];
+        let bestDiff = Infinity;
+        fromCol.forEach(function(fromId, fromRow) {
+          const d = Math.abs(toRow - fromRow);
+          if (d < bestDiff) { bestDiff = d; bestFrom = fromId; }
+        });
+        nodes.get(bestFrom).edgesOut.push(toId);
+      }
+    });
+  }
+
+  function _pickN(arr, n, rng) {
+    const copy = arr.slice();
+    for (let i = copy.length - 1; i > 0; i--) {
+      const j = Math.floor(rng() * (i + 1));
+      const tmp = copy[i]; copy[i] = copy[j]; copy[j] = tmp;
+    }
+    return copy.slice(0, n);
+  }
+
+  // Standalone mulberry32 so mapGen works in Node tests without loading rng.js.
+  function _mulberry32(seed) {
+    let s = (seed | 0) >>> 0;
+    return function() {
+      s = (s + 0x6D2B79F5) | 0;
+      let t = Math.imul(s ^ (s >>> 15), 1 | s);
+      t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+      return ((t ^ (t >>> 14)) >>> 0) / 0x100000000;
+    };
+  }
+
+  // BFS reachability check (used by tests + runtime to verify map integrity).
+  function bfsReachable(map, fromId) {
+    const seen = new Set([fromId]);
+    const queue = [fromId];
+    while (queue.length) {
+      const id = queue.shift();
+      const n = map.nodes.get(id);
+      if (!n) continue;
+      for (let i = 0; i < n.edgesOut.length; i++) {
+        const next = n.edgesOut[i];
+        if (!seen.has(next)) { seen.add(next); queue.push(next); }
+      }
+    }
+    return seen;
+  }
+
+  const exp = { generateMap: generateMap, bfsReachable: bfsReachable };
+  if (typeof module !== 'undefined' && module.exports) module.exports = exp;
+  else global.MapGen = exp;
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/claudes-math-marauder/js/run/mapScreen.js
+++ b/claudes-math-marauder/js/run/mapScreen.js
@@ -130,7 +130,12 @@
     _getSelectableIds() {
       const current = this._map.nodes.get(this._activeRun.currentNodeId);
       if (!current) return [];
-      // Selectable = outgoing edges from current completed node.
+      // If the current node isn't completed yet (e.g., browser closed mid-fight),
+      // it remains the node to enter — don't skip past it.
+      if (!current.completed && current.kind !== 'start') {
+        return [current.id];
+      }
+      // Normal case: outgoing edges that haven't been completed yet.
       return current.edgesOut.filter((id) => {
         const n = this._map.nodes.get(id);
         return n && !n.completed;

--- a/claudes-math-marauder/js/run/mapScreen.js
+++ b/claudes-math-marauder/js/run/mapScreen.js
@@ -1,0 +1,230 @@
+(function(global) {
+  'use strict';
+
+  const NODE_ICONS = {
+    start:     '🏠',
+    combat:    '⚔️',
+    elite:     '👹',
+    spellshop: '🛒',
+    mystery:   '🔮',
+    rest:      '💤',
+    boss:      '👑',
+  };
+
+  const NODE_LABELS = {
+    start:     'Start',
+    combat:    'Battle',
+    elite:     'Elite',
+    spellshop: 'Shop',
+    mystery:   'Mystery',
+    rest:      'Rest',
+    boss:      'Boss',
+  };
+
+  class MapScreen {
+    constructor() {
+      this._root = null;
+      this._map = null;
+      this._activeRun = null;
+      this._runtime = null;
+      this._onSelectNode = null;
+      this._goldEl = null;
+    }
+
+    show(map, activeRun, runtime, onSelectNode) {
+      this._map = map;
+      this._activeRun = activeRun;
+      this._runtime = runtime;
+      this._onSelectNode = onSelectNode;
+      this._root = document.getElementById('run-map-screen');
+      if (!this._root) return;
+      this._root.innerHTML = '';
+      this._render();
+    }
+
+    // Refresh gold display and node states after a node resolves.
+    refresh(activeRun) {
+      this._activeRun = activeRun;
+      if (this._goldEl) {
+        const gold = activeRun.goldThisRun || 0;
+        this._goldEl.textContent = gold + ' g';
+        this._goldEl.setAttribute('aria-label', gold + ' gold this run');
+      }
+      // Rebuild the map area to reflect new completed/selectable state.
+      const mapArea = this._root && this._root.querySelector('.run-map-area');
+      if (mapArea) {
+        mapArea.remove();
+        this._root.appendChild(this._buildMapArea());
+      }
+    }
+
+    // ── Private ───────────────────────────────────────────────────────────────
+
+    _render() {
+      this._root.appendChild(this._buildHeader());
+      this._root.appendChild(this._buildMapArea());
+      this._root.appendChild(this._buildFooter());
+    }
+
+    _buildHeader() {
+      const header = document.createElement('header');
+      header.className = 'run-map-header';
+
+      const quitBtn = document.createElement('button');
+      quitBtn.className = 'secondary run-map-quit-btn';
+      quitBtn.setAttribute('aria-label', 'Quit run and return to hub');
+      quitBtn.textContent = '← Quit';
+      quitBtn.addEventListener('click', () => this._onQuit());
+      header.appendChild(quitBtn);
+
+      const realm = this._runtime.getRealmById(this._activeRun.realmId);
+      const realmName = realm ? realm.displayName : 'Run';
+      const h2 = document.createElement('h2');
+      h2.className = 'run-map-realm-name';
+      h2.textContent = realmName;
+      header.appendChild(h2);
+
+      const goldEl = document.createElement('span');
+      const gold = this._activeRun.goldThisRun || 0;
+      goldEl.className = 'run-map-gold';
+      goldEl.textContent = gold + ' g';
+      goldEl.setAttribute('aria-label', gold + ' gold this run');
+      this._goldEl = goldEl;
+      header.appendChild(goldEl);
+
+      return header;
+    }
+
+    _buildMapArea() {
+      const area = document.createElement('div');
+      area.className = 'run-map-area';
+      area.setAttribute('role', 'group');
+      area.setAttribute('aria-label', 'Run map');
+
+      // SVG edge layer (aria-hidden — purely decorative)
+      const svg = this._buildEdgeSvg();
+      area.appendChild(svg);
+
+      // Node buttons
+      const selectableIds = this._getSelectableIds();
+      this._map.columns.forEach((col, ci) => {
+        col.forEach((nodeId, ri) => {
+          const node = this._map.nodes.get(nodeId);
+          if (!node) return;
+          const btn = this._buildNodeButton(node, ci, ri, col.length, selectableIds);
+          area.appendChild(btn);
+        });
+      });
+
+      return area;
+    }
+
+    _buildFooter() {
+      const p = document.createElement('p');
+      p.className = 'run-map-status';
+      const sel = this._getSelectableIds();
+      p.textContent = sel.length > 0 ? 'Choose your next challenge' : 'Run complete!';
+      return p;
+    }
+
+    _getSelectableIds() {
+      const current = this._map.nodes.get(this._activeRun.currentNodeId);
+      if (!current) return [];
+      // Selectable = outgoing edges from current completed node.
+      return current.edgesOut.filter((id) => {
+        const n = this._map.nodes.get(id);
+        return n && !n.completed;
+      });
+    }
+
+    _nodePos(ci, ri, colSize) {
+      // Returns { xPct, yPct } as percentages (0-100) of the map area.
+      const numCols = this._map.columns.length;
+      const xPct = (ci + 0.5) / numCols * 100;
+      const yPct = (ri + 0.5) / colSize * 100;
+      return { xPct: xPct, yPct: yPct };
+    }
+
+    _buildEdgeSvg() {
+      const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+      svg.setAttribute('class', 'run-map-edges');
+      svg.setAttribute('viewBox', '0 0 100 100');
+      svg.setAttribute('preserveAspectRatio', 'none');
+      svg.setAttribute('aria-hidden', 'true');
+
+      const currentId = this._activeRun.currentNodeId;
+
+      this._map.columns.forEach((col, ci) => {
+        col.forEach((nodeId, ri) => {
+          const node = this._map.nodes.get(nodeId);
+          if (!node || node.edgesOut.length === 0) return;
+          const { xPct: x1, yPct: y1 } = this._nodePos(ci, ri, col.length);
+
+          node.edgesOut.forEach((targetId) => {
+            const target = this._map.nodes.get(targetId);
+            if (!target) return;
+            const targetCol = this._map.columns[target.column];
+            const { xPct: x2, yPct: y2 } = this._nodePos(target.column, target.row, targetCol.length);
+
+            const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+            line.setAttribute('x1', x1.toFixed(2));
+            line.setAttribute('y1', y1.toFixed(2));
+            line.setAttribute('x2', x2.toFixed(2));
+            line.setAttribute('y2', y2.toFixed(2));
+            line.setAttribute('class', node.completed ? 'run-map-edge completed' : 'run-map-edge');
+            svg.appendChild(line);
+          });
+        });
+      });
+
+      return svg;
+    }
+
+    _buildNodeButton(node, ci, ri, colSize, selectableIds) {
+      const { xPct, yPct } = this._nodePos(ci, ri, colSize);
+      const isSelectable = selectableIds.includes(node.id);
+      const isCompleted  = node.completed;
+      const isStart      = node.kind === 'start';
+
+      const btn = document.createElement('button');
+      btn.className = 'run-map-node';
+      if (isSelectable)       btn.classList.add('glow');
+      if (isCompleted)        btn.classList.add('completed');
+      if (!isSelectable && !isStart) btn.classList.add('locked');
+
+      // Locked nodes: native disabled (removes from tab order, announces to AT).
+      if (!isSelectable) btn.disabled = true;
+
+      btn.setAttribute('style', 'left:' + xPct.toFixed(2) + '%;top:' + yPct.toFixed(2) + '%;');
+
+      const icon = document.createElement('span');
+      icon.className = 'run-map-node-icon';
+      icon.setAttribute('aria-hidden', 'true');
+      icon.textContent = NODE_ICONS[node.kind] || '?';
+      btn.appendChild(icon);
+
+      const label = document.createElement('span');
+      label.className = 'run-map-node-label';
+      label.textContent = NODE_LABELS[node.kind] || node.kind;
+      btn.appendChild(label);
+
+      const ariaLabel = (NODE_LABELS[node.kind] || node.kind) + ' node' +
+        (isCompleted ? ', completed' : isSelectable ? ', available' : ', locked');
+      btn.setAttribute('aria-label', ariaLabel);
+
+      if (isSelectable) {
+        btn.addEventListener('click', () => this._onSelectNode(node.id, node));
+      }
+
+      return btn;
+    }
+
+    _onQuit() {
+      if (!confirm('Quit this run? Your progress will be lost.')) return;
+      if (this._runtime) this._runtime.abandonRun();
+      if (window.game) window.game.setState('HUB');
+    }
+  }
+
+  global.MapScreen = MapScreen;
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/claudes-math-marauder/js/run/runtime.js
+++ b/claudes-math-marauder/js/run/runtime.js
@@ -1,0 +1,226 @@
+(function(global) {
+  'use strict';
+
+  function _uuid() {
+    return 'run-' + Date.now().toString(36) + '-' + Math.floor(Math.random() * 0xffff).toString(16);
+  }
+
+  function _serializeMapNodes(map) {
+    const obj = {};
+    map.nodes.forEach(function(n, id) {
+      obj[id] = { visited: false, completed: false };
+    });
+    // Start is implicitly completed — it's the origin.
+    obj[map.startId] = { visited: true, completed: true };
+    return obj;
+  }
+
+  class Runtime {
+    constructor() {
+      this._realmsData = null;
+      this._monstersData = null;
+      this._bossesData = null;
+      this._eventsData = null;
+      this._spellsData = null;
+      this._loading = null;
+    }
+
+    // ── Data loading ──────────────────────────────────────────────────────────
+
+    async loadData() {
+      if (this._realmsData) return;
+      if (this._loading) return this._loading;
+      this._loading = Promise.all([
+        fetch('data/realms.json').then(function(r) { return r.json(); }),
+        fetch('data/monsters.json').then(function(r) { return r.json(); }),
+        fetch('data/bosses.json').then(function(r) { return r.json(); }),
+        fetch('data/events.json').then(function(r) { return r.json(); }),
+        fetch('data/spells.json').then(function(r) { return r.json(); }),
+      ]).then((results) => {
+        this._realmsData   = results[0];
+        this._monstersData = results[1];
+        this._bossesData   = results[2];
+        this._eventsData   = results[3];
+        this._spellsData   = results[4];
+        this._loading = null;
+      });
+      return this._loading;
+    }
+
+    // ── Accessors ─────────────────────────────────────────────────────────────
+
+    getRealmById(id) {
+      return this._realmsData ? this._realmsData.realms.find(function(r) { return r.id === id; }) : null;
+    }
+
+    getMonsterById(id) {
+      return this._monstersData ? this._monstersData.monsters.find(function(m) { return m.id === id; }) : null;
+    }
+
+    getMonstersForRealm(realm) {
+      if (!this._monstersData || !realm) return [];
+      const pool = realm.monsterPool || [];
+      return pool.map((id) => this.getMonsterById(id)).filter(Boolean);
+    }
+
+    getBossById(id) {
+      return this._bossesData ? this._bossesData.bosses.find(function(b) { return b.id === id; }) : null;
+    }
+
+    getRealmBoss(realm) {
+      return realm ? this.getBossById(realm.bossId) : null;
+    }
+
+    getEvents() {
+      return this._eventsData ? this._eventsData.events : [];
+    }
+
+    getSpells() {
+      return this._spellsData ? this._spellsData.spells : [];
+    }
+
+    getSpellById(id) {
+      return this._spellsData ? this._spellsData.spells.find(function(s) { return s.id === id; }) : null;
+    }
+
+    // ── Run lifecycle ─────────────────────────────────────────────────────────
+
+    startRun(realm) {
+      const seed = (Date.now() ^ Math.floor(Math.random() * 0x80000000)) & 0x7fffffff;
+      const map = MapGen.generateMap(seed, realm);
+      const data = SaveManager.load();
+      data.activeRun = {
+        runId: _uuid(),
+        realmId: realm.id,
+        classId: data.selectedClassId || 'apprentice',
+        deck: (data.equippedDeck || []).slice(),
+        seed: seed,
+        mapNodes: _serializeMapNodes(map),
+        currentNodeId: map.startId,
+        wizardHpFlavor: 60,
+        streak: 0,
+        score: 0,
+        retries: 0,
+        ultimateCharge: 0,
+        goldThisRun: 0,
+        spellsAddedThisRun: [],
+        factsThisRun: [],
+        startedAt: Date.now(),
+      };
+      data.totalRunsStarted = (data.totalRunsStarted || 0) + 1;
+      SaveManager.save(data);
+      return { run: data.activeRun, map: map };
+    }
+
+    // Rebuild map from seed+realmId and overlay visited/completed from save.
+    buildMap(activeRun) {
+      const realm = this.getRealmById(activeRun.realmId);
+      if (!realm) return null;
+      const map = MapGen.generateMap(activeRun.seed, realm);
+      const saved = activeRun.mapNodes || {};
+      map.nodes.forEach(function(n, id) {
+        const s = saved[id];
+        if (s) { n.visited = s.visited; n.completed = s.completed; }
+      });
+      return map;
+    }
+
+    // Call before entering a node (fight/shop/event/rest).
+    advanceTo(nodeId) {
+      const data = SaveManager.load();
+      if (!data.activeRun) return;
+      data.activeRun.currentNodeId = nodeId;
+      if (!data.activeRun.mapNodes[nodeId]) data.activeRun.mapNodes[nodeId] = {};
+      data.activeRun.mapNodes[nodeId].visited = true;
+      SaveManager.save(data);
+    }
+
+    // Call after successfully completing a node.
+    completeNode(nodeId, outcome) {
+      const data = SaveManager.load();
+      if (!data.activeRun) return;
+      if (!data.activeRun.mapNodes[nodeId]) data.activeRun.mapNodes[nodeId] = {};
+      data.activeRun.mapNodes[nodeId].completed = true;
+      data.activeRun.currentNodeId = nodeId;
+
+      if (outcome) {
+        if (typeof outcome.goldDelta === 'number') {
+          data.activeRun.goldThisRun = Math.max(0, (data.activeRun.goldThisRun || 0) + outcome.goldDelta);
+        }
+        if (outcome.spellId) {
+          const run = data.activeRun;
+          if (!run.spellsAddedThisRun.includes(outcome.spellId)) {
+            run.spellsAddedThisRun.push(outcome.spellId);
+          }
+          if (!data.ownedSpellIds.includes(outcome.spellId)) {
+            data.ownedSpellIds.push(outcome.spellId);
+          }
+        }
+        if (typeof outcome.retries === 'number') {
+          data.activeRun.retries = (data.activeRun.retries || 0) + outcome.retries;
+        }
+        if (typeof outcome.score === 'number') {
+          data.activeRun.score = (data.activeRun.score || 0) + outcome.score;
+        }
+      }
+      SaveManager.save(data);
+      return data.activeRun;
+    }
+
+    // Adjust run gold (events, shop purchases).
+    modifyGold(delta) {
+      const data = SaveManager.load();
+      if (!data.activeRun) return 0;
+      data.activeRun.goldThisRun = Math.max(0, (data.activeRun.goldThisRun || 0) + delta);
+      SaveManager.save(data);
+      return data.activeRun.goldThisRun;
+    }
+
+    addSpell(spellId) {
+      const data = SaveManager.load();
+      if (!data.activeRun) return;
+      if (!data.activeRun.spellsAddedThisRun.includes(spellId)) {
+        data.activeRun.spellsAddedThisRun.push(spellId);
+      }
+      if (!data.ownedSpellIds.includes(spellId)) data.ownedSpellIds.push(spellId);
+      SaveManager.save(data);
+    }
+
+    finishRun(opts) {
+      opts = opts || {};
+      const data = SaveManager.load();
+      if (!data.activeRun) return;
+      const run = data.activeRun;
+
+      data.gold = (data.gold || 0) + (run.goldThisRun || 0);
+
+      const retries = run.retries || 0;
+      const score = run.score || 0;
+      let stars = 1;
+      if (retries === 0) stars = 2;
+      if (retries === 0 && score >= 1000) stars = 3;
+
+      if (!data.realmStars) data.realmStars = {};
+      const prev = data.realmStars[run.realmId] || 0;
+      if (stars > prev) data.realmStars[run.realmId] = stars;
+
+      data.totalRunsCompleted = (data.totalRunsCompleted || 0) + 1;
+      data.activeRun = null;
+      SaveManager.save(data);
+
+      return { stars: stars, gold: run.goldThisRun || 0 };
+    }
+
+    abandonRun() {
+      const data = SaveManager.load();
+      data.activeRun = null;
+      SaveManager.save(data);
+    }
+
+    resume() {
+      return SaveManager.load().activeRun || null;
+    }
+  }
+
+  global.Runtime = Runtime;
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/claudes-math-marauder/js/run/shop.js
+++ b/claudes-math-marauder/js/run/shop.js
@@ -1,0 +1,226 @@
+(function(global) {
+  'use strict';
+
+  const RARITY_COSTS = { common: 25, rare: 60, epic: 100 };
+  const RARITY_TIERS = [
+    ['common'],
+    ['common', 'rare'],
+    ['rare', 'epic'],
+  ];
+
+  class SpellShop {
+    constructor() {
+      this._overlay = null;
+      this._opener = null;
+      this._onComplete = null;
+      this._runtime = null;
+      this._keydownHandler = null;
+    }
+
+    open(nodeId, runtime, onComplete) {
+      this._runtime = runtime;
+      this._onComplete = onComplete;
+      this._opener = document.activeElement;
+
+      const run = runtime.resume();
+      const seed = run ? ((run.seed ^ hashString(nodeId)) & 0x7fffffff) : Date.now();
+      const shopRng = mulberry32(seed);
+
+      const offerings = this._generateOfferings(shopRng, runtime);
+      this._render(offerings);
+    }
+
+    // ── Private ───────────────────────────────────────────────────────────────
+
+    _generateOfferings(rng, runtime) {
+      const data = SaveManager.load();
+      const ownedIds = data.ownedSpellIds || [];
+      const spells = runtime.getSpells();
+      const offerings = [];
+
+      RARITY_TIERS.forEach(function(rarities) {
+        const pool = spells.filter(function(s) {
+          return rarities.includes(s.rarity) && !ownedIds.includes(s.id);
+        });
+        if (pool.length === 0) return;
+        const pick = pool[Math.floor(rng() * pool.length)];
+        const cost = RARITY_COSTS[pick.rarity] || 25;
+        offerings.push({ spell: pick, cost: cost });
+      });
+
+      return offerings;
+    }
+
+    _render(offerings) {
+      const run = this._runtime ? this._runtime.resume() : null;
+      const gold = run ? (run.goldThisRun || 0) : 0;
+
+      const overlay = document.createElement('div');
+      overlay.className = 'overlay shop-overlay';
+      overlay.setAttribute('role', 'dialog');
+      overlay.setAttribute('aria-modal', 'true');
+      overlay.setAttribute('aria-label', 'Spell Shop');
+      overlay.setAttribute('aria-hidden', 'true');
+
+      const panel = document.createElement('div');
+      panel.className = 'panel shop-panel';
+
+      // Close button — first focusable element
+      const closeBtn = document.createElement('button');
+      closeBtn.className = 'secondary overlay-close-btn';
+      closeBtn.setAttribute('aria-label', 'Leave the shop');
+      closeBtn.textContent = '✕';
+      closeBtn.addEventListener('click', () => this._close(true));
+      panel.appendChild(closeBtn);
+
+      const heading = document.createElement('h3');
+      heading.className = 'shop-heading';
+      heading.textContent = '🛒 Spell Shop';
+      panel.appendChild(heading);
+
+      const goldEl = document.createElement('p');
+      goldEl.className = 'shop-gold-display';
+      goldEl.textContent = 'Your gold: ' + gold + ' g';
+      goldEl.setAttribute('aria-live', 'polite');
+      panel.appendChild(goldEl);
+
+      if (offerings.length === 0) {
+        const empty = document.createElement('p');
+        empty.className = 'shop-empty';
+        empty.textContent = 'No new spells available. Check back later!';
+        panel.appendChild(empty);
+      } else {
+        const grid = document.createElement('div');
+        grid.className = 'shop-offerings';
+        offerings.forEach((offering) => {
+          grid.appendChild(this._buildOfferingCard(offering, gold, goldEl));
+        });
+        panel.appendChild(grid);
+      }
+
+      overlay.appendChild(panel);
+
+      const root = document.getElementById('overlay-root') || document.body;
+      root.appendChild(overlay);
+      this._overlay = overlay;
+
+      overlay.setAttribute('aria-hidden', 'false');
+      overlay.classList.add('open');
+      closeBtn.focus();
+
+      this._keydownHandler = (e) => this._onKeyDown(e, overlay);
+      overlay.addEventListener('keydown', this._keydownHandler);
+    }
+
+    _buildOfferingCard(offering, currentGold, goldDisplayEl) {
+      const spell = offering.spell;
+      const cost  = offering.cost;
+
+      const card = document.createElement('div');
+      card.className = 'shop-card rarity-' + spell.rarity;
+
+      const name = document.createElement('h4');
+      name.className = 'shop-card-name';
+      name.textContent = spell.name;
+      card.appendChild(name);
+
+      const rarity = document.createElement('span');
+      rarity.className = 'shop-card-rarity';
+      rarity.textContent = spell.rarity.charAt(0).toUpperCase() + spell.rarity.slice(1);
+      card.appendChild(rarity);
+
+      const costEl = document.createElement('p');
+      costEl.className = 'shop-card-cost';
+      costEl.textContent = cost + ' gold';
+      card.appendChild(costEl);
+
+      const actions = document.createElement('div');
+      actions.className = 'shop-card-actions';
+
+      const buyBtn = document.createElement('button');
+      buyBtn.className = 'primary shop-buy-btn';
+      buyBtn.textContent = 'Buy';
+      buyBtn.setAttribute('aria-label', 'Buy ' + spell.name + ' for ' + cost + ' gold');
+      if (currentGold < cost) buyBtn.disabled = true;
+      buyBtn.addEventListener('click', () => {
+        const newGold = this._runtime.modifyGold(-cost);
+        this._runtime.addSpell(spell.id);
+        buyBtn.disabled = true;
+        buyBtn.textContent = 'Owned';
+        if (goldDisplayEl) {
+          goldDisplayEl.textContent = 'Your gold: ' + newGold + ' g';
+        }
+        if (window.showToast) showToast('Purchased ' + spell.name + '!', 2500);
+        // Disable other cards if gold now insufficient
+        const allBuyBtns = this._overlay ? this._overlay.querySelectorAll('.shop-buy-btn:not([disabled])') : [];
+        const run2 = this._runtime.resume();
+        const g2 = run2 ? run2.goldThisRun : 0;
+        allBuyBtns.forEach(function(b) {
+          const c2 = parseInt(b.getAttribute('data-cost') || '0', 10);
+          if (g2 < c2) b.disabled = true;
+        });
+      });
+      buyBtn.setAttribute('data-cost', cost);
+
+      const skipBtn = document.createElement('button');
+      skipBtn.className = 'secondary shop-skip-btn';
+      skipBtn.textContent = 'Skip';
+      skipBtn.setAttribute('aria-label', 'Skip ' + spell.name);
+      skipBtn.addEventListener('click', () => this._close(true));
+
+      actions.appendChild(buyBtn);
+      actions.appendChild(skipBtn);
+      card.appendChild(actions);
+
+      return card;
+    }
+
+    _onKeyDown(e, overlay) {
+      if (e.key === 'Escape') {
+        if (overlay.classList.contains('open')) this._close(true);
+        return;
+      }
+      if (e.key === 'Tab') {
+        const focusables = Array.from(overlay.querySelectorAll('button:not([disabled]), select:not([disabled])'));
+        if (!focusables.length) return;
+        const first = focusables[0];
+        const last  = focusables[focusables.length - 1];
+        if (e.shiftKey) {
+          if (document.activeElement === first) { e.preventDefault(); last.focus(); }
+        } else {
+          if (document.activeElement === last)  { e.preventDefault(); first.focus(); }
+        }
+      }
+    }
+
+    _close(resolved) {
+      if (!this._overlay) return;
+      const overlay = this._overlay;
+      this._overlay = null;
+
+      if (this._keydownHandler) {
+        overlay.removeEventListener('keydown', this._keydownHandler);
+        this._keydownHandler = null;
+      }
+
+      overlay.classList.remove('open');
+      overlay.setAttribute('aria-hidden', 'true');
+
+      setTimeout(function() {
+        if (overlay.parentNode) overlay.parentNode.removeChild(overlay);
+      }, 300);
+
+      if (this._opener && document.contains(this._opener)) {
+        this._opener.focus();
+      }
+      this._opener = null;
+
+      const cb = this._onComplete;
+      this._onComplete = null;
+      this._runtime = null;
+      if (cb) cb(resolved);
+    }
+  }
+
+  global.SpellShop = SpellShop;
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/claudes-math-marauder/js/ui/hub.js
+++ b/claudes-math-marauder/js/ui/hub.js
@@ -55,6 +55,29 @@
       heading.textContent = "Wizard's Tower";
       this._root.appendChild(heading);
 
+      // Begin Run button — primary CTA
+      const beginRunBtn = document.createElement('button');
+      beginRunBtn.className = 'primary hub-begin-run-btn';
+      beginRunBtn.setAttribute('aria-label', 'Begin a new run of Goblin Forest');
+      beginRunBtn.textContent = '⚔️ Begin Run!';
+      beginRunBtn.addEventListener('click', function() {
+        if (window.game) window.game._startRun('goblin_forest');
+      });
+      this._root.appendChild(beginRunBtn);
+
+      // Resume Run button — only shown when an active run exists
+      const savedData = SaveManager.load();
+      if (savedData.activeRun) {
+        const resumeBtn = document.createElement('button');
+        resumeBtn.className = 'secondary hub-resume-run-btn';
+        resumeBtn.setAttribute('aria-label', 'Resume your current run');
+        resumeBtn.textContent = '↩ Resume Run';
+        resumeBtn.addEventListener('click', function() {
+          if (window.game) window.game._resumeActiveRun(SaveManager.load().activeRun);
+        });
+        this._root.appendChild(resumeBtn);
+      }
+
       const loading = document.createElement('p');
       loading.id = 'hub-loading';
       loading.className = 'hub-loading-text';

--- a/claudes-math-marauder/scripts/test-map-gen.js
+++ b/claudes-math-marauder/scripts/test-map-gen.js
@@ -1,0 +1,72 @@
+'use strict';
+const MG = require('../js/run/mapGen.js');
+const assert = require('assert');
+
+let p = 0, f = 0;
+function it(name, fn) {
+  try { fn(); console.log('PASS', name); p++; }
+  catch (e) { console.error('FAIL', name, e.message); f++; }
+}
+
+const realm1 = { nodeCounts: { combat: 5, elite: 1, spellshop: 1, mystery: 1, rest: 1 } };
+
+it('every map has exactly one start and one boss', function() {
+  for (let s = 1; s <= 50; s++) {
+    const m = MG.generateMap(s, realm1);
+    let starts = 0, bosses = 0;
+    m.nodes.forEach(function(n) { if (n.kind === 'start') starts++; if (n.kind === 'boss') bosses++; });
+    assert.strictEqual(starts, 1, 'seed ' + s + ': expected 1 start');
+    assert.strictEqual(bosses, 1, 'seed ' + s + ': expected 1 boss');
+  }
+});
+
+it('all nodes reachable from start (BFS)', function() {
+  for (let s = 1; s <= 100; s++) {
+    const m = MG.generateMap(s, realm1);
+    const reached = MG.bfsReachable(m, m.startId);
+    assert.strictEqual(reached.size, m.nodes.size,
+      'seed ' + s + ': reached ' + reached.size + ' / total ' + m.nodes.size);
+  }
+});
+
+it('boss reachable from every node', function() {
+  for (let s = 1; s <= 50; s++) {
+    const m = MG.generateMap(s, realm1);
+    m.nodes.forEach(function(n, id) {
+      const reached = MG.bfsReachable(m, id);
+      assert.ok(reached.has(m.bossId), 'seed ' + s + ': ' + id + ' cannot reach boss');
+    });
+  }
+});
+
+it('total node count is 11 for Realm 1 (start + 9 middle + boss)', function() {
+  for (let s = 1; s <= 50; s++) {
+    const m = MG.generateMap(s, realm1);
+    assert.strictEqual(m.nodes.size, 11, 'seed ' + s + ': got ' + m.nodes.size + ' nodes');
+  }
+});
+
+it('determinism: same seed + realm produces identical map', function() {
+  const a = MG.generateMap(42, realm1);
+  const b = MG.generateMap(42, realm1);
+  const sig = function(m) {
+    return JSON.stringify([...m.nodes.entries()].sort().map(function(e) {
+      return [e[0], e[1].edgesOut.slice().sort()];
+    }));
+  };
+  assert.strictEqual(sig(a), sig(b));
+});
+
+it('different seeds produce different maps', function() {
+  const a = MG.generateMap(1, realm1);
+  const b = MG.generateMap(2, realm1);
+  const sig = function(m) {
+    return JSON.stringify([...m.nodes.entries()].sort().map(function(e) {
+      return [e[0], e[1].edgesOut.slice().sort()];
+    }));
+  };
+  assert.notStrictEqual(sig(a), sig(b));
+});
+
+console.log('\n' + p + ' passed, ' + f + ' failed');
+process.exit(f > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary

- **mapGen.js**: Deterministic Slay-the-Spire-style branching map generator (pure, UMD, Node-testable). 6 tests pass covering reachability, determinism, and node counts.
- **runtime.js**: Run lifecycle — `startRun`, `advanceTo`, `completeNode`, `finishRun`, `abandonRun`, `resume`. Mid-run auto-save after every node; deterministic map rebuild from `(seed, realmId)`.
- **mapScreen.js**: DOM map screen with SVG edges, glowing selectable nodes, locked/completed states, Quit button with confirmation.
- **events.js**: Mystery event modal (focus trap + Escape + focus return) with gold/spell/flavor outcomes.
- **shop.js**: Spell shop modal with deterministically seeded offerings per `(run.seed, nodeId)`, buy/skip flow, gold gate on Buy.
- **game.js**: Wires `RUN_MAP` state transitions; `_startRun`, `_resumeActiveRun`, `_onNodeSelected`, `_onRunFightComplete`; boss defeat clears run and returns to HUB with star toast.
- **hub.js**: Begin Run and Resume Run buttons added.

## Bug fixes

- **#40 — Fight ends after one answer / UI messed up**: Removed duplicate `bossFight.js` script tag (was loading twice). Increased monster HP from 1 to 3–5 so fights have multiple questions.
- **#41 — Correct answer always B / same questions each session**: Added `Math.random()` entropy to fight seed (game.js is UI orchestration, not a combat module) so repeated fights against the same monster get a fresh RNG sequence.
- **Resume mid-fight**: If the browser closes during a fight, `advanceTo` is saved but `completeNode` is not. On reload the current node stays selectable so the player can re-enter rather than silently skipping it.

## Test plan

- [x] All 65 Layer-1 tests pass (6 new map-gen tests + 59 existing)
- [ ] Hub shows "Begin Run!" button → clicking starts a Goblin Forest run
- [ ] Map renders with 11 nodes, start node, boss node; glow on first available nodes
- [ ] Click combat node → fight launches with 3–5 questions; win → return to map, node completed
- [ ] All node kinds: combat, elite, spellshop (buy/skip), mystery (choice outcomes), rest (toast + advance)
- [ ] Reaching boss node launches Goblin Warlord boss fight; victory → HUB + star toast
- [ ] Reload mid-run → resumes at exact same map position
- [ ] Mid-fight reload → node stays selectable (resume mid-fight fix)
- [ ] "Quit Run" → confirmation dialog → abandons run → returns to HUB

🤖 Generated with [Claude Code](https://claude.com/claude-code)